### PR TITLE
fix: reduce codex workflow scopes

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -18,8 +18,8 @@ jobs:
     uses: mobilint/.github/.github/workflows/codex-pr-review.yml@main
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
     with:
       post_untrusted_notice: true
       skip_draft_pr: true


### PR DESCRIPTION
### Motivation
- Reduce supply-chain blast radius by limiting `GITHUB_TOKEN` write scopes that a mutable external reusable workflow could otherwise abuse.

### Description
- Updated `.github/workflows/code-review.yml` to change `pull-requests` and `issues` permissions from `write` to `read` while keeping the `uses` reference, triggers, and inputs unchanged.

### Testing
- Ran `git diff --check` and inspected the resulting diff for `.github/workflows/code-review.yml`, and the change was staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5d11dabd483249178faba86a8ca7a)