### PR TITLE
Propagate parent name_or_path to vision_config and text_config

### DIFF
--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -272,6 +272,16 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
 class MobilintVisionTextConfigMixin(PretrainedConfig):
     sub_configs = {"vision_config": MobilintConfigMixin, "text_config": MobilintConfigMixin}
 
+    @PretrainedConfig.name_or_path.setter
+    def name_or_path(self, value):
+        PretrainedConfig.name_or_path.fset(self, value)
+        vision_config = getattr(self, "vision_config", None)
+        if vision_config is not None:
+            vision_config.name_or_path = value
+        text_config = getattr(self, "text_config", None)
+        if text_config is not None:
+            text_config.name_or_path = value
+
     @property
     def vision_mxq_path(self) -> str:
         return self.vision_config.mxq_path


### PR DESCRIPTION
`Transformers` sets `config.name_or_path = pretrained_model_name_or_path` only after `from_dict` returns and right before `cls(config, ...)`. The existing explicit propagation inside `MobilintVisionTextConfigMixin.from_dict` runs too early, so sub-configs end up with an empty `name_or_path`.

When `MobilintQwen3VLModel.__init__` then builds the vision sub-model, its NPU backend reads the empty `name_or_path` and calls `hf_hub_download(repo_id="mobilint/", ...)`, raising `HFValidationError: Repo id must use alphanumeric chars ... 'mobilint/'`.

Override the `name_or_path` setter on `MobilintVisionTextConfigMixin` so any update on the parent config propagates to `vision_config` and `text_config`. This catches the assignment in
`PreTrainedModel.from_pretrained` and keeps sub-configs in sync for any future vision-text Mobilint model.