### PR TITLE
raise when download fail to prevent fallback to transformers

### DIFF
--- a/mblt_model_zoo/utils/downloads.py
+++ b/mblt_model_zoo/utils/downloads.py
@@ -94,3 +94,4 @@ def download_url_to_folder(
 
         except Exception:
             print(f"{u} download failed")
+            raise


### PR DESCRIPTION
네트워크가 없는 환경에서 download_url_to_folder 함수 사용 시 transformers 라이브러리로 fallback되는 현상을 방지하고 오류를 명시적으로 반환합니다