### PR TITLE
Grant `actions: write` permission to Codex Review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -17,6 +17,7 @@ jobs:
   codex-review:
     uses: mobilint/.github/.github/workflows/codex-pr-review.yml@main
     permissions:
+      actions: write
       contents: read
       pull-requests: write
       issues: write


### PR DESCRIPTION
### Motivation
- Allow the Codex review workflow to perform operations that require the `actions: write` permission by giving the job that permission. 

### Description
- Added `actions: write` to the `permissions` block for the `codex-review` job in `.github/workflows/code-review.yml` so the workflow can perform write-level actions. 

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5d3331f788324a8460c5e43595cc8)