### PR TITLE
Add Mobilint ASR beam cache tracing

### DIFF
--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -195,13 +195,19 @@ def _is_whisper_like_model(model_id: str) -> bool:
     return "whisper" in model_id.lower()
 
 
+def _uses_encoder_decoder_core_mode_kwargs(model_id: str) -> bool:
+    """Return whether an ASR target expects encoder/decoder-prefixed NPU kwargs."""
+
+    return _is_qwen3_asr_model(model_id) or _is_whisper_like_model(model_id)
+
+
 def _apply_asr_core_mode_model_kwargs(
     model_kwargs: dict[str, Any],
     model_id: str,
     core_mode: str | None,
 ) -> dict[str, Any]:
     """Apply core-mode kwargs for ASR models, expanding composite encoder/decoder configs when needed."""
-    if not _is_qwen3_asr_model(model_id):
+    if not _uses_encoder_decoder_core_mode_kwargs(model_id):
         return _apply_core_mode_model_kwargs_common(model_kwargs, core_mode)
 
     expanded: dict[str, Any] = {}

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -236,8 +236,11 @@ class MobilintQwen3ASRTextModel(
             if row_logits_ndarray is None:
                 raise RuntimeError("Qwen3-ASR beam decode produced no logits.")
             row_logits = torch.tensor(row_logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
-            if row_logits.ndim == 4 and int(row_logits.shape[0]) == 1:
-                row_logits = row_logits.squeeze(0)
+            while row_logits.ndim > 2:
+                singleton_dims = [dim for dim, size in enumerate(row_logits.shape[:-1]) if int(size) == 1]
+                if not singleton_dims:
+                    raise ValueError(f"Unexpected Qwen3-ASR beam logits shape: {tuple(row_logits.shape)}")
+                row_logits = row_logits.squeeze(singleton_dims[0])
             if row_logits.ndim == 2:
                 row_logits = row_logits.unsqueeze(0)
             logits_list.append(row_logits)
@@ -260,12 +263,17 @@ class MobilintQwen3ASRTextModel(
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if use_cache and past_key_values is None:
-            past_key_values = self._get_cache("", 0, 0)
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         assert inputs_embeds is not None
+
+        if int(inputs_embeds.shape[0]) > 1:
+            use_cache = True
+
+        if use_cache and past_key_values is None:
+            past_key_values = self._get_cache("", int(inputs_embeds.shape[0]), 0)
 
         if cache_position is None:
             past_seen_tokens = (
@@ -334,6 +342,10 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
     def get_cache_mxq_model(self):
         return self.model.get_mxq_model()
 
+    def _get_cache(self, cache_implementation: str, batch_size: int, max_cache_len: int, *args) -> MobilintBeamCache:
+        """Return a beam-snapshot cache for the nested Qwen3-ASR thinker generation loop."""
+        return self.model._get_cache(cache_implementation, batch_size, max_cache_len, *args)
+
     @wraps(Qwen3ASRThinkerForConditionalGeneration.forward)
     def forward(
         self,
@@ -342,7 +354,11 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
         **kwargs: object,
     ) -> Union[tuple, Qwen3ASRThinkerCausalLMOutputWithPast]:
         kwargs["count_npu_time"] = count_npu_time
-        return super().forward(*args, **kwargs)
+        outputs = super().forward(*args, **kwargs)
+        logits = getattr(outputs, "logits", None)
+        if isinstance(logits, torch.Tensor) and logits.ndim == 4 and int(logits.shape[1]) == 1:
+            outputs.logits = logits.squeeze(1)
+        return outputs
 
 
 class MobilintQwen3ASRForConditionalGeneration(

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -203,14 +203,22 @@ class MobilintQwen3ASRTextModel(
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         mxq_model = self.npu_backend.mxq_model
         logits_list: list[torch.Tensor] = []
+        logits_by_target_tokens: dict[tuple[int, ...], torch.Tensor] = {}
         self.npu_time = 0.0 if count_npu_time else None
         input_ids = input_ids.view(batch_size, -1)
 
         for beam_index in range(batch_size):
             previous_tokens = past_key_values.get_beam_tokens(beam_index)
             target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
+            target_key = tuple(target_tokens)
             prefix_length = past_key_values.get_common_prefix_length(target_tokens)
             previous_length = len(previous_tokens)
+            if prefix_length == len(target_tokens) and target_key in logits_by_target_tokens:
+                logits_list.append(logits_by_target_tokens[target_key])
+                past_key_values.commit_beam_tokens(beam_index, target_tokens)
+                continue
+            if prefix_length == len(target_tokens):
+                prefix_length = max(0, len(target_tokens) - int(input_ids.shape[1]))
             local_start_index = max(0, prefix_length - previous_length)
             timing_phase = "prefill" if prefix_length == 0 else "decode"
             row_logits_ndarray: np.ndarray | None = None
@@ -266,7 +274,9 @@ class MobilintQwen3ASRTextModel(
                 row_logits = row_logits.squeeze(singleton_dims[0])
             if row_logits.ndim == 2:
                 row_logits = row_logits.unsqueeze(0)
+            row_logits = row_logits[:, -int(input_ids.shape[1]) :, :]
             logits_list.append(row_logits)
+            logits_by_target_tokens[target_key] = row_logits
 
         return torch.cat(logits_list, dim=0)
 
@@ -283,8 +293,8 @@ class MobilintQwen3ASRTextModel(
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> Union[tuple, BaseModelOutputWithPast]:
-        if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You must specify input_ids, inputs_embeds, or both.")
 
         use_cache = use_cache if use_cache is not None else self.config.use_cache
 
@@ -375,16 +385,81 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
     @wraps(Qwen3ASRThinkerForConditionalGeneration.forward)
     def forward(
         self,
-        *args: object,
+        input_ids=None,
+        input_features=None,
+        attention_mask=None,
+        feature_attention_mask=None,
+        audio_feature_lengths=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        rope_deltas=None,
+        labels=None,
+        use_cache=None,
+        cache_position=None,
         count_npu_time: bool = False,
-        **kwargs: object,
+        **kwargs,
     ) -> Union[tuple, Qwen3ASRThinkerCausalLMOutputWithPast]:
-        kwargs["count_npu_time"] = count_npu_time
-        outputs = super().forward(*args, **kwargs)
-        logits = getattr(outputs, "logits", None)
+        if inputs_embeds is None:
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+
+        if input_features is not None:
+            audio_features = self.get_audio_features(
+                input_features,
+                feature_attention_mask=feature_attention_mask,
+                audio_feature_lengths=audio_feature_lengths,
+            )
+            audio_features = audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            audio_mask = self.get_placeholder_mask(input_ids, inputs_embeds=inputs_embeds)
+            inputs_embeds = inputs_embeds.masked_scatter(audio_mask, audio_features)
+
+        if feature_attention_mask is not None:
+            audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
+        else:
+            audio_feature_lengths = None
+
+        if attention_mask is not None and position_ids is None:
+            if cache_position is None or (cache_position is not None and cache_position[0] == 0) or self.rope_deltas is None:
+                delta0 = (1 - attention_mask).sum(dim=-1).unsqueeze(1)
+                position_ids, rope_deltas = self.get_rope_index(attention_mask)
+                rope_deltas = rope_deltas - delta0
+                self.rope_deltas = rope_deltas
+            else:
+                batch_size, seq_length = input_ids.shape
+                delta = cache_position[0] + self.rope_deltas if cache_position is not None else 0
+                position_ids = torch.arange(seq_length, device=input_ids.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                position_ids = position_ids.add(delta)
+                position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            count_npu_time=count_npu_time,
+            **kwargs,
+        )
+        hidden_states = outputs[0]
+        logits = self.lm_head(hidden_states)
         if isinstance(logits, torch.Tensor) and logits.ndim == 4 and int(logits.shape[1]) == 1:
-            outputs.logits = logits.squeeze(1)
-        return outputs
+            logits = logits.squeeze(1)
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size)
+
+        return Qwen3ASRThinkerCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            past_key_values=outputs.past_key_values,
+            rope_deltas=self.rope_deltas,
+        )
 
 
 class MobilintQwen3ASRForConditionalGeneration(

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -398,9 +398,12 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
         labels=None,
         use_cache=None,
         cache_position=None,
+        return_dict=None,
         count_npu_time: bool = False,
         **kwargs,
     ) -> Union[tuple, Qwen3ASRThinkerCausalLMOutputWithPast]:
+        return_dict = return_dict if return_dict is not None else self.config.return_dict
+
         if inputs_embeds is None:
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -457,7 +460,7 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
         if labels is not None:
             loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size)
 
-        return Qwen3ASRThinkerCausalLMOutputWithPast(
+        output = Qwen3ASRThinkerCausalLMOutputWithPast(
             loss=loss,
             logits=logits,
             hidden_states=outputs.hidden_states,
@@ -465,6 +468,10 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
             past_key_values=outputs.past_key_values,
             rope_deltas=self.rope_deltas,
         )
+        if not return_dict:
+            return output.to_tuple()
+
+        return output
 
 
 class MobilintQwen3ASRForConditionalGeneration(

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -183,13 +183,14 @@ class MobilintQwen3ASRTextModel(
 
     def _beam_llm_forward(
         self,
+        input_ids: torch.LongTensor,
         inputs_embeds: torch.Tensor,
         past_key_values: MobilintBeamCache,
         cache_position: torch.Tensor,
         prefill_chunk_size: Optional[int] = None,
         count_npu_time: bool = False,
     ) -> torch.Tensor:
-        """Run Qwen3-ASR decoder by swapping one active beam cache at a time."""
+        """Run Qwen3-ASR decoder by forwarding only suffixes missing from active cache."""
         if inputs_embeds.ndim != 3:
             raise ValueError(f"Expected rank-3 inputs_embeds for beam decode, got {tuple(inputs_embeds.shape)}")
 
@@ -200,22 +201,44 @@ class MobilintQwen3ASRTextModel(
 
         past_key_values.ensure_batch_size(batch_size)
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
-        num_of_chunks = math.ceil(sequence_length / resolved_prefill_chunk_size)
         mxq_model = self.npu_backend.mxq_model
         logits_list: list[torch.Tensor] = []
         self.npu_time = 0.0 if count_npu_time else None
+        input_ids = input_ids.view(batch_size, -1)
 
         for beam_index in range(batch_size):
-            initial_cache_size = past_key_values.load_beam_cache(beam_index)
-            timing_phase = "prefill" if initial_cache_size == 0 else "decode"
+            previous_tokens = past_key_values.get_beam_tokens(beam_index)
+            target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
+            prefix_length = past_key_values.get_common_prefix_length(target_tokens)
+            previous_length = len(previous_tokens)
+            local_start_index = max(0, prefix_length - previous_length)
+            timing_phase = "prefill" if prefix_length == 0 else "decode"
             row_logits_ndarray: np.ndarray | None = None
-            row_embeds_numpy = inputs_embeds[beam_index : beam_index + 1].type(torch.float32).cpu().numpy()
-            row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
 
-            for chunk_index in range(num_of_chunks):
+            if prefix_length < previous_length:
+                suffix_tokens = torch.tensor(
+                    [target_tokens[prefix_length:]],
+                    dtype=torch.long,
+                    device=inputs_embeds.device,
+                )
+                row_embeds = self.embed_tokens(suffix_tokens)
+            else:
+                row_embeds = inputs_embeds[beam_index : beam_index + 1, local_start_index:, :]
+
+            suffix_length = int(row_embeds.shape[1])
+            if suffix_length <= 0:
+                row_embeds = inputs_embeds[beam_index : beam_index + 1, -1:, :]
+                suffix_length = 1
+                prefix_length = max(0, len(target_tokens) - 1)
+
+            row_embeds_numpy = row_embeds.type(torch.float32).cpu().numpy()
+            row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
+            num_suffix_chunks = math.ceil(suffix_length / resolved_prefill_chunk_size)
+
+            for chunk_index in range(num_suffix_chunks):
                 start_index = chunk_index * resolved_prefill_chunk_size
-                end_index = min(start_index + resolved_prefill_chunk_size, sequence_length)
-                cache_size = past_key_values.get_seq_length(beam_index)
+                end_index = min(start_index + resolved_prefill_chunk_size, suffix_length)
+                cache_size = prefix_length + start_index
                 chunk = row_embeds_numpy[:, :, start_index:end_index, :]
 
                 if count_npu_time:
@@ -230,9 +253,9 @@ class MobilintQwen3ASRTextModel(
 
                 assert result is not None, "mxq infer result is None!"
                 row_logits_ndarray = result[0]
-                past_key_values.update_cache_position(cache_position[start_index:end_index], index=beam_index)
 
-            past_key_values.dump_beam_cache(beam_index)
+            past_key_values.commit_beam_tokens(beam_index, target_tokens)
+            past_key_values.commit_active_tokens(target_tokens)
             if row_logits_ndarray is None:
                 raise RuntimeError("Qwen3-ASR beam decode produced no logits.")
             row_logits = torch.tensor(row_logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
@@ -289,7 +312,10 @@ class MobilintQwen3ASRTextModel(
             )
 
         if isinstance(past_key_values, MobilintBeamCache):
+            if input_ids is None:
+                raise ValueError("MobilintBeamCache requires input_ids to track Qwen3-ASR beam token histories.")
             logits = self._beam_llm_forward(
+                input_ids=input_ids,
                 inputs_embeds=inputs_embeds,
                 past_key_values=past_key_values,
                 cache_position=cache_position,

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -1,3 +1,5 @@
+import math
+import time
 from functools import wraps
 from typing import Optional, Union, cast
 
@@ -14,7 +16,7 @@ from transformers.processing_utils import Unpack
 from transformers.utils.generic import TransformersKwargs, logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
-from ...utils.cache_utils import MobilintCache
+from ...utils.cache_utils import MobilintBeamCache, MobilintCache
 from ...utils.generation_utils import MobilintGenerationMixin
 from ...utils.modeling_utils import MobilintModelMixin
 from ._errors import guard_qwen_asr_import
@@ -166,6 +168,82 @@ class MobilintQwen3ASRTextModel(
     def set_input_embeddings(self, value: nn.Module) -> None:
         self.embed_tokens = value
 
+    def _get_cache(self, cache_implementation: str, batch_size: int, max_cache_len: int, *args) -> MobilintBeamCache:
+        """Return a beam-snapshot cache for Qwen3-ASR text generation."""
+        del cache_implementation, max_cache_len, args
+        configured_batch_size = max(1, int(batch_size), getattr(self.config, "max_batch_size", 1))
+        if not hasattr(self, "_cache") or not isinstance(self._cache, MobilintBeamCache):
+            self._cache = MobilintBeamCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
+        elif getattr(self._cache, "batch_size", 1) != configured_batch_size:
+            self._cache = MobilintBeamCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
+        else:
+            self._cache.reset()
+
+        return self._cache
+
+    def _beam_llm_forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        past_key_values: MobilintBeamCache,
+        cache_position: torch.Tensor,
+        prefill_chunk_size: Optional[int] = None,
+        count_npu_time: bool = False,
+    ) -> torch.Tensor:
+        """Run Qwen3-ASR decoder by swapping one active beam cache at a time."""
+        if inputs_embeds.ndim != 3:
+            raise ValueError(f"Expected rank-3 inputs_embeds for beam decode, got {tuple(inputs_embeds.shape)}")
+
+        batch_size = int(inputs_embeds.shape[0])
+        sequence_length = int(inputs_embeds.shape[1])
+        if sequence_length <= 0:
+            raise ValueError("Qwen3-ASR beam decode received an empty token sequence.")
+
+        past_key_values.ensure_batch_size(batch_size)
+        resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
+        num_of_chunks = math.ceil(sequence_length / resolved_prefill_chunk_size)
+        mxq_model = self.npu_backend.mxq_model
+        logits_list: list[torch.Tensor] = []
+        self.npu_time = 0.0 if count_npu_time else None
+
+        for beam_index in range(batch_size):
+            initial_cache_size = past_key_values.load_beam_cache(beam_index)
+            timing_phase = "prefill" if initial_cache_size == 0 else "decode"
+            row_logits_ndarray: np.ndarray | None = None
+            row_embeds_numpy = inputs_embeds[beam_index : beam_index + 1].type(torch.float32).cpu().numpy()
+            row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
+
+            for chunk_index in range(num_of_chunks):
+                start_index = chunk_index * resolved_prefill_chunk_size
+                end_index = min(start_index + resolved_prefill_chunk_size, sequence_length)
+                cache_size = past_key_values.get_seq_length(beam_index)
+                chunk = row_embeds_numpy[:, :, start_index:end_index, :]
+
+                if count_npu_time:
+                    t0 = time.perf_counter()
+                    result = mxq_model.infer([chunk], None, cache_size)
+                    elapsed = time.perf_counter() - t0
+                    assert self.npu_time is not None
+                    self.npu_time += elapsed
+                    self._record_npu_timing(timing_phase, elapsed)
+                else:
+                    result = mxq_model.infer([chunk], None, cache_size)
+
+                assert result is not None, "mxq infer result is None!"
+                row_logits_ndarray = result[0]
+                past_key_values.update_cache_position(cache_position[start_index:end_index], index=beam_index)
+
+            past_key_values.dump_beam_cache(beam_index)
+            if row_logits_ndarray is None:
+                raise RuntimeError("Qwen3-ASR beam decode produced no logits.")
+            row_logits = torch.tensor(row_logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
+            if row_logits.ndim == 4 and int(row_logits.shape[0]) == 1:
+                row_logits = row_logits.squeeze(0)
+            if row_logits.ndim == 2:
+                row_logits = row_logits.unsqueeze(0)
+            logits_list.append(row_logits)
+
+        return torch.cat(logits_list, dim=0)
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -202,14 +280,23 @@ class MobilintQwen3ASRTextModel(
                 ),
             )
 
-        logits = self.llm_forward(
-            inputs_embeds=inputs_embeds,
-            past_key_values=past_key_values,
-            cache_position=cache_position,
-            prefill_chunk_size=prefill_chunk_size,
-            count_npu_time=count_npu_time,
-            attention_mask=None,
-        )
+        if isinstance(past_key_values, MobilintBeamCache):
+            logits = self._beam_llm_forward(
+                inputs_embeds=inputs_embeds,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                prefill_chunk_size=prefill_chunk_size,
+                count_npu_time=count_npu_time,
+            )
+        else:
+            logits = self.llm_forward(
+                inputs_embeds=inputs_embeds,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                prefill_chunk_size=prefill_chunk_size,
+                count_npu_time=count_npu_time,
+                attention_mask=None,
+            )
 
         return BaseModelOutputWithPast(
             last_hidden_state=cast(torch.FloatTensor, logits),

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -181,6 +181,21 @@ class MobilintQwen3ASRTextModel(
 
         return self._cache
 
+    def _resolve_source_indices(self, inputs_embeds: torch.Tensor) -> list[int]:
+        """Return source ids for rows sharing the same audio-conditioned prompt embeddings."""
+        source_indices: list[int] = []
+        seen_signatures: list[torch.Tensor] = []
+        for row in inputs_embeds.detach().cpu():
+            source_index = next(
+                (index for index, seen_row in enumerate(seen_signatures) if torch.equal(row, seen_row)),
+                None,
+            )
+            if source_index is None:
+                source_index = len(seen_signatures)
+                seen_signatures.append(row.clone())
+            source_indices.append(source_index)
+        return source_indices
+
     def _beam_llm_forward(
         self,
         input_ids: torch.LongTensor,
@@ -203,15 +218,17 @@ class MobilintQwen3ASRTextModel(
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         mxq_model = self.npu_backend.mxq_model
         logits_list: list[torch.Tensor] = []
-        logits_by_target_tokens: dict[tuple[int, ...], torch.Tensor] = {}
+        logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], torch.Tensor] = {}
         self.npu_time = 0.0 if count_npu_time else None
         input_ids = input_ids.view(batch_size, -1)
+        source_indices = self._resolve_source_indices(inputs_embeds)
 
         for beam_index in range(batch_size):
             previous_tokens = past_key_values.get_beam_tokens(beam_index)
             target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
-            target_key = tuple(target_tokens)
-            prefix_length = past_key_values.get_common_prefix_length(target_tokens)
+            source_index = source_indices[beam_index]
+            target_key = (source_index, tuple(target_tokens))
+            prefix_length = past_key_values.get_common_prefix_length(target_tokens, source_index=source_index)
             previous_length = len(previous_tokens)
             if prefix_length == len(target_tokens) and target_key in logits_by_target_tokens:
                 logits_list.append(logits_by_target_tokens[target_key])
@@ -263,7 +280,7 @@ class MobilintQwen3ASRTextModel(
                 row_logits_ndarray = result[0]
 
             past_key_values.commit_beam_tokens(beam_index, target_tokens)
-            past_key_values.commit_active_tokens(target_tokens)
+            past_key_values.commit_active_tokens(target_tokens, source_index=source_index)
             if row_logits_ndarray is None:
                 raise RuntimeError("Qwen3-ASR beam decode produced no logits.")
             row_logits = torch.tensor(row_logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -296,13 +296,14 @@ class MobilintQwen3ASRTextModel(
         if input_ids is None and inputs_embeds is None:
             raise ValueError("You must specify input_ids, inputs_embeds, or both.")
 
+        explicit_no_cache = use_cache is False
         use_cache = use_cache if use_cache is not None else self.config.use_cache
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         assert inputs_embeds is not None
 
-        if int(inputs_embeds.shape[0]) > 1:
+        if int(inputs_embeds.shape[0]) > 1 and not explicit_no_cache:
             use_cache = True
 
         if use_cache and past_key_values is None:
@@ -419,7 +420,11 @@ class MobilintQwen3ASRThinkerForConditionalGeneration(
             audio_feature_lengths = None
 
         if attention_mask is not None and position_ids is None:
-            if cache_position is None or (cache_position is not None and cache_position[0] == 0) or self.rope_deltas is None:
+            if (
+                cache_position is None
+                or (cache_position is not None and cache_position[0] == 0)
+                or self.rope_deltas is None
+            ):
                 delta0 = (1 - attention_mask).sum(dim=-1).unsqueeze(1)
                 position_ids, rope_deltas = self.get_rope_index(attention_mask)
                 rope_deltas = rope_deltas - delta0

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -221,7 +221,14 @@ class MobilintQwen3ASRTextModel(
         logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], torch.Tensor] = {}
         self.npu_time = 0.0 if count_npu_time else None
         input_ids = input_ids.view(batch_size, -1)
-        source_indices = self._resolve_source_indices(inputs_embeds)
+        embedding_source_indices = self._resolve_source_indices(inputs_embeds)
+        source_indices: list[int] = []
+        for beam_index in range(batch_size):
+            cached_source_index = past_key_values.get_beam_source_index(beam_index)
+            source_indices.append(
+                embedding_source_indices[beam_index] if cached_source_index is None else cached_source_index
+            )
+        past_key_values.set_beam_source_indices(source_indices)
 
         for beam_index in range(batch_size):
             previous_tokens = past_key_values.get_beam_tokens(beam_index)
@@ -256,7 +263,7 @@ class MobilintQwen3ASRTextModel(
                 suffix_length = 1
                 prefix_length = max(0, len(target_tokens) - 1)
 
-            row_embeds_numpy = row_embeds.type(torch.float32).cpu().numpy()
+            row_embeds_numpy = row_embeds.detach().type(torch.float32).cpu().numpy()
             row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
             num_suffix_chunks = math.ceil(suffix_length / resolved_prefill_chunk_size)
 

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -336,7 +336,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
         if encoder_hidden_states is not None and encoder_hidden_states.ndim == 3:
             encoder_hidden_states = encoder_hidden_states.unsqueeze(1)
 
-        if use_cache and past_key_values is None:
+        if use_cache and past_key_values is None and input_ids is not None:
             past_key_values = MobilintWhisperCache(self.get_mxq_model(), batch_size=input_shape[0])
 
         past_key_values_length = 0

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -1,4 +1,4 @@
-from typing import Union, cast
+from typing import Any, Union, cast
 
 import torch
 import torch.nn as nn
@@ -20,7 +20,7 @@ from transformers.models.whisper.modeling_whisper import (
 from transformers.utils.generic import logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
-from ...utils.cache_utils import MobilintCache
+from ...utils.cache_utils import MobilintWhisperCache
 from ...utils.generation_utils import MobilintGenerationMixin
 from ...utils.modeling_utils import MobilintModelMixin
 from .configuration_whisper import MobilintWhisperConfig
@@ -100,6 +100,50 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
     
     def get_input_embeddings(self) -> nn.Module:
         return self.embed_tokens
+
+    def decoder_forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        past_key_values: Union[MobilintWhisperCache, None],
+        cache_position: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run Whisper decoder MXQ by swapping one active beam cache at a time."""
+        batch_size = int(hidden_states.shape[0])
+        if past_key_values is None:
+            return super().decoder_forward(hidden_states, encoder_hidden_states, past_key_values, cache_position)
+
+        if batch_size <= 1:
+            past_key_values.load_beam_cache(0)
+            logits = super().decoder_forward(hidden_states, encoder_hidden_states, past_key_values, cache_position)
+            past_key_values.dump_beam_cache(0)
+            return logits
+
+        past_key_values.ensure_batch_size(batch_size)
+        if encoder_hidden_states.shape[0] == 1 and batch_size > 1:
+            encoder_hidden_states = encoder_hidden_states.expand(batch_size, *encoder_hidden_states.shape[1:])
+        sequence_length = int(hidden_states.shape[2])
+
+        logits_list = []
+        mxq_model = self.npu_backend.mxq_model
+        for beam_index in range(batch_size):
+            cache_size = past_key_values.load_beam_cache(beam_index)
+            hidden_states_numpy = hidden_states[beam_index : beam_index + 1].type(torch.float32).cpu().numpy()
+            encoder_hidden_states_numpy = (
+                encoder_hidden_states[beam_index : beam_index + 1].type(torch.float32).cpu().numpy()
+            )
+            result = mxq_model.infer([hidden_states_numpy, encoder_hidden_states_numpy], None, cache_size)
+            assert result is not None, "mxq infer result is None!"
+            logits = torch.tensor(result[0], dtype=hidden_states.dtype, device=hidden_states.device)
+            if logits.ndim == 2 and int(logits.shape[0]) == sequence_length:
+                logits = logits.reshape(1, 1, sequence_length, -1)
+            elif logits.ndim == 3:
+                logits = logits.unsqueeze(0)
+            logits_list.append(logits)
+            past_key_values.update_cache_position(cache_position, index=beam_index)
+            past_key_values.dump_beam_cache(beam_index)
+
+        return torch.cat(logits_list, dim=0)
     
     def forward(
         self,
@@ -137,8 +181,11 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
+        if encoder_hidden_states is not None and encoder_hidden_states.ndim == 3:
+            encoder_hidden_states = encoder_hidden_states.unsqueeze(1)
+
         if use_cache and past_key_values is None:
-            past_key_values = MobilintCache(self.get_mxq_model())
+            past_key_values = MobilintWhisperCache(self.get_mxq_model(), batch_size=input_shape[0])
 
         past_key_values_length = 0
         if cache_position is not None:
@@ -165,6 +212,15 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             )
 
         hidden_states = inputs_embeds + positions.to(inputs_embeds.device)
+        if isinstance(past_key_values, MobilintWhisperCache) and input_ids is not None:
+            past_key_values.configure_reorder_replay(
+                decoder_input_ids=input_ids,
+                decoder_forward=self.forward,
+                encoder_hidden_states=cast(torch.Tensor, encoder_hidden_states),
+                device=inputs_embeds.device,
+                return_dict=return_dict,
+                use_cache=use_cache,
+            )
         
         if output_attentions:
             logger.warning("output_attentions is not supported.")
@@ -255,7 +311,7 @@ class MobilintWhisperModel(PretrainedOnlyMixin, MobilintWhisperPreTrainedModel):
         decoder_input_ids: Union[torch.LongTensor, None] = None,
         decoder_attention_mask: Union[torch.LongTensor, None] = None,
         encoder_outputs: Union[tuple[torch.FloatTensor], BaseModelOutput, None] = None,
-        past_key_values: Union[MobilintCache, None] = None,
+        past_key_values: Union[MobilintWhisperCache, None] = None,
         decoder_inputs_embeds: Union[tuple[torch.FloatTensor], None] = None,
         decoder_position_ids: Union[tuple[torch.LongTensor], None] = None,
         use_cache: Union[bool, None] = None,
@@ -355,7 +411,90 @@ class MobilintWhisperForConditionalGeneration(
 
     def get_cache_mxq_model(self):
         return self.get_decoder().get_mxq_model()
-    
+
+    def _get_cache(
+        self,
+        cache_implementation: str,
+        batch_size: int,
+        max_cache_len: int,
+        *args: Any,
+    ) -> MobilintWhisperCache:
+        """Return a Whisper-specific Mobilint cache for Hugging Face generation."""
+        del cache_implementation, max_cache_len, args
+        configured_batch_size = max(1, int(batch_size), int(getattr(self.config, "max_batch_size", 1)))
+        if not hasattr(self, "_cache"):
+            self._cache = MobilintWhisperCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
+        elif not isinstance(self._cache, MobilintWhisperCache):
+            self._cache = MobilintWhisperCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
+        elif getattr(self._cache, "batch_size", 1) != configured_batch_size:
+            self._cache = MobilintWhisperCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
+        else:
+            self._cache.reset()
+        return self._cache
+
+    def prepare_inputs_for_generation(
+        self,
+        *args: Any,
+        count_npu_time: bool = False,
+        prefill_chunk_size: Union[int, None] = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Prepare Whisper generation inputs and refresh cache replay context."""
+        model_inputs = super().prepare_inputs_for_generation(
+            *args,
+            count_npu_time=count_npu_time,
+            prefill_chunk_size=prefill_chunk_size,
+            **kwargs,
+        )
+        past_key_values = model_inputs.get("past_key_values", kwargs.get("past_key_values"))
+        if isinstance(past_key_values, MobilintWhisperCache):
+            decoder_input_ids = self._resolve_generation_decoder_input_ids(args, kwargs, model_inputs)
+            encoder_hidden_states = self._resolve_generation_encoder_hidden_states(kwargs, model_inputs)
+            if encoder_hidden_states is not None and encoder_hidden_states.ndim == 3:
+                encoder_hidden_states = encoder_hidden_states.unsqueeze(1)
+            device = decoder_input_ids.device if decoder_input_ids is not None else None
+            past_key_values.configure_reorder_replay(
+                decoder_input_ids=decoder_input_ids,
+                decoder_forward=self.model.decoder.forward,
+                encoder_hidden_states=encoder_hidden_states,
+                device=device,
+                return_dict=bool(model_inputs.get("return_dict", self.config.return_dict)),
+                use_cache=bool(model_inputs.get("use_cache", self.config.use_cache)),
+            )
+        return model_inputs
+
+    @staticmethod
+    def _resolve_generation_decoder_input_ids(
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        model_inputs: dict[str, Any],
+    ) -> Union[torch.LongTensor, None]:
+        """Resolve the most complete decoder token history available during generation."""
+        for key in ("decoder_input_ids", "input_ids"):
+            value = kwargs.get(key)
+            if isinstance(value, torch.Tensor):
+                return cast(torch.LongTensor, value)
+        for key in ("decoder_input_ids", "input_ids"):
+            value = model_inputs.get(key)
+            if isinstance(value, torch.Tensor):
+                return cast(torch.LongTensor, value)
+        if args and isinstance(args[0], torch.Tensor):
+            return cast(torch.LongTensor, args[0])
+        return None
+
+    @staticmethod
+    def _resolve_generation_encoder_hidden_states(
+        kwargs: dict[str, Any],
+        model_inputs: dict[str, Any],
+    ) -> Union[torch.Tensor, None]:
+        """Resolve encoder hidden states from generation kwargs or prepared model inputs."""
+        encoder_outputs = model_inputs.get("encoder_outputs", kwargs.get("encoder_outputs"))
+        if encoder_outputs is None:
+            return None
+        if isinstance(encoder_outputs, BaseModelOutput):
+            return encoder_outputs.last_hidden_state
+        return encoder_outputs[0]
+
     def forward(
         self,
         input_features: Union[torch.FloatTensor, None] = None,
@@ -363,7 +502,7 @@ class MobilintWhisperForConditionalGeneration(
         decoder_input_ids: Union[torch.LongTensor, None] = None,
         decoder_attention_mask: Union[torch.LongTensor, None] = None,
         encoder_outputs: Union[tuple[tuple[torch.FloatTensor]], None] = None,
-        past_key_values: Union[MobilintCache, None] = None,
+        past_key_values: Union[MobilintWhisperCache, None] = None,
         decoder_inputs_embeds: Union[tuple[torch.FloatTensor], None] = None,
         decoder_position_ids: Union[tuple[torch.LongTensor], None] = None,
         labels: Union[torch.LongTensor, None] = None,

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -136,6 +136,61 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             return logits.unsqueeze(0)
         return logits
 
+    def _resolve_source_indices(
+        self,
+        encoder_hidden_states: torch.Tensor,
+        batch_size: int,
+        past_key_values: MobilintWhisperCache,
+    ) -> list[int]:
+        """Map beam-expanded decoder rows back to their original encoder source rows."""
+        encoder_batch_size = int(encoder_hidden_states.shape[0])
+        if encoder_batch_size == 1:
+            return [0] * batch_size
+
+        source_count = past_key_values.get_encoder_source_count()
+        if source_count is not None and source_count > 0 and batch_size % source_count == 0:
+            beams_per_source = batch_size // source_count
+            if encoder_batch_size == batch_size:
+                return [beam_index // beams_per_source for beam_index in range(batch_size)]
+
+        if encoder_batch_size == batch_size:
+            inferred_source_indices = self._infer_source_indices_from_expanded_encoder_rows(encoder_hidden_states)
+            if inferred_source_indices is not None:
+                return inferred_source_indices
+
+        if encoder_batch_size == batch_size:
+            return list(range(batch_size))
+
+        return [0] * batch_size
+
+    def _infer_source_indices_from_expanded_encoder_rows(
+        self,
+        encoder_hidden_states: torch.Tensor,
+    ) -> Union[list[int], None]:
+        """Infer contiguous beam groups when HF expanded identical encoder rows."""
+        flattened_states = encoder_hidden_states.reshape(int(encoder_hidden_states.shape[0]), -1)
+        source_indices: list[int] = []
+        current_source_index = -1
+        previous_state: Union[torch.Tensor, None] = None
+        seen_signatures: list[torch.Tensor] = []
+
+        for state in flattened_states:
+            if previous_state is not None and torch.equal(state, previous_state):
+                source_indices.append(current_source_index)
+                continue
+
+            if any(torch.equal(state, seen_state) for seen_state in seen_signatures):
+                return None
+
+            current_source_index += 1
+            source_indices.append(current_source_index)
+            seen_signatures.append(state.clone())
+            previous_state = state
+
+        if current_source_index + 1 == int(encoder_hidden_states.shape[0]):
+            return None
+        return source_indices
+
     def decoder_forward(
         self,
         hidden_states: torch.Tensor,
@@ -155,11 +210,9 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
         input_ids = input_ids.view(batch_size, -1)
 
         past_key_values.ensure_batch_size(batch_size)
-        source_indices = [0] * batch_size
         if encoder_hidden_states.shape[0] == 1 and batch_size > 1:
             encoder_hidden_states = encoder_hidden_states.expand(batch_size, *encoder_hidden_states.shape[1:])
-        elif encoder_hidden_states.shape[0] == batch_size:
-            source_indices = list(range(batch_size))
+        source_indices = self._resolve_source_indices(encoder_hidden_states, batch_size, past_key_values)
 
         logits_list: list[torch.Tensor] = []
         logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], torch.Tensor] = {}
@@ -418,9 +471,11 @@ class MobilintWhisperModel(PretrainedOnlyMixin, MobilintWhisperPreTrainedModel):
         )
         use_cache = use_cache if use_cache is not None else self.config.use_cache
         return_dict = return_dict if return_dict is not None else self.config.return_dict
+        encoder_source_count = None
 
         if encoder_outputs is None:
             assert input_features is not None, "input_features is None!"
+            encoder_source_count = int(input_features.shape[0])
             input_features = self._mask_input_features(input_features, attention_mask=attention_mask)
 
             encoder_outputs = self.encoder(
@@ -438,6 +493,9 @@ class MobilintWhisperModel(PretrainedOnlyMixin, MobilintWhisperPreTrainedModel):
             )
             
         assert encoder_outputs is not None, "encoder_outputs is None!"
+
+        if encoder_source_count is not None and isinstance(past_key_values, MobilintWhisperCache):
+            past_key_values.set_encoder_source_count(encoder_source_count)
 
         # decoder outputs consists of (dec_features, past_key_values, dec_hidden, dec_attn)
         encoder_hidden_states = encoder_outputs[0]

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -212,15 +212,6 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             )
 
         hidden_states = inputs_embeds + positions.to(inputs_embeds.device)
-        if isinstance(past_key_values, MobilintWhisperCache) and input_ids is not None:
-            past_key_values.configure_reorder_replay(
-                decoder_input_ids=input_ids,
-                decoder_forward=self.forward,
-                encoder_hidden_states=cast(torch.Tensor, encoder_hidden_states),
-                device=inputs_embeds.device,
-                return_dict=return_dict,
-                use_cache=use_cache,
-            )
         
         if output_attentions:
             logger.warning("output_attentions is not supported.")
@@ -439,61 +430,13 @@ class MobilintWhisperForConditionalGeneration(
         prefill_chunk_size: Union[int, None] = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Prepare Whisper generation inputs and refresh cache replay context."""
-        model_inputs = super().prepare_inputs_for_generation(
+        """Prepare Whisper generation inputs while preserving Mobilint kwargs."""
+        return super().prepare_inputs_for_generation(
             *args,
             count_npu_time=count_npu_time,
             prefill_chunk_size=prefill_chunk_size,
             **kwargs,
         )
-        past_key_values = model_inputs.get("past_key_values", kwargs.get("past_key_values"))
-        if isinstance(past_key_values, MobilintWhisperCache):
-            decoder_input_ids = self._resolve_generation_decoder_input_ids(args, kwargs, model_inputs)
-            encoder_hidden_states = self._resolve_generation_encoder_hidden_states(kwargs, model_inputs)
-            if encoder_hidden_states is not None and encoder_hidden_states.ndim == 3:
-                encoder_hidden_states = encoder_hidden_states.unsqueeze(1)
-            device = decoder_input_ids.device if decoder_input_ids is not None else None
-            past_key_values.configure_reorder_replay(
-                decoder_input_ids=decoder_input_ids,
-                decoder_forward=self.model.decoder.forward,
-                encoder_hidden_states=encoder_hidden_states,
-                device=device,
-                return_dict=bool(model_inputs.get("return_dict", self.config.return_dict)),
-                use_cache=bool(model_inputs.get("use_cache", self.config.use_cache)),
-            )
-        return model_inputs
-
-    @staticmethod
-    def _resolve_generation_decoder_input_ids(
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-        model_inputs: dict[str, Any],
-    ) -> Union[torch.LongTensor, None]:
-        """Resolve the most complete decoder token history available during generation."""
-        for key in ("decoder_input_ids", "input_ids"):
-            value = kwargs.get(key)
-            if isinstance(value, torch.Tensor):
-                return cast(torch.LongTensor, value)
-        for key in ("decoder_input_ids", "input_ids"):
-            value = model_inputs.get(key)
-            if isinstance(value, torch.Tensor):
-                return cast(torch.LongTensor, value)
-        if args and isinstance(args[0], torch.Tensor):
-            return cast(torch.LongTensor, args[0])
-        return None
-
-    @staticmethod
-    def _resolve_generation_encoder_hidden_states(
-        kwargs: dict[str, Any],
-        model_inputs: dict[str, Any],
-    ) -> Union[torch.Tensor, None]:
-        """Resolve encoder hidden states from generation kwargs or prepared model inputs."""
-        encoder_outputs = model_inputs.get("encoder_outputs", kwargs.get("encoder_outputs"))
-        if encoder_outputs is None:
-            return None
-        if isinstance(encoder_outputs, BaseModelOutput):
-            return encoder_outputs.last_hidden_state
-        return encoder_outputs[0]
 
     def forward(
         self,

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -169,7 +169,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
             source_index = source_indices[beam_index]
             target_key = (source_index, tuple(target_tokens))
-            prefix_length = past_key_values.get_common_prefix_length(target_tokens)
+            prefix_length = past_key_values.get_common_prefix_length(target_tokens, source_index=source_index)
             if trace_enabled:
                 append_whisper_beam_debug_event(
                     {
@@ -179,6 +179,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
                         "input_ids": [int(token) for token in input_ids[beam_index].detach().cpu().reshape(-1).tolist()],
                         "target_tokens": list(target_tokens),
                         "active_tokens": past_key_values.get_active_tokens(),
+                        "active_source_index": past_key_values.get_active_source_index(),
                         "stored_beam_tokens": past_key_values.get_beam_tokens(beam_index),
                         "prefix_length": int(prefix_length),
                     }
@@ -218,7 +219,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             logits_list.append(current_logits)
             logits_by_target_tokens[target_key] = current_logits
             past_key_values.commit_beam_tokens(beam_index, target_tokens)
-            past_key_values.commit_active_tokens(target_tokens)
+            past_key_values.commit_active_tokens(target_tokens, source_index=source_index)
             if trace_enabled:
                 top_values, top_indices = torch.topk(
                     current_logits[:, :, -1, :],
@@ -237,6 +238,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
                         "top_token_ids": [int(token) for token in top_indices.detach().cpu().reshape(-1).tolist()],
                         "top_logits": [float(value) for value in top_values.detach().cpu().reshape(-1).tolist()],
                         "active_tokens": past_key_values.get_active_tokens(),
+                        "active_source_index": past_key_values.get_active_source_index(),
                     }
                 )
 

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -155,22 +155,27 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
         input_ids = input_ids.view(batch_size, -1)
 
         past_key_values.ensure_batch_size(batch_size)
+        source_indices = [0] * batch_size
         if encoder_hidden_states.shape[0] == 1 and batch_size > 1:
             encoder_hidden_states = encoder_hidden_states.expand(batch_size, *encoder_hidden_states.shape[1:])
+        elif encoder_hidden_states.shape[0] == batch_size:
+            source_indices = list(range(batch_size))
 
         logits_list: list[torch.Tensor] = []
-        logits_by_target_tokens: dict[tuple[int, ...], torch.Tensor] = {}
+        logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], torch.Tensor] = {}
         mxq_model = self.npu_backend.mxq_model
         trace_enabled = is_whisper_beam_debug_trace_enabled()
         for beam_index in range(batch_size):
             target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
-            target_key = tuple(target_tokens)
+            source_index = source_indices[beam_index]
+            target_key = (source_index, tuple(target_tokens))
             prefix_length = past_key_values.get_common_prefix_length(target_tokens)
             if trace_enabled:
                 append_whisper_beam_debug_event(
                     {
                         "event": "decoder_beam_before",
                         "beam_index": beam_index,
+                        "source_index": source_index,
                         "input_ids": [int(token) for token in input_ids[beam_index].detach().cpu().reshape(-1).tolist()],
                         "target_tokens": list(target_tokens),
                         "active_tokens": past_key_values.get_active_tokens(),
@@ -186,6 +191,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
                         {
                             "event": "decoder_beam_duplicate_logits",
                             "beam_index": beam_index,
+                            "source_index": source_index,
                             "target_tokens": list(target_tokens),
                         }
                     )
@@ -223,6 +229,7 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
                     {
                         "event": "decoder_beam_after",
                         "beam_index": beam_index,
+                        "source_index": source_index,
                         "target_tokens": list(target_tokens),
                         "prefix_length": int(prefix_length),
                         "suffix_tokens": list(target_tokens[prefix_length:]),

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Union, cast
 
 import torch
@@ -20,7 +21,7 @@ from transformers.models.whisper.modeling_whisper import (
 from transformers.utils.generic import logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
-from ...utils.cache_utils import MobilintWhisperCache
+from ...utils.cache_utils import MobilintWhisperCache, append_whisper_beam_debug_event
 from ...utils.generation_utils import MobilintGenerationMixin
 from ...utils.modeling_utils import MobilintModelMixin
 from .configuration_whisper import MobilintWhisperConfig
@@ -160,12 +161,32 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
             target_key = tuple(target_tokens)
             prefix_length = past_key_values.get_common_prefix_length(target_tokens)
+            append_whisper_beam_debug_event(
+                {
+                    "event": "decoder_beam_before",
+                    "beam_index": beam_index,
+                    "input_ids": [int(token) for token in input_ids[beam_index].detach().cpu().reshape(-1).tolist()],
+                    "target_tokens": list(target_tokens),
+                    "active_tokens": past_key_values.get_active_tokens(),
+                    "stored_beam_tokens": past_key_values.get_beam_tokens(beam_index),
+                    "prefix_length": int(prefix_length),
+                }
+            )
             if prefix_length == len(target_tokens) and target_key in logits_by_target_tokens:
                 logits_list.append(logits_by_target_tokens[target_key])
                 past_key_values.commit_beam_tokens(beam_index, target_tokens)
+                append_whisper_beam_debug_event(
+                    {
+                        "event": "decoder_beam_duplicate_logits",
+                        "beam_index": beam_index,
+                        "target_tokens": list(target_tokens),
+                    }
+                )
                 continue
             if prefix_length == len(target_tokens):
                 prefix_length = max(0, len(target_tokens) - int(input_ids.shape[1]))
+            if os.environ.get("MBLT_WHISPER_BEAM_FORCE_FULL_REPLAY"):
+                prefix_length = 0
             suffix_hidden_states = self._embed_token_suffix(
                 target_tokens,
                 prefix_length,
@@ -181,10 +202,28 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             logits = torch.tensor(result[0], dtype=hidden_states.dtype, device=hidden_states.device)
             logits = self._normalize_decoder_logits(logits, sequence_length=suffix_length)
             current_logits = logits[:, :, -input_ids.shape[1] :, :]
+            top_values, top_indices = torch.topk(
+                current_logits[:, :, -1, :],
+                k=min(5, current_logits.shape[-1]),
+                dim=-1,
+            )
             logits_list.append(current_logits)
             logits_by_target_tokens[target_key] = current_logits
             past_key_values.commit_beam_tokens(beam_index, target_tokens)
             past_key_values.commit_active_tokens(target_tokens)
+            append_whisper_beam_debug_event(
+                {
+                    "event": "decoder_beam_after",
+                    "beam_index": beam_index,
+                    "target_tokens": list(target_tokens),
+                    "prefix_length": int(prefix_length),
+                    "suffix_tokens": list(target_tokens[prefix_length:]),
+                    "suffix_length": suffix_length,
+                    "top_token_ids": [int(token) for token in top_indices.detach().cpu().reshape(-1).tolist()],
+                    "top_logits": [float(value) for value in top_values.detach().cpu().reshape(-1).tolist()],
+                    "active_tokens": past_key_values.get_active_tokens(),
+                }
+            )
 
         return torch.cat(logits_list, dim=0)
     

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -21,7 +21,11 @@ from transformers.models.whisper.modeling_whisper import (
 from transformers.utils.generic import logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
-from ...utils.cache_utils import MobilintWhisperCache, append_whisper_beam_debug_event
+from ...utils.cache_utils import (
+    MobilintWhisperCache,
+    append_whisper_beam_debug_event,
+    is_whisper_beam_debug_trace_enabled,
+)
 from ...utils.generation_utils import MobilintGenerationMixin
 from ...utils.modeling_utils import MobilintModelMixin
 from .configuration_whisper import MobilintWhisperConfig
@@ -157,31 +161,34 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
         logits_list: list[torch.Tensor] = []
         logits_by_target_tokens: dict[tuple[int, ...], torch.Tensor] = {}
         mxq_model = self.npu_backend.mxq_model
+        trace_enabled = is_whisper_beam_debug_trace_enabled()
         for beam_index in range(batch_size):
             target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
             target_key = tuple(target_tokens)
             prefix_length = past_key_values.get_common_prefix_length(target_tokens)
-            append_whisper_beam_debug_event(
-                {
-                    "event": "decoder_beam_before",
-                    "beam_index": beam_index,
-                    "input_ids": [int(token) for token in input_ids[beam_index].detach().cpu().reshape(-1).tolist()],
-                    "target_tokens": list(target_tokens),
-                    "active_tokens": past_key_values.get_active_tokens(),
-                    "stored_beam_tokens": past_key_values.get_beam_tokens(beam_index),
-                    "prefix_length": int(prefix_length),
-                }
-            )
+            if trace_enabled:
+                append_whisper_beam_debug_event(
+                    {
+                        "event": "decoder_beam_before",
+                        "beam_index": beam_index,
+                        "input_ids": [int(token) for token in input_ids[beam_index].detach().cpu().reshape(-1).tolist()],
+                        "target_tokens": list(target_tokens),
+                        "active_tokens": past_key_values.get_active_tokens(),
+                        "stored_beam_tokens": past_key_values.get_beam_tokens(beam_index),
+                        "prefix_length": int(prefix_length),
+                    }
+                )
             if prefix_length == len(target_tokens) and target_key in logits_by_target_tokens:
                 logits_list.append(logits_by_target_tokens[target_key])
                 past_key_values.commit_beam_tokens(beam_index, target_tokens)
-                append_whisper_beam_debug_event(
-                    {
-                        "event": "decoder_beam_duplicate_logits",
-                        "beam_index": beam_index,
-                        "target_tokens": list(target_tokens),
-                    }
-                )
+                if trace_enabled:
+                    append_whisper_beam_debug_event(
+                        {
+                            "event": "decoder_beam_duplicate_logits",
+                            "beam_index": beam_index,
+                            "target_tokens": list(target_tokens),
+                        }
+                    )
                 continue
             if prefix_length == len(target_tokens):
                 prefix_length = max(0, len(target_tokens) - int(input_ids.shape[1]))
@@ -202,28 +209,29 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             logits = torch.tensor(result[0], dtype=hidden_states.dtype, device=hidden_states.device)
             logits = self._normalize_decoder_logits(logits, sequence_length=suffix_length)
             current_logits = logits[:, :, -input_ids.shape[1] :, :]
-            top_values, top_indices = torch.topk(
-                current_logits[:, :, -1, :],
-                k=min(5, current_logits.shape[-1]),
-                dim=-1,
-            )
             logits_list.append(current_logits)
             logits_by_target_tokens[target_key] = current_logits
             past_key_values.commit_beam_tokens(beam_index, target_tokens)
             past_key_values.commit_active_tokens(target_tokens)
-            append_whisper_beam_debug_event(
-                {
-                    "event": "decoder_beam_after",
-                    "beam_index": beam_index,
-                    "target_tokens": list(target_tokens),
-                    "prefix_length": int(prefix_length),
-                    "suffix_tokens": list(target_tokens[prefix_length:]),
-                    "suffix_length": suffix_length,
-                    "top_token_ids": [int(token) for token in top_indices.detach().cpu().reshape(-1).tolist()],
-                    "top_logits": [float(value) for value in top_values.detach().cpu().reshape(-1).tolist()],
-                    "active_tokens": past_key_values.get_active_tokens(),
-                }
-            )
+            if trace_enabled:
+                top_values, top_indices = torch.topk(
+                    current_logits[:, :, -1, :],
+                    k=min(5, current_logits.shape[-1]),
+                    dim=-1,
+                )
+                append_whisper_beam_debug_event(
+                    {
+                        "event": "decoder_beam_after",
+                        "beam_index": beam_index,
+                        "target_tokens": list(target_tokens),
+                        "prefix_length": int(prefix_length),
+                        "suffix_tokens": list(target_tokens[prefix_length:]),
+                        "suffix_length": suffix_length,
+                        "top_token_ids": [int(token) for token in top_indices.detach().cpu().reshape(-1).tolist()],
+                        "top_logits": [float(value) for value in top_values.detach().cpu().reshape(-1).tolist()],
+                        "active_tokens": past_key_values.get_active_tokens(),
+                    }
+                )
 
         return torch.cat(logits_list, dim=0)
     

--- a/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py
@@ -101,47 +101,90 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
     def get_input_embeddings(self) -> nn.Module:
         return self.embed_tokens
 
+    def _embed_token_suffix(
+        self,
+        token_history: list[int],
+        start_index: int,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Embed a suffix of a Whisper decoder token history with absolute positions."""
+        suffix_tokens = token_history[start_index:]
+        if not suffix_tokens:
+            raise ValueError("Cannot embed an empty Whisper token suffix.")
+        input_ids = torch.tensor([suffix_tokens], dtype=torch.long, device=device)
+        position_ids = torch.arange(start_index, len(token_history), dtype=torch.long, device=device).unsqueeze(0)
+        inputs_embeds = self.embed_tokens(input_ids)
+        positions = self.embed_positions(input_ids, past_key_values_length=start_index, position_ids=position_ids)
+        return (inputs_embeds + positions.to(inputs_embeds.device)).unsqueeze(1)
+
+    def _normalize_decoder_logits(
+        self,
+        logits: torch.Tensor,
+        *,
+        sequence_length: int,
+    ) -> torch.Tensor:
+        """Normalize raw Whisper decoder logits to ``(batch, 1, seq_len, vocab)``."""
+        if logits.ndim == 2 and int(logits.shape[0]) == sequence_length:
+            return logits.reshape(1, 1, sequence_length, -1)
+        if logits.ndim == 3:
+            return logits.unsqueeze(0)
+        return logits
+
     def decoder_forward(
         self,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         past_key_values: Union[MobilintWhisperCache, None],
         cache_position: torch.Tensor,
+        input_ids: Union[torch.LongTensor, None] = None,
     ) -> torch.Tensor:
-        """Run Whisper decoder MXQ by swapping one active beam cache at a time."""
+        """Run Whisper decoder MXQ by replaying only beam suffixes missing from active cache."""
         batch_size = int(hidden_states.shape[0])
         if past_key_values is None:
             return super().decoder_forward(hidden_states, encoder_hidden_states, past_key_values, cache_position)
 
-        if batch_size <= 1:
-            past_key_values.load_beam_cache(0)
-            logits = super().decoder_forward(hidden_states, encoder_hidden_states, past_key_values, cache_position)
-            past_key_values.dump_beam_cache(0)
-            return logits
+        if input_ids is None:
+            raise ValueError("MobilintWhisperCache requires input_ids to track beam token histories.")
+
+        input_ids = input_ids.view(batch_size, -1)
 
         past_key_values.ensure_batch_size(batch_size)
         if encoder_hidden_states.shape[0] == 1 and batch_size > 1:
             encoder_hidden_states = encoder_hidden_states.expand(batch_size, *encoder_hidden_states.shape[1:])
-        sequence_length = int(hidden_states.shape[2])
 
-        logits_list = []
+        logits_list: list[torch.Tensor] = []
+        logits_by_target_tokens: dict[tuple[int, ...], torch.Tensor] = {}
         mxq_model = self.npu_backend.mxq_model
         for beam_index in range(batch_size):
-            cache_size = past_key_values.load_beam_cache(beam_index)
-            hidden_states_numpy = hidden_states[beam_index : beam_index + 1].type(torch.float32).cpu().numpy()
+            target_tokens = past_key_values.build_target_tokens(beam_index, input_ids[beam_index])
+            target_key = tuple(target_tokens)
+            prefix_length = past_key_values.get_common_prefix_length(target_tokens)
+            if prefix_length == len(target_tokens) and target_key in logits_by_target_tokens:
+                logits_list.append(logits_by_target_tokens[target_key])
+                past_key_values.commit_beam_tokens(beam_index, target_tokens)
+                continue
+            if prefix_length == len(target_tokens):
+                prefix_length = max(0, len(target_tokens) - int(input_ids.shape[1]))
+            suffix_hidden_states = self._embed_token_suffix(
+                target_tokens,
+                prefix_length,
+                device=hidden_states.device,
+            )
+            suffix_length = int(suffix_hidden_states.shape[2])
+            hidden_states_numpy = suffix_hidden_states.type(torch.float32).cpu().numpy()
             encoder_hidden_states_numpy = (
                 encoder_hidden_states[beam_index : beam_index + 1].type(torch.float32).cpu().numpy()
             )
-            result = mxq_model.infer([hidden_states_numpy, encoder_hidden_states_numpy], None, cache_size)
+            result = mxq_model.infer([hidden_states_numpy, encoder_hidden_states_numpy], None, prefix_length)
             assert result is not None, "mxq infer result is None!"
             logits = torch.tensor(result[0], dtype=hidden_states.dtype, device=hidden_states.device)
-            if logits.ndim == 2 and int(logits.shape[0]) == sequence_length:
-                logits = logits.reshape(1, 1, sequence_length, -1)
-            elif logits.ndim == 3:
-                logits = logits.unsqueeze(0)
-            logits_list.append(logits)
-            past_key_values.update_cache_position(cache_position, index=beam_index)
-            past_key_values.dump_beam_cache(beam_index)
+            logits = self._normalize_decoder_logits(logits, sequence_length=suffix_length)
+            current_logits = logits[:, :, -input_ids.shape[1] :, :]
+            logits_list.append(current_logits)
+            logits_by_target_tokens[target_key] = current_logits
+            past_key_values.commit_beam_tokens(beam_index, target_tokens)
+            past_key_values.commit_active_tokens(target_tokens)
 
         return torch.cat(logits_list, dim=0)
     
@@ -223,7 +266,8 @@ class MobilintWhisperDecoder(MobilintModelMixin, MobilintWhisperPreTrainedModel)
             hidden_states.unsqueeze(1),
             cast(torch.Tensor, encoder_hidden_states),
             past_key_values,
-            cache_position
+            cache_position,
+            input_ids=input_ids,
         )
 
         next_cache = past_key_values if use_cache else None

--- a/mblt_model_zoo/hf_transformers/models/whisper/processing_whisper.py
+++ b/mblt_model_zoo/hf_transformers/models/whisper/processing_whisper.py
@@ -47,10 +47,14 @@ class MobilintWhisperFeatureExtractor(HFWhisperFeatureExtractor):
         Returns:
             The batch feature output from the parent feature extractor.
         """
+        return_token_timestamps = bool(kwargs.pop("return_token_timestamps", False))
+        if return_token_timestamps:
+            kwargs["return_attention_mask"] = True
+
         processed = super().__call__(*args, **kwargs)
 
         if (
-            kwargs.get("return_token_timestamps")
+            return_token_timestamps
             and "num_frames" not in processed
             and "attention_mask" in processed
         ):

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -10,6 +10,11 @@ import torch
 from transformers.cache_utils import Cache, CacheLayerMixin
 
 
+def is_whisper_beam_debug_trace_enabled() -> bool:
+    """Return whether Whisper beam-cache debug tracing is enabled."""
+    return bool(os.environ.get("MBLT_WHISPER_BEAM_DEBUG_TRACE"))
+
+
 def append_whisper_beam_debug_event(event: dict[str, Any]) -> None:
     """Append one Whisper beam-cache debug event when tracing is enabled."""
     trace_path = os.environ.get("MBLT_WHISPER_BEAM_DEBUG_TRACE")
@@ -314,25 +319,28 @@ class MobilintBeamCache(MobilintCache):
     def reorder_cache(self, beam_idx: torch.LongTensor) -> "MobilintBeamCache":
         """Reorder application-level beam token histories in HF beam order."""
         beam_idx = self._validate_beam_indices(beam_idx)
+        trace_enabled = is_whisper_beam_debug_trace_enabled()
 
-        append_whisper_beam_debug_event(
-            {
-                "event": "cache_reorder_before",
-                "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
-                "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
-                "beam_seq_lengths": list(self._beam_seq_lengths),
-                "active_token_history": list(self._active_token_history),
-            }
-        )
-
-        if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
+        if trace_enabled:
             append_whisper_beam_debug_event(
                 {
-                    "event": "cache_reorder_identity",
+                    "event": "cache_reorder_before",
                     "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
+                    "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
+                    "beam_seq_lengths": list(self._beam_seq_lengths),
                     "active_token_history": list(self._active_token_history),
                 }
             )
+
+        if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
+            if trace_enabled:
+                append_whisper_beam_debug_event(
+                    {
+                        "event": "cache_reorder_identity",
+                        "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
+                        "active_token_history": list(self._active_token_history),
+                    }
+                )
             return self
 
         old_token_histories = [list(tokens) for tokens in self._beam_token_histories]
@@ -342,15 +350,16 @@ class MobilintBeamCache(MobilintCache):
         self._beam_seq_lengths = [old_seq_lengths[index] for index in beam_indices]
         for beam_id, seq_length in enumerate(self._beam_seq_lengths):
             self.layers[beam_id].set_seq_length(seq_length)
-        append_whisper_beam_debug_event(
-            {
-                "event": "cache_reorder_after",
-                "beam_idx": beam_indices,
-                "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
-                "beam_seq_lengths": list(self._beam_seq_lengths),
-                "active_token_history": list(self._active_token_history),
-            }
-        )
+        if trace_enabled:
+            append_whisper_beam_debug_event(
+                {
+                    "event": "cache_reorder_after",
+                    "beam_idx": beam_indices,
+                    "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
+                    "beam_seq_lengths": list(self._beam_seq_lengths),
+                    "active_token_history": list(self._active_token_history),
+                }
+            )
         return self
 
     def _validate_beam_indices(self, beam_idx: torch.LongTensor) -> torch.LongTensor:

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -402,6 +402,33 @@ class MobilintBeamCache(MobilintCache):
 class MobilintWhisperCache(MobilintBeamCache):
     """Whisper cache using token-history beam replay."""
 
+    def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1) -> None:
+        super().__init__(mxq_model=mxq_model, batch_size=batch_size)
+        self._encoder_source_count: int | None = None
+
+    def reset(self) -> None:
+        """Reset beam cache state and forget the current encoder source grouping."""
+        super().reset()
+        self._encoder_source_count = None
+
+    def set_encoder_source_count(self, source_count: int) -> None:
+        """Record the original audio batch size before Hugging Face beam expansion."""
+        source_count = int(source_count)
+        if source_count < 1:
+            raise ValueError(f"source_count must be positive, got {source_count}")
+        self._encoder_source_count = source_count
+
+    def get_encoder_source_count(self) -> int | None:
+        """Return the original encoder source count when it is known."""
+        return self._encoder_source_count
+
+    def copy(self) -> "MobilintWhisperCache":
+        """Return a copy preserving Whisper encoder source grouping metadata."""
+        copied = super().copy()
+        assert isinstance(copied, MobilintWhisperCache)
+        copied._encoder_source_count = self._encoder_source_count
+        return copied
+
 
 class MobilintDeepStackCache(MobilintCache):
     """Mobilint KV cache carrying Qwen3-VL deepstack decoder inputs.

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -1,23 +1,10 @@
 import copy
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Optional, Union
 
 import qbruntime
 import torch
 from transformers.cache_utils import Cache, CacheLayerMixin
-
-
-@dataclass
-class MobilintWhisperReplayState:
-    """Replay context needed to rebuild Whisper KV cache state after beam reordering."""
-
-    decoder_input_ids: Optional[torch.LongTensor] = None
-    decoder_forward: Optional[Callable[..., Any]] = None
-    encoder_hidden_states: Optional[torch.Tensor] = None
-    device: Optional[torch.device] = None
-    return_dict: bool = True
-    use_cache: bool = True
 
 
 class MobilintLayer(CacheLayerMixin):
@@ -27,7 +14,7 @@ class MobilintLayer(CacheLayerMixin):
         self.mxq_model = mxq_model
         self.cache_id = cache_id
         self._seen_tokens = 0
-        self.buffer: List[bytes] = []
+        self.buffer: list[bytes] = []
         self.buffer_seq_length: Optional[int] = None
 
     def lazy_initialization(self, key_states: torch.Tensor):
@@ -213,59 +200,8 @@ class MobilintWhisperCache(MobilintCache):
 
     def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1) -> None:
         super().__init__(mxq_model=mxq_model, batch_size=batch_size)
-        self._replay_state = MobilintWhisperReplayState()
-        self._is_replaying = False
-        self._beam_cache_buffers: list[Optional[List[bytes]]] = [None for _ in range(self.batch_size)]
+        self._beam_cache_buffers: list[Optional[list[bytes]]] = [None for _ in range(self.batch_size)]
         self._beam_seq_lengths: list[int] = [0 for _ in range(self.batch_size)]
-
-    def configure_reorder_replay(
-        self,
-        *,
-        decoder_input_ids: Optional[torch.LongTensor] = None,
-        decoder_forward: Optional[Callable[..., Any]] = None,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        device: Optional[torch.device] = None,
-        return_dict: bool = True,
-        use_cache: bool = True,
-    ) -> None:
-        """Configure replay state used by ``reorder_cache``.
-
-        Args:
-            decoder_input_ids: Full decoder token history for each active beam row.
-            decoder_forward: Whisper decoder-compatible forward callable.
-            encoder_hidden_states: Encoder outputs required by Whisper cross-attention.
-            device: Device used for replay token and cache-position tensors.
-            return_dict: Whether replay calls should request return-dict outputs.
-            use_cache: Whether replay calls should update this cache.
-
-        Raises:
-            ValueError: If ``decoder_input_ids`` is not rank 2.
-        """
-        if self._is_replaying:
-            return
-        if decoder_input_ids is not None and decoder_input_ids.ndim != 2:
-            raise ValueError(f"decoder_input_ids must be rank 2, got shape {tuple(decoder_input_ids.shape)}")
-
-        if decoder_input_ids is not None and self._should_update_decoder_input_ids(decoder_input_ids):
-            self.ensure_batch_size(int(decoder_input_ids.shape[0]))
-            self._replay_state.decoder_input_ids = decoder_input_ids.detach().clone().to(dtype=torch.long)
-        if decoder_forward is not None:
-            self._replay_state.decoder_forward = decoder_forward
-        if encoder_hidden_states is not None:
-            self._replay_state.encoder_hidden_states = encoder_hidden_states
-        if device is not None:
-            self._replay_state.device = device
-        self._replay_state.return_dict = return_dict
-        self._replay_state.use_cache = use_cache
-
-    def _should_update_decoder_input_ids(self, decoder_input_ids: torch.LongTensor) -> bool:
-        """Return whether a new decoder history should replace the stored history."""
-        current_input_ids = self._replay_state.decoder_input_ids
-        if current_input_ids is None:
-            return True
-        if int(decoder_input_ids.shape[0]) != int(current_input_ids.shape[0]):
-            return True
-        return int(decoder_input_ids.shape[1]) >= int(current_input_ids.shape[1])
 
     def reset(self) -> None:
         """Reset active qbruntime cache bookkeeping and clear stored beam blobs."""
@@ -332,8 +268,7 @@ class MobilintWhisperCache(MobilintCache):
 
     def reorder_cache(self, beam_idx: torch.LongTensor) -> "MobilintWhisperCache":
         """Reorder application-level Whisper beam KV blobs in HF beam order."""
-        beam_idx = self._validate_replay_ready(beam_idx)
-        decoder_input_ids = self._replay_state.decoder_input_ids
+        beam_idx = self._validate_beam_indices(beam_idx)
 
         if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
             return self
@@ -345,86 +280,30 @@ class MobilintWhisperCache(MobilintCache):
         self._beam_seq_lengths = [old_seq_lengths[index] for index in beam_indices]
         for beam_id, seq_length in enumerate(self._beam_seq_lengths):
             self.layers[beam_id].set_seq_length(seq_length)
-        if decoder_input_ids is not None:
-            self._replay_state.decoder_input_ids = decoder_input_ids.index_select(
-                0, beam_idx.to(decoder_input_ids.device)
-            ).detach().clone()
         return self
 
-    def _validate_replay_ready(self, beam_idx: torch.LongTensor) -> torch.LongTensor:
-        """Validate beam indices and replay context before rebuilding cache state."""
+    def _validate_beam_indices(self, beam_idx: torch.LongTensor) -> torch.LongTensor:
+        """Validate beam indices before reordering cache snapshots."""
         if not isinstance(beam_idx, torch.Tensor):
             raise TypeError("beam_idx must be a torch.Tensor")
         if beam_idx.ndim != 1:
             raise ValueError(f"beam_idx must be rank 1, got shape {tuple(beam_idx.shape)}")
 
         beam_idx = beam_idx.to(dtype=torch.long)
-        state = self._replay_state
-        if state.decoder_input_ids is not None and int(state.decoder_input_ids.shape[0]) != int(beam_idx.numel()):
-            raise ValueError(
-                "decoder_input_ids row count must match beam_idx length: "
-                f"{int(state.decoder_input_ids.shape[0])} vs {int(beam_idx.numel())}"
-            )
         self.ensure_batch_size(int(beam_idx.numel()))
         if beam_idx.numel() > 0 and (int(beam_idx.min()) < 0 or int(beam_idx.max()) >= int(beam_idx.numel())):
             raise ValueError(f"beam_idx contains out-of-range values for {int(beam_idx.numel())} beams")
         return beam_idx
 
-    @staticmethod
-    def _longest_common_prefix_length(decoder_input_ids: torch.LongTensor) -> int:
-        """Return the shared prefix length across all reordered decoder rows."""
-        if decoder_input_ids.ndim != 2:
-            raise ValueError(f"decoder_input_ids must be rank 2, got shape {tuple(decoder_input_ids.shape)}")
-        if int(decoder_input_ids.shape[0]) <= 1:
-            return int(decoder_input_ids.shape[1])
-
-        first_row = decoder_input_ids[0]
-        for position in range(int(decoder_input_ids.shape[1])):
-            if not torch.equal(decoder_input_ids[:, position], first_row[position].expand_as(decoder_input_ids[:, position])):
-                return position
-        return int(decoder_input_ids.shape[1])
-
-    def _replay_tokens(self, input_ids: torch.LongTensor, start_position: int) -> None:
-        """Replay decoder tokens into qbruntime-backed cache memory."""
-        if input_ids.numel() == 0:
-            return
-
-        state = self._replay_state
-        assert state.decoder_forward is not None
-        assert state.encoder_hidden_states is not None
-        device = state.device or input_ids.device
-        replay_input_ids = input_ids.to(device=device, dtype=torch.long)
-        cache_position = torch.arange(
-            start_position,
-            start_position + int(replay_input_ids.shape[1]),
-            device=device,
-            dtype=torch.long,
-        )
-
-        self._is_replaying = True
-        try:
-            state.decoder_forward(
-                input_ids=replay_input_ids,
-                encoder_hidden_states=state.encoder_hidden_states,
-                past_key_values=self,
-                use_cache=state.use_cache,
-                return_dict=state.return_dict,
-                cache_position=cache_position,
-            )
-        finally:
-            self._is_replaying = False
-
     def copy(self) -> "MobilintWhisperCache":
-        """Return a copy preserving KV state and replay configuration."""
+        """Return a copy preserving application-level beam KV snapshots."""
         copied = MobilintWhisperCache(self.mxq_model, batch_size=self.batch_size)
         for i in range(self.batch_size):
             copied.layers[i] = self.layers[i].copy()
-        copied._replay_state = copy.copy(self._replay_state)
-        if self._replay_state.decoder_input_ids is not None:
-            copied._replay_state.decoder_input_ids = self._replay_state.decoder_input_ids.clone()
-        copied._beam_cache_buffers = [copy.deepcopy(buffer) if buffer is not None else None for buffer in self._beam_cache_buffers]
+        copied._beam_cache_buffers = [
+            copy.deepcopy(buffer) if buffer is not None else None for buffer in self._beam_cache_buffers
+        ]
         copied._beam_seq_lengths = list(self._beam_seq_lengths)
-        copied._is_replaying = False
         return copied
 
 

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -222,6 +222,7 @@ class MobilintBeamCache(MobilintCache):
     def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1) -> None:
         super().__init__(mxq_model=mxq_model, batch_size=batch_size)
         self._beam_token_histories: list[list[int]] = [[] for _ in range(self.batch_size)]
+        self._beam_source_indices: list[int | None] = [None for _ in range(self.batch_size)]
         self._active_token_history: list[int] = []
         self._active_source_index: int | None = None
         self._beam_seq_lengths: list[int] = [0 for _ in range(self.batch_size)]
@@ -230,6 +231,7 @@ class MobilintBeamCache(MobilintCache):
         """Reset active qbruntime cache bookkeeping and clear beam token histories."""
         super().reset()
         self._beam_token_histories = [[] for _ in range(self.batch_size)]
+        self._beam_source_indices = [None for _ in range(self.batch_size)]
         self._active_token_history = []
         self._active_source_index = None
         self._beam_seq_lengths = [0 for _ in range(self.batch_size)]
@@ -241,6 +243,7 @@ class MobilintBeamCache(MobilintCache):
         if self.batch_size <= previous_batch_size:
             return
         self._beam_token_histories.extend([[] for _ in range(self.batch_size - previous_batch_size)])
+        self._beam_source_indices.extend([None for _ in range(self.batch_size - previous_batch_size)])
         self._beam_seq_lengths.extend([0 for _ in range(self.batch_size - previous_batch_size)])
 
     def get_seq_length(self, index: int = 0) -> int:
@@ -283,6 +286,17 @@ class MobilintBeamCache(MobilintCache):
         """Return a copy of the stored token history for one logical beam."""
         self.ensure_batch_size(beam_index + 1)
         return list(self._beam_token_histories[beam_index])
+
+    def get_beam_source_index(self, beam_index: int) -> int | None:
+        """Return the source row identity stored for one logical beam."""
+        self.ensure_batch_size(beam_index + 1)
+        return self._beam_source_indices[beam_index]
+
+    def set_beam_source_indices(self, source_indices: Sequence[int | None]) -> None:
+        """Store source row identities for logical beams when they are first resolved."""
+        self.ensure_batch_size(len(source_indices))
+        for beam_index, source_index in enumerate(source_indices):
+            self._beam_source_indices[beam_index] = None if source_index is None else int(source_index)
 
     def get_active_tokens(self) -> list[int]:
         """Return a copy of the token history represented by the active qbruntime cache."""
@@ -336,6 +350,7 @@ class MobilintBeamCache(MobilintCache):
                     "event": "cache_reorder_before",
                     "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
                     "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
+                    "beam_source_indices": list(self._beam_source_indices),
                     "beam_seq_lengths": list(self._beam_seq_lengths),
                     "active_token_history": list(self._active_token_history),
                     "active_source_index": self._active_source_index,
@@ -355,9 +370,11 @@ class MobilintBeamCache(MobilintCache):
             return self
 
         old_token_histories = [list(tokens) for tokens in self._beam_token_histories]
+        old_source_indices = list(self._beam_source_indices)
         old_seq_lengths = list(self._beam_seq_lengths)
         beam_indices = [int(index) for index in beam_idx.cpu().tolist()]
         self._beam_token_histories = [list(old_token_histories[index]) for index in beam_indices]
+        self._beam_source_indices = [old_source_indices[index] for index in beam_indices]
         self._beam_seq_lengths = [old_seq_lengths[index] for index in beam_indices]
         for beam_id, seq_length in enumerate(self._beam_seq_lengths):
             self.layers[beam_id].set_seq_length(seq_length)
@@ -367,6 +384,7 @@ class MobilintBeamCache(MobilintCache):
                     "event": "cache_reorder_after",
                     "beam_idx": beam_indices,
                     "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
+                    "beam_source_indices": list(self._beam_source_indices),
                     "beam_seq_lengths": list(self._beam_seq_lengths),
                     "active_token_history": list(self._active_token_history),
                     "active_source_index": self._active_source_index,
@@ -393,6 +411,7 @@ class MobilintBeamCache(MobilintCache):
         for i in range(self.batch_size):
             copied.layers[i] = self.layers[i].copy()
         copied._beam_token_histories = [list(tokens) for tokens in self._beam_token_histories]
+        copied._beam_source_indices = list(self._beam_source_indices)
         copied._active_token_history = list(self._active_token_history)
         copied._active_source_index = self._active_source_index
         copied._beam_seq_lengths = list(self._beam_seq_lengths)

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -1,6 +1,6 @@
 import copy
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Sequence, Union
 
 import qbruntime
 import torch
@@ -190,32 +190,35 @@ class MobilintCache(Cache):
 
 
 class MobilintBeamCache(MobilintCache):
-    """Mobilint cache with application-level beam KV blobs.
+    """Mobilint beam cache tracked by token histories instead of KV snapshots.
 
-    Some decoder MXQs own a single active KV cache in qbruntime memory. Beam
-    search therefore stores each beam's KV payload as a dumped blob in Python and
-    swaps one blob into the active qbruntime cache before each batch-size-1
-    decoder call.
+    qbruntime owns one active KV cache. This class tracks the token history for
+    each logical beam and the token history currently represented by the active
+    qbruntime cache. Callers can compare a target beam history with the active
+    history, skip the common prefix, and forward only the suffix with the proper
+    cache position.
     """
 
     def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1) -> None:
         super().__init__(mxq_model=mxq_model, batch_size=batch_size)
-        self._beam_cache_buffers: list[Optional[list[bytes]]] = [None for _ in range(self.batch_size)]
+        self._beam_token_histories: list[list[int]] = [[] for _ in range(self.batch_size)]
+        self._active_token_history: list[int] = []
         self._beam_seq_lengths: list[int] = [0 for _ in range(self.batch_size)]
 
     def reset(self) -> None:
-        """Reset active qbruntime cache bookkeeping and clear stored beam blobs."""
+        """Reset active qbruntime cache bookkeeping and clear beam token histories."""
         super().reset()
-        self._beam_cache_buffers = [None for _ in range(self.batch_size)]
+        self._beam_token_histories = [[] for _ in range(self.batch_size)]
+        self._active_token_history = []
         self._beam_seq_lengths = [0 for _ in range(self.batch_size)]
 
     def ensure_batch_size(self, batch_size: int) -> None:
-        """Grow logical beam blob storage for beam-expanded Whisper generation."""
+        """Grow logical beam token storage for beam-expanded generation."""
         previous_batch_size = self.batch_size
         super().ensure_batch_size(batch_size)
         if self.batch_size <= previous_batch_size:
             return
-        self._beam_cache_buffers.extend([None for _ in range(self.batch_size - previous_batch_size)])
+        self._beam_token_histories.extend([[] for _ in range(self.batch_size - previous_batch_size)])
         self._beam_seq_lengths.extend([0 for _ in range(self.batch_size - previous_batch_size)])
 
     def get_seq_length(self, index: int = 0) -> int:
@@ -230,6 +233,7 @@ class MobilintBeamCache(MobilintCache):
             if sequence_lengths < 0:
                 raise ValueError(f"seq_length must be non-negative, got {sequence_lengths}")
             self._beam_seq_lengths[index] = sequence_lengths
+            self._beam_token_histories[index] = self._beam_token_histories[index][:sequence_lengths]
             self.layers[index].set_seq_length(sequence_lengths)
             return
         if sequence_lengths:
@@ -238,6 +242,7 @@ class MobilintBeamCache(MobilintCache):
             if seq_len < 0:
                 raise ValueError(f"seq_length must be non-negative, got {seq_len}")
             self._beam_seq_lengths[beam_id] = seq_len
+            self._beam_token_histories[beam_id] = self._beam_token_histories[beam_id][:seq_len]
             self.layers[beam_id].set_seq_length(seq_len)
 
     def update_cache_position(self, cache_position: torch.Tensor, index: int = 0) -> None:
@@ -246,44 +251,69 @@ class MobilintBeamCache(MobilintCache):
         self._beam_seq_lengths[index] += int(cache_position.numel())
         self.layers[index].set_seq_length(self._beam_seq_lengths[index])
 
-    def load_beam_cache(self, beam_index: int) -> int:
-        """Load one stored beam blob into the single active qbruntime KV cache."""
+    def build_target_tokens(self, beam_index: int, input_ids: torch.Tensor) -> list[int]:
+        """Return the target token history for one beam after appending new ids."""
         self.ensure_batch_size(beam_index + 1)
-        seq_length = self._beam_seq_lengths[beam_index]
-        self.layers[0].reset()
-        self.layers[0].set_seq_length(seq_length)
-        buffer = self._beam_cache_buffers[beam_index]
-        if seq_length > 0 and buffer is not None:
-            self.mxq_model.load_cache_memory(copy.deepcopy(buffer), 0)
-        return seq_length
+        new_tokens = self._tensor_to_token_list(input_ids)
+        return [*self._beam_token_histories[beam_index], *new_tokens]
 
-    def dump_beam_cache(self, beam_index: int) -> None:
-        """Store the single active qbruntime KV cache as one logical beam blob."""
+    def get_beam_tokens(self, beam_index: int) -> list[int]:
+        """Return a copy of the stored token history for one logical beam."""
         self.ensure_batch_size(beam_index + 1)
-        seq_length = self._beam_seq_lengths[beam_index]
-        if seq_length == 0:
-            self._beam_cache_buffers[beam_index] = None
-            return
-        self._beam_cache_buffers[beam_index] = copy.deepcopy(self.mxq_model.dump_cache_memory(0))
+        return list(self._beam_token_histories[beam_index])
+
+    def get_active_tokens(self) -> list[int]:
+        """Return a copy of the token history represented by the active qbruntime cache."""
+        return list(self._active_token_history)
+
+    def get_common_prefix_length(self, target_tokens: Sequence[int]) -> int:
+        """Return how many target tokens already match the active qbruntime cache."""
+        prefix_length = 0
+        for active_token, target_token in zip(self._active_token_history, target_tokens):
+            if active_token != target_token:
+                break
+            prefix_length += 1
+        return prefix_length
+
+    def commit_beam_tokens(self, beam_index: int, target_tokens: Sequence[int]) -> None:
+        """Store the completed target history for one logical beam."""
+        self.ensure_batch_size(beam_index + 1)
+        token_history = [int(token) for token in target_tokens]
+        self._beam_token_histories[beam_index] = token_history
+        self._beam_seq_lengths[beam_index] = len(token_history)
+        self.layers[beam_index].set_seq_length(len(token_history))
+
+    def commit_active_tokens(self, target_tokens: Sequence[int]) -> None:
+        """Record which token history is now represented by active qbruntime cache memory."""
+        self._active_token_history = [int(token) for token in target_tokens]
+        self.layers[0].set_seq_length(len(self._active_token_history))
+
+    def _tensor_to_token_list(self, input_ids: torch.Tensor) -> list[int]:
+        """Convert a one-row token tensor to a flat Python token list."""
+        if not isinstance(input_ids, torch.Tensor):
+            raise TypeError("input_ids must be a torch.Tensor")
+        if input_ids.ndim == 0:
+            input_ids = input_ids.reshape(1)
+        return [int(token) for token in input_ids.reshape(-1).detach().cpu().tolist()]
 
     def reorder_cache(self, beam_idx: torch.LongTensor) -> "MobilintBeamCache":
-        """Reorder application-level beam KV blobs in HF beam order."""
+        """Reorder application-level beam token histories in HF beam order."""
         beam_idx = self._validate_beam_indices(beam_idx)
 
         if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
             return self
 
-        old_buffers = [copy.deepcopy(buffer) if buffer is not None else None for buffer in self._beam_cache_buffers]
+        old_token_histories = [list(tokens) for tokens in self._beam_token_histories]
         old_seq_lengths = list(self._beam_seq_lengths)
         beam_indices = [int(index) for index in beam_idx.cpu().tolist()]
-        self._beam_cache_buffers = [copy.deepcopy(old_buffers[index]) for index in beam_indices]
+        self._beam_token_histories = [list(old_token_histories[index]) for index in beam_indices]
         self._beam_seq_lengths = [old_seq_lengths[index] for index in beam_indices]
         for beam_id, seq_length in enumerate(self._beam_seq_lengths):
             self.layers[beam_id].set_seq_length(seq_length)
         return self
 
     def _validate_beam_indices(self, beam_idx: torch.LongTensor) -> torch.LongTensor:
-        """Validate beam indices before reordering cache snapshots."""
+        """Validate beam indices before reordering token histories."""
         if not isinstance(beam_idx, torch.Tensor):
             raise TypeError("beam_idx must be a torch.Tensor")
         if beam_idx.ndim != 1:
@@ -296,19 +326,18 @@ class MobilintBeamCache(MobilintCache):
         return beam_idx
 
     def copy(self) -> "MobilintBeamCache":
-        """Return a copy preserving application-level beam KV snapshots."""
+        """Return a copy preserving application-level beam token histories."""
         copied = self.__class__(self.mxq_model, batch_size=self.batch_size)
         for i in range(self.batch_size):
             copied.layers[i] = self.layers[i].copy()
-        copied._beam_cache_buffers = [
-            copy.deepcopy(buffer) if buffer is not None else None for buffer in self._beam_cache_buffers
-        ]
+        copied._beam_token_histories = [list(tokens) for tokens in self._beam_token_histories]
+        copied._active_token_history = list(self._active_token_history)
         copied._beam_seq_lengths = list(self._beam_seq_lengths)
         return copied
 
 
 class MobilintWhisperCache(MobilintBeamCache):
-    """Backward-compatible Whisper cache alias for beam snapshot decoding."""
+    """Whisper cache using token-history beam replay."""
 
 
 class MobilintDeepStackCache(MobilintCache):

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -223,6 +223,7 @@ class MobilintBeamCache(MobilintCache):
         super().__init__(mxq_model=mxq_model, batch_size=batch_size)
         self._beam_token_histories: list[list[int]] = [[] for _ in range(self.batch_size)]
         self._active_token_history: list[int] = []
+        self._active_source_index: int | None = None
         self._beam_seq_lengths: list[int] = [0 for _ in range(self.batch_size)]
 
     def reset(self) -> None:
@@ -230,6 +231,7 @@ class MobilintBeamCache(MobilintCache):
         super().reset()
         self._beam_token_histories = [[] for _ in range(self.batch_size)]
         self._active_token_history = []
+        self._active_source_index = None
         self._beam_seq_lengths = [0 for _ in range(self.batch_size)]
 
     def ensure_batch_size(self, batch_size: int) -> None:
@@ -286,8 +288,14 @@ class MobilintBeamCache(MobilintCache):
         """Return a copy of the token history represented by the active qbruntime cache."""
         return list(self._active_token_history)
 
-    def get_common_prefix_length(self, target_tokens: Sequence[int]) -> int:
+    def get_active_source_index(self) -> int | None:
+        """Return the source row represented by the active qbruntime cache."""
+        return self._active_source_index
+
+    def get_common_prefix_length(self, target_tokens: Sequence[int], source_index: int | None = None) -> int:
         """Return how many target tokens already match the active qbruntime cache."""
+        if source_index is not None and self._active_source_index != int(source_index):
+            return 0
         prefix_length = 0
         for active_token, target_token in zip(self._active_token_history, target_tokens):
             if active_token != target_token:
@@ -303,9 +311,10 @@ class MobilintBeamCache(MobilintCache):
         self._beam_seq_lengths[beam_index] = len(token_history)
         self.layers[beam_index].set_seq_length(len(token_history))
 
-    def commit_active_tokens(self, target_tokens: Sequence[int]) -> None:
+    def commit_active_tokens(self, target_tokens: Sequence[int], source_index: int | None = None) -> None:
         """Record which token history is now represented by active qbruntime cache memory."""
         self._active_token_history = [int(token) for token in target_tokens]
+        self._active_source_index = None if source_index is None else int(source_index)
         self.layers[0].set_seq_length(len(self._active_token_history))
 
     def _tensor_to_token_list(self, input_ids: torch.Tensor) -> list[int]:
@@ -329,6 +338,7 @@ class MobilintBeamCache(MobilintCache):
                     "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
                     "beam_seq_lengths": list(self._beam_seq_lengths),
                     "active_token_history": list(self._active_token_history),
+                    "active_source_index": self._active_source_index,
                 }
             )
 
@@ -339,6 +349,7 @@ class MobilintBeamCache(MobilintCache):
                         "event": "cache_reorder_identity",
                         "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
                         "active_token_history": list(self._active_token_history),
+                        "active_source_index": self._active_source_index,
                     }
                 )
             return self
@@ -358,6 +369,7 @@ class MobilintBeamCache(MobilintCache):
                     "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
                     "beam_seq_lengths": list(self._beam_seq_lengths),
                     "active_token_history": list(self._active_token_history),
+                    "active_source_index": self._active_source_index,
                 }
             )
         return self
@@ -382,6 +394,7 @@ class MobilintBeamCache(MobilintCache):
             copied.layers[i] = self.layers[i].copy()
         copied._beam_token_histories = [list(tokens) for tokens in self._beam_token_histories]
         copied._active_token_history = list(self._active_token_history)
+        copied._active_source_index = self._active_source_index
         copied._beam_seq_lengths = list(self._beam_seq_lengths)
         return copied
 

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -189,13 +189,13 @@ class MobilintCache(Cache):
         return copied
 
 
-class MobilintWhisperCache(MobilintCache):
-    """Whisper-specific Mobilint cache with application-level beam KV blobs.
+class MobilintBeamCache(MobilintCache):
+    """Mobilint cache with application-level beam KV blobs.
 
-    Whisper decoder MXQ owns a single active KV cache in qbruntime memory. Beam
+    Some decoder MXQs own a single active KV cache in qbruntime memory. Beam
     search therefore stores each beam's KV payload as a dumped blob in Python and
-    swaps one blob into the active qbruntime cache before each batch-size-1 decoder
-    call.
+    swaps one blob into the active qbruntime cache before each batch-size-1
+    decoder call.
     """
 
     def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1) -> None:
@@ -219,12 +219,12 @@ class MobilintWhisperCache(MobilintCache):
         self._beam_seq_lengths.extend([0 for _ in range(self.batch_size - previous_batch_size)])
 
     def get_seq_length(self, index: int = 0) -> int:
-        """Return the stored sequence length for one logical Whisper beam."""
+        """Return the stored sequence length for one logical beam."""
         self.ensure_batch_size(index + 1)
         return self._beam_seq_lengths[index]
 
     def set_seq_length(self, sequence_lengths: Union[dict[int, int], int], index: int = 0) -> None:
-        """Set stored sequence lengths for one or more logical Whisper beams."""
+        """Set stored sequence lengths for one or more logical beams."""
         if isinstance(sequence_lengths, int):
             self.ensure_batch_size(index + 1)
             if sequence_lengths < 0:
@@ -266,8 +266,8 @@ class MobilintWhisperCache(MobilintCache):
             return
         self._beam_cache_buffers[beam_index] = copy.deepcopy(self.mxq_model.dump_cache_memory(0))
 
-    def reorder_cache(self, beam_idx: torch.LongTensor) -> "MobilintWhisperCache":
-        """Reorder application-level Whisper beam KV blobs in HF beam order."""
+    def reorder_cache(self, beam_idx: torch.LongTensor) -> "MobilintBeamCache":
+        """Reorder application-level beam KV blobs in HF beam order."""
         beam_idx = self._validate_beam_indices(beam_idx)
 
         if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
@@ -295,9 +295,9 @@ class MobilintWhisperCache(MobilintCache):
             raise ValueError(f"beam_idx contains out-of-range values for {int(beam_idx.numel())} beams")
         return beam_idx
 
-    def copy(self) -> "MobilintWhisperCache":
+    def copy(self) -> "MobilintBeamCache":
         """Return a copy preserving application-level beam KV snapshots."""
-        copied = MobilintWhisperCache(self.mxq_model, batch_size=self.batch_size)
+        copied = self.__class__(self.mxq_model, batch_size=self.batch_size)
         for i in range(self.batch_size):
             copied.layers[i] = self.layers[i].copy()
         copied._beam_cache_buffers = [
@@ -305,6 +305,10 @@ class MobilintWhisperCache(MobilintCache):
         ]
         copied._beam_seq_lengths = list(self._beam_seq_lengths)
         return copied
+
+
+class MobilintWhisperCache(MobilintBeamCache):
+    """Backward-compatible Whisper cache alias for beam snapshot decoding."""
 
 
 class MobilintDeepStackCache(MobilintCache):

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -1,10 +1,23 @@
 import copy
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 import qbruntime
 import torch
 from transformers.cache_utils import Cache, CacheLayerMixin
+
+
+@dataclass
+class MobilintWhisperReplayState:
+    """Replay context needed to rebuild Whisper KV cache state after beam reordering."""
+
+    decoder_input_ids: Optional[torch.LongTensor] = None
+    decoder_forward: Optional[Callable[..., Any]] = None
+    encoder_hidden_states: Optional[torch.Tensor] = None
+    device: Optional[torch.device] = None
+    return_dict: bool = True
+    use_cache: bool = True
 
 
 class MobilintLayer(CacheLayerMixin):
@@ -168,10 +181,250 @@ class MobilintCache(Cache):
     def load_cache_memory_from(self, cache_dir: str, index: int = 0):
         self.layers[index].load_cache_memory_from(cache_dir)
 
+    def reset(self) -> None:
+        """Reset all cache entries in this Mobilint cache."""
+        for layer in self.layers:
+            layer.reset()
+
+    def ensure_batch_size(self, batch_size: int) -> None:
+        """Grow logical cache entries so batched generation can track each active row."""
+        batch_size = max(1, int(batch_size))
+        if batch_size <= self.batch_size:
+            return
+        for cache_id in range(self.batch_size, batch_size):
+            self.layers.append(MobilintLayer(self.mxq_model, cache_id))
+        self.batch_size = batch_size
+
     def copy(self):
         copied = MobilintCache(self.mxq_model, batch_size=self.batch_size)
         for i in range(self.batch_size):
             copied.layers[i] = self.layers[i].copy()
+        return copied
+
+
+class MobilintWhisperCache(MobilintCache):
+    """Whisper-specific Mobilint cache with application-level beam KV blobs.
+
+    Whisper decoder MXQ owns a single active KV cache in qbruntime memory. Beam
+    search therefore stores each beam's KV payload as a dumped blob in Python and
+    swaps one blob into the active qbruntime cache before each batch-size-1 decoder
+    call.
+    """
+
+    def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1) -> None:
+        super().__init__(mxq_model=mxq_model, batch_size=batch_size)
+        self._replay_state = MobilintWhisperReplayState()
+        self._is_replaying = False
+        self._beam_cache_buffers: list[Optional[List[bytes]]] = [None for _ in range(self.batch_size)]
+        self._beam_seq_lengths: list[int] = [0 for _ in range(self.batch_size)]
+
+    def configure_reorder_replay(
+        self,
+        *,
+        decoder_input_ids: Optional[torch.LongTensor] = None,
+        decoder_forward: Optional[Callable[..., Any]] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        device: Optional[torch.device] = None,
+        return_dict: bool = True,
+        use_cache: bool = True,
+    ) -> None:
+        """Configure replay state used by ``reorder_cache``.
+
+        Args:
+            decoder_input_ids: Full decoder token history for each active beam row.
+            decoder_forward: Whisper decoder-compatible forward callable.
+            encoder_hidden_states: Encoder outputs required by Whisper cross-attention.
+            device: Device used for replay token and cache-position tensors.
+            return_dict: Whether replay calls should request return-dict outputs.
+            use_cache: Whether replay calls should update this cache.
+
+        Raises:
+            ValueError: If ``decoder_input_ids`` is not rank 2.
+        """
+        if self._is_replaying:
+            return
+        if decoder_input_ids is not None and decoder_input_ids.ndim != 2:
+            raise ValueError(f"decoder_input_ids must be rank 2, got shape {tuple(decoder_input_ids.shape)}")
+
+        if decoder_input_ids is not None and self._should_update_decoder_input_ids(decoder_input_ids):
+            self.ensure_batch_size(int(decoder_input_ids.shape[0]))
+            self._replay_state.decoder_input_ids = decoder_input_ids.detach().clone().to(dtype=torch.long)
+        if decoder_forward is not None:
+            self._replay_state.decoder_forward = decoder_forward
+        if encoder_hidden_states is not None:
+            self._replay_state.encoder_hidden_states = encoder_hidden_states
+        if device is not None:
+            self._replay_state.device = device
+        self._replay_state.return_dict = return_dict
+        self._replay_state.use_cache = use_cache
+
+    def _should_update_decoder_input_ids(self, decoder_input_ids: torch.LongTensor) -> bool:
+        """Return whether a new decoder history should replace the stored history."""
+        current_input_ids = self._replay_state.decoder_input_ids
+        if current_input_ids is None:
+            return True
+        if int(decoder_input_ids.shape[0]) != int(current_input_ids.shape[0]):
+            return True
+        return int(decoder_input_ids.shape[1]) >= int(current_input_ids.shape[1])
+
+    def reset(self) -> None:
+        """Reset active qbruntime cache bookkeeping and clear stored beam blobs."""
+        super().reset()
+        self._beam_cache_buffers = [None for _ in range(self.batch_size)]
+        self._beam_seq_lengths = [0 for _ in range(self.batch_size)]
+
+    def ensure_batch_size(self, batch_size: int) -> None:
+        """Grow logical beam blob storage for beam-expanded Whisper generation."""
+        previous_batch_size = self.batch_size
+        super().ensure_batch_size(batch_size)
+        if self.batch_size <= previous_batch_size:
+            return
+        self._beam_cache_buffers.extend([None for _ in range(self.batch_size - previous_batch_size)])
+        self._beam_seq_lengths.extend([0 for _ in range(self.batch_size - previous_batch_size)])
+
+    def get_seq_length(self, index: int = 0) -> int:
+        """Return the stored sequence length for one logical Whisper beam."""
+        self.ensure_batch_size(index + 1)
+        return self._beam_seq_lengths[index]
+
+    def set_seq_length(self, sequence_lengths: Union[dict[int, int], int], index: int = 0) -> None:
+        """Set stored sequence lengths for one or more logical Whisper beams."""
+        if isinstance(sequence_lengths, int):
+            self.ensure_batch_size(index + 1)
+            if sequence_lengths < 0:
+                raise ValueError(f"seq_length must be non-negative, got {sequence_lengths}")
+            self._beam_seq_lengths[index] = sequence_lengths
+            self.layers[index].set_seq_length(sequence_lengths)
+            return
+        if sequence_lengths:
+            self.ensure_batch_size(max(sequence_lengths) + 1)
+        for beam_id, seq_len in sequence_lengths.items():
+            if seq_len < 0:
+                raise ValueError(f"seq_length must be non-negative, got {seq_len}")
+            self._beam_seq_lengths[beam_id] = seq_len
+            self.layers[beam_id].set_seq_length(seq_len)
+
+    def update_cache_position(self, cache_position: torch.Tensor, index: int = 0) -> None:
+        """Update one logical beam length after its active qbruntime cache advances."""
+        self.ensure_batch_size(index + 1)
+        self._beam_seq_lengths[index] += int(cache_position.numel())
+        self.layers[index].set_seq_length(self._beam_seq_lengths[index])
+
+    def load_beam_cache(self, beam_index: int) -> int:
+        """Load one stored beam blob into the single active qbruntime KV cache."""
+        self.ensure_batch_size(beam_index + 1)
+        seq_length = self._beam_seq_lengths[beam_index]
+        self.layers[0].reset()
+        self.layers[0].set_seq_length(seq_length)
+        buffer = self._beam_cache_buffers[beam_index]
+        if seq_length > 0 and buffer is not None:
+            self.mxq_model.load_cache_memory(copy.deepcopy(buffer), 0)
+        return seq_length
+
+    def dump_beam_cache(self, beam_index: int) -> None:
+        """Store the single active qbruntime KV cache as one logical beam blob."""
+        self.ensure_batch_size(beam_index + 1)
+        seq_length = self._beam_seq_lengths[beam_index]
+        if seq_length == 0:
+            self._beam_cache_buffers[beam_index] = None
+            return
+        self._beam_cache_buffers[beam_index] = copy.deepcopy(self.mxq_model.dump_cache_memory(0))
+
+    def reorder_cache(self, beam_idx: torch.LongTensor) -> "MobilintWhisperCache":
+        """Reorder application-level Whisper beam KV blobs in HF beam order."""
+        beam_idx = self._validate_replay_ready(beam_idx)
+        decoder_input_ids = self._replay_state.decoder_input_ids
+
+        if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
+            return self
+
+        old_buffers = [copy.deepcopy(buffer) if buffer is not None else None for buffer in self._beam_cache_buffers]
+        old_seq_lengths = list(self._beam_seq_lengths)
+        beam_indices = [int(index) for index in beam_idx.cpu().tolist()]
+        self._beam_cache_buffers = [copy.deepcopy(old_buffers[index]) for index in beam_indices]
+        self._beam_seq_lengths = [old_seq_lengths[index] for index in beam_indices]
+        for beam_id, seq_length in enumerate(self._beam_seq_lengths):
+            self.layers[beam_id].set_seq_length(seq_length)
+        if decoder_input_ids is not None:
+            self._replay_state.decoder_input_ids = decoder_input_ids.index_select(
+                0, beam_idx.to(decoder_input_ids.device)
+            ).detach().clone()
+        return self
+
+    def _validate_replay_ready(self, beam_idx: torch.LongTensor) -> torch.LongTensor:
+        """Validate beam indices and replay context before rebuilding cache state."""
+        if not isinstance(beam_idx, torch.Tensor):
+            raise TypeError("beam_idx must be a torch.Tensor")
+        if beam_idx.ndim != 1:
+            raise ValueError(f"beam_idx must be rank 1, got shape {tuple(beam_idx.shape)}")
+
+        beam_idx = beam_idx.to(dtype=torch.long)
+        state = self._replay_state
+        if state.decoder_input_ids is not None and int(state.decoder_input_ids.shape[0]) != int(beam_idx.numel()):
+            raise ValueError(
+                "decoder_input_ids row count must match beam_idx length: "
+                f"{int(state.decoder_input_ids.shape[0])} vs {int(beam_idx.numel())}"
+            )
+        self.ensure_batch_size(int(beam_idx.numel()))
+        if beam_idx.numel() > 0 and (int(beam_idx.min()) < 0 or int(beam_idx.max()) >= int(beam_idx.numel())):
+            raise ValueError(f"beam_idx contains out-of-range values for {int(beam_idx.numel())} beams")
+        return beam_idx
+
+    @staticmethod
+    def _longest_common_prefix_length(decoder_input_ids: torch.LongTensor) -> int:
+        """Return the shared prefix length across all reordered decoder rows."""
+        if decoder_input_ids.ndim != 2:
+            raise ValueError(f"decoder_input_ids must be rank 2, got shape {tuple(decoder_input_ids.shape)}")
+        if int(decoder_input_ids.shape[0]) <= 1:
+            return int(decoder_input_ids.shape[1])
+
+        first_row = decoder_input_ids[0]
+        for position in range(int(decoder_input_ids.shape[1])):
+            if not torch.equal(decoder_input_ids[:, position], first_row[position].expand_as(decoder_input_ids[:, position])):
+                return position
+        return int(decoder_input_ids.shape[1])
+
+    def _replay_tokens(self, input_ids: torch.LongTensor, start_position: int) -> None:
+        """Replay decoder tokens into qbruntime-backed cache memory."""
+        if input_ids.numel() == 0:
+            return
+
+        state = self._replay_state
+        assert state.decoder_forward is not None
+        assert state.encoder_hidden_states is not None
+        device = state.device or input_ids.device
+        replay_input_ids = input_ids.to(device=device, dtype=torch.long)
+        cache_position = torch.arange(
+            start_position,
+            start_position + int(replay_input_ids.shape[1]),
+            device=device,
+            dtype=torch.long,
+        )
+
+        self._is_replaying = True
+        try:
+            state.decoder_forward(
+                input_ids=replay_input_ids,
+                encoder_hidden_states=state.encoder_hidden_states,
+                past_key_values=self,
+                use_cache=state.use_cache,
+                return_dict=state.return_dict,
+                cache_position=cache_position,
+            )
+        finally:
+            self._is_replaying = False
+
+    def copy(self) -> "MobilintWhisperCache":
+        """Return a copy preserving KV state and replay configuration."""
+        copied = MobilintWhisperCache(self.mxq_model, batch_size=self.batch_size)
+        for i in range(self.batch_size):
+            copied.layers[i] = self.layers[i].copy()
+        copied._replay_state = copy.copy(self._replay_state)
+        if self._replay_state.decoder_input_ids is not None:
+            copied._replay_state.decoder_input_ids = self._replay_state.decoder_input_ids.clone()
+        copied._beam_cache_buffers = [copy.deepcopy(buffer) if buffer is not None else None for buffer in self._beam_cache_buffers]
+        copied._beam_seq_lengths = list(self._beam_seq_lengths)
+        copied._is_replaying = False
         return copied
 
 

--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -1,10 +1,25 @@
 import copy
+import json
+import os
+import time
 from pathlib import Path
 from typing import Any, Optional, Sequence, Union
 
 import qbruntime
 import torch
 from transformers.cache_utils import Cache, CacheLayerMixin
+
+
+def append_whisper_beam_debug_event(event: dict[str, Any]) -> None:
+    """Append one Whisper beam-cache debug event when tracing is enabled."""
+    trace_path = os.environ.get("MBLT_WHISPER_BEAM_DEBUG_TRACE")
+    if not trace_path:
+        return
+    payload = {"time_s": time.time(), **event}
+    path = Path(trace_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload, ensure_ascii=False) + "\n")
 
 
 class MobilintLayer(CacheLayerMixin):
@@ -300,7 +315,24 @@ class MobilintBeamCache(MobilintCache):
         """Reorder application-level beam token histories in HF beam order."""
         beam_idx = self._validate_beam_indices(beam_idx)
 
+        append_whisper_beam_debug_event(
+            {
+                "event": "cache_reorder_before",
+                "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
+                "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
+                "beam_seq_lengths": list(self._beam_seq_lengths),
+                "active_token_history": list(self._active_token_history),
+            }
+        )
+
         if torch.equal(beam_idx.cpu(), torch.arange(int(beam_idx.numel()), dtype=torch.long)):
+            append_whisper_beam_debug_event(
+                {
+                    "event": "cache_reorder_identity",
+                    "beam_idx": [int(index) for index in beam_idx.cpu().tolist()],
+                    "active_token_history": list(self._active_token_history),
+                }
+            )
             return self
 
         old_token_histories = [list(tokens) for tokens in self._beam_token_histories]
@@ -310,6 +342,15 @@ class MobilintBeamCache(MobilintCache):
         self._beam_seq_lengths = [old_seq_lengths[index] for index in beam_indices]
         for beam_id, seq_length in enumerate(self._beam_seq_lengths):
             self.layers[beam_id].set_seq_length(seq_length)
+        append_whisper_beam_debug_event(
+            {
+                "event": "cache_reorder_after",
+                "beam_idx": beam_indices,
+                "beam_token_histories": [list(tokens) for tokens in self._beam_token_histories],
+                "beam_seq_lengths": list(self._beam_seq_lengths),
+                "active_token_history": list(self._active_token_history),
+            }
+        )
         return self
 
     def _validate_beam_indices(self, beam_idx: torch.LongTensor) -> torch.LongTensor:

--- a/scripts/debug_whisper_beam_trace.py
+++ b/scripts/debug_whisper_beam_trace.py
@@ -1,0 +1,198 @@
+"""Collect comparable Whisper beam-search traces for GPU and Mobilint NPU models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().tolist()
+    return str(value)
+
+
+def _load_sample(args: argparse.Namespace) -> dict[str, Any]:
+    dataset = load_dataset(
+        args.dataset,
+        args.dataset_config,
+        split=args.dataset_split,
+        streaming=True,
+        trust_remote_code=True,
+    )
+    if args.seed is not None:
+        dataset = dataset.shuffle(seed=int(args.seed), buffer_size=1000)
+    for index, sample in enumerate(dataset):
+        if index < int(args.sample_index):
+            continue
+        audio = sample["audio"]
+        return {
+            "id": str(sample.get("id", index)),
+            "audio": audio,
+            "reference": str(sample.get("text", sample.get("reference", ""))),
+        }
+    raise RuntimeError(f"No sample found at index {args.sample_index}")
+
+
+def _topk_scores(scores: tuple[torch.Tensor, ...], *, limit_steps: int, top_k: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for step, score in enumerate(scores[:limit_steps]):
+        top_values, top_indices = torch.topk(score.detach().cpu(), k=min(top_k, int(score.shape[-1])), dim=-1)
+        rows.append(
+            {
+                "step": step,
+                "shape": list(score.shape),
+                "top_token_ids": top_indices.tolist(),
+                "top_scores": top_values.tolist(),
+            }
+        )
+    return rows
+
+
+def _run_model(
+    *,
+    label: str,
+    model_id: str,
+    sample: dict[str, Any],
+    args: argparse.Namespace,
+    out_dir: Path,
+) -> None:
+    processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+    model_kwargs: dict[str, Any] = {"trust_remote_code": True}
+    if label == "gpu":
+        model_kwargs["torch_dtype"] = torch.float16
+    else:
+        model_kwargs["decoder_core_mode"] = args.core_mode
+        model_kwargs["encoder_core_mode"] = args.core_mode
+        if args.core_mode == "single":
+            model_kwargs["decoder_target_cores"] = ["0:0"]
+            model_kwargs["encoder_target_cores"] = ["0:0"]
+        elif args.core_mode == "global4":
+            model_kwargs["decoder_target_clusters"] = [0]
+            model_kwargs["encoder_target_clusters"] = [0]
+        elif args.core_mode == "global8":
+            model_kwargs["decoder_target_clusters"] = [0, 1]
+            model_kwargs["encoder_target_clusters"] = [0, 1]
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id, **model_kwargs)
+    if label == "gpu":
+        model.to(args.gpu_device)
+    model.eval()
+
+    audio = sample["audio"]
+    inputs = processor(
+        audio["array"],
+        sampling_rate=int(audio["sampling_rate"]),
+        return_tensors="pt",
+    )
+    if label == "gpu":
+        model_dtype = next(model.parameters()).dtype
+        inputs = {
+            key: (
+                value.to(args.gpu_device, dtype=model_dtype)
+                if torch.is_floating_point(value)
+                else value.to(args.gpu_device)
+            )
+            for key, value in inputs.items()
+        }
+
+    previous_trace = os.environ.get("MBLT_WHISPER_BEAM_DEBUG_TRACE")
+    npu_trace_path = out_dir / f"{label}_cache_trace.jsonl"
+    if label == "npu":
+        if npu_trace_path.exists():
+            npu_trace_path.unlink()
+        os.environ["MBLT_WHISPER_BEAM_DEBUG_TRACE"] = str(npu_trace_path)
+
+    try:
+        with torch.inference_mode():
+            generate_kwargs: dict[str, Any] = {
+                "language": args.language,
+                "task": args.task,
+                "num_beams": int(args.num_beams),
+                "early_stopping": True,
+                "max_new_tokens": int(args.max_new_tokens),
+            }
+            if args.no_cache:
+                generate_kwargs["use_cache"] = False
+            if label == "gpu":
+                generate_kwargs["return_dict_in_generate"] = True
+                generate_kwargs["output_scores"] = True
+            output = model.generate(**inputs, **generate_kwargs)
+    finally:
+        if label == "npu":
+            if previous_trace is None:
+                os.environ.pop("MBLT_WHISPER_BEAM_DEBUG_TRACE", None)
+            else:
+                os.environ["MBLT_WHISPER_BEAM_DEBUG_TRACE"] = previous_trace
+
+    sequences = output.sequences.detach().cpu() if hasattr(output, "sequences") else output.detach().cpu()
+    decoded = processor.batch_decode(sequences, skip_special_tokens=True)
+    scores = tuple(output.scores) if hasattr(output, "scores") and output.scores is not None else ()
+    payload = {
+        "label": label,
+        "model_id": model_id,
+        "sample_id": sample["id"],
+        "reference": sample["reference"],
+        "decoded": decoded,
+        "sequences": sequences.tolist(),
+        "scores_topk": _topk_scores(scores, limit_steps=int(args.trace_steps), top_k=int(args.top_k)),
+        "num_scores": len(scores),
+    }
+    (out_dir / f"{label}_generate_trace.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, default=_json_default),
+        encoding="utf-8",
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gpu-model-id", default="openai/whisper-small")
+    parser.add_argument("--npu-model-id", default="mobilint/whisper-small")
+    parser.add_argument("--dataset", default="openslr/librispeech_asr")
+    parser.add_argument("--dataset-config", default="clean")
+    parser.add_argument("--dataset-split", default="test")
+    parser.add_argument("--sample-index", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--task", default="transcribe")
+    parser.add_argument("--num-beams", type=int, default=5)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--trace-steps", type=int, default=16)
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--core-mode", default="single")
+    parser.add_argument("--gpu-device", default="cuda:0")
+    parser.add_argument("--output-dir", default="debug/whisper_beam_trace")
+    parser.add_argument("--backend", choices=["gpu", "npu", "both"], default="both")
+    parser.add_argument("--no-cache", action="store_true", help="pass use_cache=False to generate()")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    out_dir = Path(args.output_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sample = _load_sample(args)
+    (out_dir / "sample.json").write_text(
+        json.dumps(sample, ensure_ascii=False, indent=2, default=_json_default),
+        encoding="utf-8",
+    )
+    if args.backend in {"gpu", "both"}:
+        _run_model(label="gpu", model_id=args.gpu_model_id, sample=sample, args=args, out_dir=out_dir)
+    if args.backend in {"npu", "both"}:
+        _run_model(label="npu", model_id=args.npu_model_id, sample=sample, args=args, out_dir=out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
+++ b/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
@@ -826,6 +826,44 @@ def test_run_one_sample_retries_without_whisper_only_kwargs() -> None:
     assert "language" not in pipe.calls[-1]
 
 
+def test_run_one_sample_preserves_qwen3_asr_num_beams() -> None:
+    """Verify Qwen3-ASR benchmark calls keep explicit beam settings effective."""
+
+    class DummyPipe:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+            self.tokenizer = None
+
+        def __call__(self, audio_input, **kwargs):  # type: ignore[no-untyped-def]
+            del audio_input
+            payload = dict(kwargs.get("generate_kwargs") or {})
+            self.calls.append(payload)
+            return {"text": "qwen output"}
+
+    pipe = DummyPipe()
+    sample = {
+        "id": "sample-1",
+        "audio": {"array": [0.0, 0.0, 0.0, 0.0], "sampling_rate": 16000},
+        "reference": "qwen output",
+    }
+    args = asr_bench._parse_args(["--num-beams", "4"])
+    generate_kwargs = asr_bench._generate_kwargs_for_target(args, "mobilint/Qwen3-ASR-1.7B")
+
+    result = asr_bench._run_one_sample(pipe, sample, generate_kwargs)
+
+    assert pipe.calls == [
+        {
+            "num_beams": 4,
+            "max_new_tokens": 444,
+            "return_timestamps": False,
+            "early_stopping": True,
+        }
+    ]
+    assert result.hypothesis == "qwen output"
+    assert result.num_beams == 4
+    assert result.effective_generate_kwargs == pipe.calls[0]
+
+
 def test_run_one_sample_retries_with_empty_generate_kwargs() -> None:
     """Verify fallback can call generic ASR pipelines without generation kwargs."""
 

--- a/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
+++ b/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
@@ -453,6 +453,19 @@ def test_qwen3_asr_uses_encoder_decoder_core_mode_kwargs(monkeypatch: pytest.Mon
     assert "core_mode" not in model_kwargs
 
 
+def test_whisper_asr_uses_encoder_decoder_core_mode_kwargs() -> None:
+    """Verify Whisper ASR receives encoder/decoder-prefixed core-mode kwargs."""
+
+    model_kwargs = asr_bench._apply_asr_core_mode_model_kwargs({}, "openai/whisper-small", "global4")
+
+    assert model_kwargs.get("encoder_core_mode") == "global4"
+    assert model_kwargs.get("decoder_core_mode") == "global4"
+    assert model_kwargs.get("encoder_target_clusters") == [0]
+    assert model_kwargs.get("decoder_target_clusters") == [0]
+    assert "core_mode" not in model_kwargs
+    assert "target_clusters" not in model_kwargs
+
+
 def test_qwen3_asr_original_model_prefers_native_qwen_asr_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -769,7 +782,7 @@ def test_qwen3_asr_original_model_missing_optional_backend_has_actionable_error(
 def test_non_composite_asr_uses_top_level_core_mode_kwargs() -> None:
     """Verify non-composite ASR models keep the existing top-level core-mode kwargs."""
 
-    model_kwargs = asr_bench._apply_asr_core_mode_model_kwargs({}, "openai/whisper-small", "global4")
+    model_kwargs = asr_bench._apply_asr_core_mode_model_kwargs({}, "facebook/wav2vec2-base-960h", "global4")
 
     assert model_kwargs.get("core_mode") == "global4"
     assert model_kwargs.get("target_clusters") == [0]

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr.py
@@ -61,6 +61,26 @@ def test_via_huggingface_pipeline(pipe):
         print("Answer: %s" % ds[i]["text"])  # type: ignore
 
 
+def test_via_huggingface_pipeline_beam_search(pipe):
+    """Run Qwen3-ASR HF pipeline inference with beam search enabled."""
+    pipe.generation_config.max_new_tokens = 256
+
+    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    sample = ds[0]["audio"]  # type: ignore
+
+    output = pipe(
+        sample,
+        generate_kwargs={
+            "num_beams": 2,
+            "early_stopping": True,
+        },
+    )
+
+    assert isinstance(output["text"], str)
+    print("Beam Result: %s" % output["text"])
+    print("Answer: %s" % ds[0]["text"])  # type: ignore
+
+
 @pytest.fixture(params=MODEL_PATHS, scope="module")
 def transcriber(request, revision):
     """Upstream ``qwen_asr.Qwen3ASRModel`` fixture.

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -1,0 +1,89 @@
+"""Regression tests for Qwen3-ASR cache creation semantics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "qwen_asr",
+    reason="Qwen3-ASR cache contract tests require the optional qwen-asr package.",
+)
+
+from mblt_model_zoo.hf_transformers.models.qwen3_asr.modeling_qwen3_asr import (  # noqa: E402
+    MobilintQwen3ASRTextModel,
+)
+
+
+class _DummyCache:
+    """Tiny cache stub exposing the sequence length API used by ``forward``."""
+
+    def get_seq_length(self) -> int:
+        """Return an empty cache length."""
+        return 0
+
+
+class _DummyQwen3ASRTextModel(MobilintQwen3ASRTextModel):
+    """Minimal Qwen3-ASR text model that avoids NPU initialization."""
+
+    def __init__(self, use_cache: bool) -> None:
+        torch.nn.Module.__init__(self)
+        self.config = SimpleNamespace(use_cache=use_cache, vocab_size=8, hidden_size=4, pad_token_id=0)
+        self.embed_tokens = torch.nn.Embedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            self.config.pad_token_id,
+        )
+        self.cache_created = False
+        self.forward_past_key_values = None
+
+    def _get_cache(self, cache_implementation: str, batch_size: int, max_cache_len: int, *args: object) -> object:
+        """Record cache creation without allocating a real Mobilint cache."""
+        del cache_implementation, batch_size, max_cache_len, args
+        self.cache_created = True
+        return _DummyCache()
+
+    def llm_forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        past_key_values: object | None,
+        cache_position: torch.Tensor,
+        prefill_chunk_size: int | None = None,
+        count_npu_time: bool = False,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return deterministic logits while exposing forward-time cache state."""
+        del cache_position, prefill_chunk_size, count_npu_time, attention_mask
+        self.forward_past_key_values = past_key_values
+        return torch.zeros(
+            inputs_embeds.shape[0],
+            inputs_embeds.shape[1],
+            self.config.vocab_size,
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
+        )
+
+
+@pytest.mark.parametrize("config_use_cache", [False, True])
+def test_qwen3_asr_forward_does_not_force_cache_when_use_cache_is_false(config_use_cache: bool) -> None:
+    """Respect explicit ``use_cache=False`` even for beam-expanded batches."""
+    model = _DummyQwen3ASRTextModel(use_cache=config_use_cache)
+
+    outputs = model(input_ids=torch.tensor([[1, 2], [1, 3]], dtype=torch.long), use_cache=False)
+
+    assert model.cache_created is False
+    assert model.forward_past_key_values is None
+    assert outputs.past_key_values is None
+
+
+def test_qwen3_asr_forward_creates_cache_for_multi_row_default_cache() -> None:
+    """Keep the existing multi-row cache path when caching is not explicitly disabled."""
+    model = _DummyQwen3ASRTextModel(use_cache=True)
+
+    outputs = model(input_ids=torch.tensor([[1, 2], [1, 3]], dtype=torch.long))
+
+    assert model.cache_created is True
+    assert model.forward_past_key_values is outputs.past_key_values
+    assert outputs.past_key_values is not None

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from transformers.modeling_outputs import BaseModelOutputWithPast
 
 pytest.importorskip(
     "qwen_asr",
@@ -14,6 +15,7 @@ pytest.importorskip(
 
 from mblt_model_zoo.hf_transformers.models.qwen3_asr.modeling_qwen3_asr import (  # noqa: E402
     MobilintQwen3ASRTextModel,
+    MobilintQwen3ASRThinkerForConditionalGeneration,
 )
 
 
@@ -66,6 +68,37 @@ class _DummyQwen3ASRTextModel(MobilintQwen3ASRTextModel):
         )
 
 
+class _DummyQwen3ASRThinkerTextModel(torch.nn.Module):
+    """Minimal nested text model for thinker output contract tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.forward_kwargs = None
+
+    def forward(self, **kwargs: object) -> BaseModelOutputWithPast:
+        """Return deterministic hidden states while recording forwarded kwargs."""
+        self.forward_kwargs = kwargs
+        inputs_embeds = kwargs["inputs_embeds"]
+        assert isinstance(inputs_embeds, torch.Tensor)
+        return BaseModelOutputWithPast(last_hidden_state=inputs_embeds, past_key_values=None)
+
+
+class _DummyQwen3ASRThinker(MobilintQwen3ASRThinkerForConditionalGeneration):
+    """Minimal Qwen3-ASR thinker that avoids NPU initialization."""
+
+    def __init__(self, return_dict: bool) -> None:
+        torch.nn.Module.__init__(self)
+        self.config = SimpleNamespace(return_dict=return_dict)
+        self.model = _DummyQwen3ASRThinkerTextModel()
+        self.embed_tokens = torch.nn.Embedding(8, 4)
+        self.lm_head = torch.nn.Identity()
+        self.rope_deltas = None
+
+    def get_input_embeddings(self) -> torch.nn.Module:
+        """Return dummy token embeddings."""
+        return self.embed_tokens
+
+
 @pytest.mark.parametrize("config_use_cache", [False, True])
 def test_qwen3_asr_forward_does_not_force_cache_when_use_cache_is_false(config_use_cache: bool) -> None:
     """Respect explicit ``use_cache=False`` even for beam-expanded batches."""
@@ -87,3 +120,26 @@ def test_qwen3_asr_forward_creates_cache_for_multi_row_default_cache() -> None:
     assert model.cache_created is True
     assert model.forward_past_key_values is outputs.past_key_values
     assert outputs.past_key_values is not None
+
+
+def test_qwen3_asr_thinker_forward_supports_return_dict_false() -> None:
+    """Preserve upstream tuple output contract when ``return_dict=False`` is explicit."""
+    model = _DummyQwen3ASRThinker(return_dict=True)
+    input_ids = torch.tensor([[1, 2]], dtype=torch.long)
+
+    outputs = model(input_ids=input_ids, return_dict=False)
+
+    assert isinstance(outputs, tuple)
+    assert torch.equal(outputs[0], model.get_input_embeddings()(input_ids))
+    assert "return_dict" not in model.model.forward_kwargs
+
+
+def test_qwen3_asr_thinker_forward_uses_config_return_dict_default() -> None:
+    """Use the thinker config default when ``return_dict`` is omitted."""
+    model = _DummyQwen3ASRThinker(return_dict=False)
+    input_ids = torch.tensor([[1, 2]], dtype=torch.long)
+
+    outputs = model(input_ids=input_ids)
+
+    assert isinstance(outputs, tuple)
+    assert torch.equal(outputs[0], model.get_input_embeddings()(input_ids))

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -17,6 +17,23 @@ from mblt_model_zoo.hf_transformers.models.qwen3_asr.modeling_qwen3_asr import (
     MobilintQwen3ASRTextModel,
     MobilintQwen3ASRThinkerForConditionalGeneration,
 )
+from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintBeamCache  # noqa: E402
+
+
+class _InputsEmbedAwareMxqModel:
+    """MXQ stub that makes logits depend on the supplied decoder embedding row."""
+
+    def __init__(self) -> None:
+        self.infer_calls = 0
+
+    def infer(self, inputs: list[object], output_buffer: object, cache_size: int) -> list[object]:
+        """Return logits whose value identifies the forwarded embedding row."""
+        del output_buffer, cache_size
+        row_embeds = inputs[0]
+        self.infer_calls += 1
+        suffix_length = int(row_embeds.shape[2])
+        row_value = float(row_embeds.mean())
+        return [torch.full((suffix_length, 8), row_value, dtype=torch.float32).numpy()]
 
 
 class _DummyCache:
@@ -66,6 +83,25 @@ class _DummyQwen3ASRTextModel(MobilintQwen3ASRTextModel):
             dtype=inputs_embeds.dtype,
             device=inputs_embeds.device,
         )
+
+
+class _DummyQwen3ASRBeamTextModel(MobilintQwen3ASRTextModel):
+    """Minimal Qwen3-ASR text model for exercising beam decode directly."""
+
+    def __init__(self, mxq_model: _InputsEmbedAwareMxqModel) -> None:
+        torch.nn.Module.__init__(self)
+        self.config = SimpleNamespace(use_cache=True, vocab_size=8, hidden_size=2, pad_token_id=0)
+        self.embed_tokens = torch.nn.Embedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            self.config.pad_token_id,
+        )
+        self.npu_backend = SimpleNamespace(mxq_model=mxq_model)
+        self.npu_time = None
+
+    def resolve_prefill_chunk_size(self, prefill_chunk_size: int | None) -> int:
+        """Use one chunk per test sequence unless explicitly overridden."""
+        return prefill_chunk_size or 16
 
 
 class _DummyQwen3ASRThinkerTextModel(torch.nn.Module):
@@ -120,6 +156,59 @@ def test_qwen3_asr_forward_creates_cache_for_multi_row_default_cache() -> None:
     assert model.cache_created is True
     assert model.forward_past_key_values is outputs.past_key_values
     assert outputs.past_key_values is not None
+
+
+def test_qwen3_asr_duplicate_logits_are_not_reused_across_audio_rows() -> None:
+    """Identical token rows with different audio-conditioned embeddings should not share logits."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4], [4]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0]],
+            [[7.0, 7.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.tensor([0], dtype=torch.long),
+    )
+
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (2, 1, 8)
+    assert torch.equal(logits[0], torch.full((1, 8), 1.0))
+    assert torch.equal(logits[1], torch.full((1, 8), 7.0))
+
+
+def test_qwen3_asr_duplicate_logits_reuse_single_source_beams() -> None:
+    """Beam-expanded rows from the same audio-conditioned prompt may share logits."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4], [4]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[3.0, 3.0]],
+            [[3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.tensor([0], dtype=torch.long),
+    )
+
+    assert mxq_model.infer_calls == 1
+    assert logits.shape == (2, 1, 8)
+    assert torch.equal(logits[0], logits[1])
 
 
 def test_qwen3_asr_thinker_forward_supports_return_dict_false() -> None:

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -185,6 +185,42 @@ def test_qwen3_asr_duplicate_logits_are_not_reused_across_audio_rows() -> None:
     assert torch.equal(logits[1], torch.full((1, 8), 7.0))
 
 
+def test_qwen3_asr_cached_suffix_keeps_audio_source_identity() -> None:
+    """Keep source ids from the audio-conditioned prompt when later token suffixes match."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+
+    model._beam_llm_forward(
+        input_ids=torch.tensor([[4], [4]], dtype=torch.long),
+        inputs_embeds=torch.tensor(
+            [
+                [[1.0, 1.0]],
+                [[7.0, 7.0]],
+            ],
+            dtype=torch.float32,
+        ),
+        past_key_values=cache,
+        cache_position=torch.tensor([0], dtype=torch.long),
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=torch.tensor([[5], [5]], dtype=torch.long),
+        inputs_embeds=torch.tensor(
+            [
+                [[3.0, 3.0]],
+                [[3.0, 3.0]],
+            ],
+            dtype=torch.float32,
+        ),
+        past_key_values=cache,
+        cache_position=torch.tensor([1], dtype=torch.long),
+    )
+
+    assert mxq_model.infer_calls == 4
+    assert logits.shape == (2, 1, 8)
+
+
 def test_qwen3_asr_duplicate_logits_reuse_single_source_beams() -> None:
     """Beam-expanded rows from the same audio-conditioned prompt may share logits."""
     mxq_model = _InputsEmbedAwareMxqModel()

--- a/tests/transformers/automatic_speech_recognition/test_whisper.py
+++ b/tests/transformers/automatic_speech_recognition/test_whisper.py
@@ -36,11 +36,7 @@ def test_whisper(pipe):
 
         output = pipe(
             sample,
-            batch_size=8,
-            return_timestamps=True,
-            generate_kwargs={
-                "num_beams": 1,  # Supports for beam search with reorder_cache is not implemented yet
-            },
+            language="en",
         )
 
         print("Result: %s" % output["text"])

--- a/tests/transformers/automatic_speech_recognition/test_whisper_decoder_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_whisper_decoder_cache_contract.py
@@ -96,3 +96,65 @@ def test_whisper_duplicate_logits_still_reuse_single_source_beams() -> None:
     assert mxq_model.infer_calls == 1
     assert logits.shape == (2, 1, 1, 4)
     assert torch.equal(logits[0], logits[1])
+
+
+def test_whisper_duplicate_logits_reuse_beam_expanded_single_source_rows() -> None:
+    """Beam-expanded encoder rows for one audio source should share the same source id."""
+    mxq_model = _EncoderAwareMxqModel()
+    decoder = _make_decoder(mxq_model)
+    cache = MobilintWhisperCache(mxq_model, batch_size=2)
+    cache.set_encoder_source_count(1)
+    hidden_states = torch.ones((2, 1, 1, 2), dtype=torch.float32)
+    encoder_hidden_states = torch.tensor(
+        [
+            [[[3.0, 3.0]]],
+            [[[3.0, 3.0]]],
+        ],
+        dtype=torch.float32,
+    )
+    input_ids = torch.tensor([[42], [42]], dtype=torch.long)
+
+    logits = decoder.decoder_forward(
+        hidden_states,
+        encoder_hidden_states,
+        cache,
+        torch.tensor([0], dtype=torch.long),
+        input_ids=input_ids,
+    )
+
+    assert mxq_model.infer_calls == 1
+    assert logits.shape == (2, 1, 1, 4)
+    assert torch.equal(logits[0], logits[1])
+
+
+def test_whisper_duplicate_logits_reuse_only_within_beam_expanded_source_groups() -> None:
+    """Beam grouping should prevent duplicate logits from crossing original audio sources."""
+    mxq_model = _EncoderAwareMxqModel()
+    decoder = _make_decoder(mxq_model)
+    cache = MobilintWhisperCache(mxq_model, batch_size=4)
+    cache.set_encoder_source_count(2)
+    hidden_states = torch.ones((4, 1, 1, 2), dtype=torch.float32)
+    encoder_hidden_states = torch.tensor(
+        [
+            [[[1.0, 1.0]]],
+            [[[1.0, 1.0]]],
+            [[[7.0, 7.0]]],
+            [[[7.0, 7.0]]],
+        ],
+        dtype=torch.float32,
+    )
+    input_ids = torch.tensor([[42], [42], [42], [42]], dtype=torch.long)
+
+    logits = decoder.decoder_forward(
+        hidden_states,
+        encoder_hidden_states,
+        cache,
+        torch.tensor([0], dtype=torch.long),
+        input_ids=input_ids,
+    )
+
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (4, 1, 1, 4)
+    assert torch.equal(logits[0], logits[1])
+    assert torch.equal(logits[2], logits[3])
+    assert not torch.equal(logits[0], logits[2])

--- a/tests/transformers/automatic_speech_recognition/test_whisper_decoder_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_whisper_decoder_cache_contract.py
@@ -158,3 +158,57 @@ def test_whisper_duplicate_logits_reuse_only_within_beam_expanded_source_groups(
     assert torch.equal(logits[0], logits[1])
     assert torch.equal(logits[2], logits[3])
     assert not torch.equal(logits[0], logits[2])
+
+
+def test_whisper_embeds_only_decoder_does_not_create_default_cache() -> None:
+    """Keep embeds-only decoder calls on the non-cache path when cache defaults to enabled."""
+    decoder = object.__new__(MobilintWhisperDecoder)
+    decoder.config = SimpleNamespace(
+        output_attentions=False,
+        output_hidden_states=False,
+        use_cache=True,
+        return_dict=True,
+    )
+
+    def get_mxq_model(self: MobilintWhisperDecoder) -> object:
+        del self
+        raise AssertionError("embeds-only decoder calls must not create a MobilintWhisperCache")
+
+    def embed_positions(
+        inputs: torch.Tensor,
+        *,
+        past_key_values_length: int,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        del past_key_values_length, position_ids
+        return torch.zeros_like(inputs)
+
+    def decoder_forward(
+        self: MobilintWhisperDecoder,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        past_key_values: MobilintWhisperCache | None,
+        cache_position: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del self, encoder_hidden_states, cache_position
+        assert past_key_values is None
+        assert input_ids is None
+        return torch.zeros(
+            (hidden_states.shape[0], 1, hidden_states.shape[2], 4),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+    decoder.get_mxq_model = MethodType(get_mxq_model, decoder)
+    decoder.embed_positions = embed_positions
+    decoder.decoder_forward = MethodType(decoder_forward, decoder)
+
+    outputs = decoder.forward(
+        inputs_embeds=torch.ones((1, 2, 3), dtype=torch.float32),
+        encoder_hidden_states=torch.ones((1, 1, 2, 3), dtype=torch.float32),
+    )
+
+    assert outputs.past_key_values is None
+    assert outputs.last_hidden_state.shape == (1, 1, 2, 4)

--- a/tests/transformers/automatic_speech_recognition/test_whisper_decoder_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_whisper_decoder_cache_contract.py
@@ -1,0 +1,98 @@
+"""Regression tests for Whisper decoder cache reuse contracts."""
+
+from __future__ import annotations
+
+from types import MethodType, SimpleNamespace
+
+import numpy as np
+import torch
+
+from mblt_model_zoo.hf_transformers.models.whisper.modeling_whisper import MobilintWhisperDecoder
+from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintWhisperCache
+
+
+class _EncoderAwareMxqModel:
+    """MXQ stub that makes decoder logits depend on the supplied encoder row."""
+
+    def __init__(self) -> None:
+        self.infer_calls = 0
+
+    def infer(self, inputs: list[object], output_buffer: object, cache_size: int) -> list[np.ndarray]:
+        """Return logits whose value identifies the encoder input row."""
+        del output_buffer, cache_size
+        hidden_states, encoder_hidden_states = inputs
+        self.infer_calls += 1
+        suffix_length = int(hidden_states.shape[2])
+        encoder_value = float(encoder_hidden_states.mean())
+        return [np.full((suffix_length, 4), encoder_value, dtype=np.float32)]
+
+
+def _make_decoder(mxq_model: _EncoderAwareMxqModel) -> MobilintWhisperDecoder:
+    """Create a minimal decoder instance for exercising ``decoder_forward`` directly."""
+    decoder = object.__new__(MobilintWhisperDecoder)
+    decoder.npu_backend = SimpleNamespace(mxq_model=mxq_model)
+
+    def embed_token_suffix(
+        self: MobilintWhisperDecoder,
+        token_history: list[int],
+        start_index: int,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor:
+        del self
+        suffix_length = len(token_history) - start_index
+        return torch.ones((1, 1, suffix_length, 2), dtype=torch.float32, device=device)
+
+    decoder._embed_token_suffix = MethodType(embed_token_suffix, decoder)
+    return decoder
+
+
+def test_whisper_duplicate_logits_are_not_reused_across_audio_rows() -> None:
+    """Identical decoder tokens from different audio rows should use row-specific encoder states."""
+    mxq_model = _EncoderAwareMxqModel()
+    decoder = _make_decoder(mxq_model)
+    cache = MobilintWhisperCache(mxq_model, batch_size=2)
+    hidden_states = torch.ones((2, 1, 1, 2), dtype=torch.float32)
+    encoder_hidden_states = torch.tensor(
+        [
+            [[[1.0, 1.0]]],
+            [[[7.0, 7.0]]],
+        ],
+        dtype=torch.float32,
+    )
+    input_ids = torch.tensor([[42], [42]], dtype=torch.long)
+
+    logits = decoder.decoder_forward(
+        hidden_states,
+        encoder_hidden_states,
+        cache,
+        torch.tensor([0], dtype=torch.long),
+        input_ids=input_ids,
+    )
+
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (2, 1, 1, 4)
+    assert torch.equal(logits[0], torch.full((1, 1, 4), 1.0))
+    assert torch.equal(logits[1], torch.full((1, 1, 4), 7.0))
+
+
+def test_whisper_duplicate_logits_still_reuse_single_source_beams() -> None:
+    """Beam-expanded rows from one encoder source should keep the duplicate-logit shortcut."""
+    mxq_model = _EncoderAwareMxqModel()
+    decoder = _make_decoder(mxq_model)
+    cache = MobilintWhisperCache(mxq_model, batch_size=2)
+    hidden_states = torch.ones((2, 1, 1, 2), dtype=torch.float32)
+    encoder_hidden_states = torch.tensor([[[[3.0, 3.0]]]], dtype=torch.float32)
+    input_ids = torch.tensor([[42], [42]], dtype=torch.long)
+
+    logits = decoder.decoder_forward(
+        hidden_states,
+        encoder_hidden_states,
+        cache,
+        torch.tensor([0], dtype=torch.long),
+        input_ids=input_ids,
+    )
+
+    assert mxq_model.infer_calls == 1
+    assert logits.shape == (2, 1, 1, 4)
+    assert torch.equal(logits[0], logits[1])

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -92,7 +92,7 @@ def test_fake_prefill_rejects_negative_length() -> None:
         cache.fake_prefill(-1)
 
 
-def test_whisper_cache_reorder_works_without_replay_state() -> None:
+def test_whisper_cache_reorder_works_with_application_level_blobs() -> None:
     """Whisper beam reorder should only require application-level KV blobs."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
     cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
@@ -107,95 +107,52 @@ def test_whisper_cache_reorder_works_without_replay_state() -> None:
 def test_whisper_cache_reorder_rejects_invalid_beam_idx_shape() -> None:
     """Whisper beam reorder should only accept rank-1 beam indices."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
-    cache.configure_reorder_replay(
-        decoder_input_ids=torch.tensor([[1, 2], [1, 3]], dtype=torch.long),
-        decoder_forward=lambda **kwargs: None,
-        encoder_hidden_states=torch.ones(2, 1, 4, 3),
-    )
 
     with pytest.raises(ValueError, match="rank 1"):
         cache.reorder_cache(torch.tensor([[0, 1]], dtype=torch.long))
 
 
 def test_whisper_cache_reorder_reorders_application_level_blobs() -> None:
-    """Whisper beam reorder should reorder stored KV blobs without decoder replay."""
+    """Whisper beam reorder should reorder stored KV blobs."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=3)
-    replay_calls = 0
-
-    def fake_decoder_forward(**kwargs) -> None:
-        nonlocal replay_calls
-        replay_calls += 1
-        kwargs["past_key_values"].update_cache_position(kwargs["cache_position"])
-
-    cache.configure_reorder_replay(
-        decoder_input_ids=torch.tensor(
-            [
-                [10, 20, 30, 31],
-                [10, 20, 40, 41],
-                [10, 20, 50, 51],
-            ],
-            dtype=torch.long,
-        ),
-        decoder_forward=fake_decoder_forward,
-        encoder_hidden_states=torch.ones(3, 1, 4, 3),
-        device=torch.device("cpu"),
-    )
     cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
     cache._beam_seq_lengths = [4, 5, 6]
 
     result = cache.reorder_cache(torch.tensor([2, 0, 2], dtype=torch.long))
 
     assert result is cache
-    assert replay_calls == 0
     assert cache._beam_cache_buffers == [[b"beam-2"], [b"beam-0"], [b"beam-2"]]
     assert cache._beam_cache_buffers[0] is not cache._beam_cache_buffers[2]
     assert [cache.get_seq_length(index=i) for i in range(3)] == [6, 4, 6]
-    assert torch.equal(
-        cache._replay_state.decoder_input_ids,
-        torch.tensor([[10, 20, 50, 51], [10, 20, 30, 31], [10, 20, 50, 51]], dtype=torch.long),
-    )
 
 
-def test_whisper_cache_reorder_skips_replay_for_identity_order_only() -> None:
-    """Whisper beam reorder should only skip replay when beam order is identity."""
+def test_whisper_cache_reorder_identity_order_is_noop() -> None:
+    """Whisper beam reorder should no-op for identity beam order."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=1)
-    replay_calls = 0
-
-    def fake_decoder_forward(**kwargs) -> None:
-        nonlocal replay_calls
-        replay_calls += 1
-        kwargs["past_key_values"].update_cache_position(kwargs["cache_position"])
-
-    cache.configure_reorder_replay(
-        decoder_input_ids=torch.tensor([[10, 20], [10, 20], [10, 20]], dtype=torch.long),
-        decoder_forward=fake_decoder_forward,
-        encoder_hidden_states=torch.ones(3, 1, 4, 3),
-    )
     cache.set_seq_length({0: 2, 1: 2, 2: 2})
+    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
 
     result = cache.reorder_cache(torch.tensor([0, 1, 2], dtype=torch.long))
 
     assert result is cache
-    assert replay_calls == 0
     assert cache.batch_size == 3
+    assert cache._beam_cache_buffers == [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
     assert [cache.get_seq_length(index=i) for i in range(3)] == [2, 2, 2]
 
 
-def test_whisper_cache_copy_preserves_replay_configuration_safely() -> None:
-    """Whisper cache copy should clone token history without sharing mutable tensors."""
+def test_whisper_cache_copy_preserves_beam_snapshots_safely() -> None:
+    """Whisper cache copy should clone beam snapshots without sharing mutable buffers."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
-    decoder_input_ids = torch.tensor([[1, 2], [1, 3]], dtype=torch.long)
-    cache.configure_reorder_replay(
-        decoder_input_ids=decoder_input_ids,
-        decoder_forward=lambda **kwargs: None,
-        encoder_hidden_states=torch.ones(2, 1, 4, 3),
-    )
+    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
+    cache._beam_seq_lengths = [2, 3]
 
     copied = cache.copy()
-    decoder_input_ids[0, 0] = 99
+    cache._beam_cache_buffers[0][0] = b"changed"
+    cache._beam_seq_lengths[0] = 99
 
     assert isinstance(copied, MobilintWhisperCache)
-    assert torch.equal(copied._replay_state.decoder_input_ids, torch.tensor([[1, 2], [1, 3]], dtype=torch.long))
+    assert copied._beam_cache_buffers == [[b"beam-0"], [b"beam-1"]]
+    assert copied._beam_seq_lengths == [2, 3]
 
 
 def test_deepstack_cache_returns_real_chunk() -> None:

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from mblt_model_zoo.hf_transformers.utils.cache_utils import (
+    MobilintBeamCache,
     MobilintCache,
     MobilintDeepStackCache,
     MobilintEagle3Cache,
@@ -102,6 +103,25 @@ def test_whisper_cache_reorder_works_with_application_level_blobs() -> None:
 
     assert cache._beam_cache_buffers == [[b"beam-1"], [b"beam-0"]]
     assert [cache.get_seq_length(index=i) for i in range(2)] == [3, 2]
+
+
+def test_beam_cache_reorder_works_with_application_level_blobs() -> None:
+    """Generic beam cache should reorder stored KV blobs for beam search."""
+    cache = MobilintBeamCache(_FakeMxqModel(), batch_size=2)
+    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
+    cache._beam_seq_lengths = [2, 3]
+
+    cache.reorder_cache(torch.tensor([1, 0], dtype=torch.long))
+
+    assert cache._beam_cache_buffers == [[b"beam-1"], [b"beam-0"]]
+    assert [cache.get_seq_length(index=i) for i in range(2)] == [3, 2]
+
+
+def test_whisper_cache_is_beam_cache_for_backwards_compatibility() -> None:
+    """Whisper cache should preserve its public name while reusing generic beam cache behavior."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=1)
+
+    assert isinstance(cache, MobilintBeamCache)
 
 
 def test_whisper_cache_reorder_rejects_invalid_beam_idx_shape() -> None:

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -196,6 +196,26 @@ def test_whisper_cache_copy_preserves_token_histories_safely() -> None:
     assert copied._beam_seq_lengths == [2, 3]
 
 
+def test_whisper_cache_tracks_encoder_source_count() -> None:
+    """Whisper cache should preserve original encoder source count across copies only."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
+
+    cache.set_encoder_source_count(2)
+    copied = cache.copy()
+    cache.reset()
+
+    assert copied.get_encoder_source_count() == 2
+    assert cache.get_encoder_source_count() is None
+
+
+def test_whisper_cache_rejects_invalid_encoder_source_count() -> None:
+    """Whisper cache should require positive encoder source counts."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=1)
+
+    with pytest.raises(ValueError, match="positive"):
+        cache.set_encoder_source_count(0)
+
+
 def test_deepstack_cache_returns_real_chunk() -> None:
     """Deepstack cache should slice the current forward-call tensor."""
     cache = MobilintDeepStackCache(_FakeMxqModel(), num_deepstack_layers=2, hidden_size=3)

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -11,6 +11,8 @@ from mblt_model_zoo.hf_transformers.utils.cache_utils import (
     MobilintDeepStackCache,
     MobilintEagle3Cache,
     MobilintWhisperCache,
+    append_whisper_beam_debug_event,
+    is_whisper_beam_debug_trace_enabled,
 )
 
 
@@ -33,6 +35,30 @@ class _FakeMxqModel:
 
     def load_cache_memory_from(self, cache_dir: str, cache_id: int) -> None:
         del cache_dir, cache_id
+
+
+def test_whisper_beam_debug_trace_predicate_follows_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whisper beam debug trace predicate should only reflect the trace-path environment variable."""
+    monkeypatch.delenv("MBLT_WHISPER_BEAM_DEBUG_TRACE", raising=False)
+
+    assert is_whisper_beam_debug_trace_enabled() is False
+
+    monkeypatch.setenv("MBLT_WHISPER_BEAM_DEBUG_TRACE", "beam_trace.jsonl")
+
+    assert is_whisper_beam_debug_trace_enabled() is True
+
+
+def test_append_whisper_beam_debug_event_is_noop_without_trace_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Whisper beam debug event append should be a no-op when tracing is disabled."""
+    monkeypatch.delenv("MBLT_WHISPER_BEAM_DEBUG_TRACE", raising=False)
+    trace_path = tmp_path / "beam_trace.jsonl"
+
+    append_whisper_beam_debug_event({"event": "noop"})
+
+    assert not trace_path.exists()
 
 
 def test_dump_cache_memory_roundtrip_restores_seq_length() -> None:

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -93,27 +93,15 @@ def test_fake_prefill_rejects_negative_length() -> None:
         cache.fake_prefill(-1)
 
 
-def test_whisper_cache_reorder_works_with_application_level_blobs() -> None:
-    """Whisper beam reorder should only require application-level KV blobs."""
-    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
-    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
-    cache._beam_seq_lengths = [2, 3]
-
-    cache.reorder_cache(torch.tensor([1, 0], dtype=torch.long))
-
-    assert cache._beam_cache_buffers == [[b"beam-1"], [b"beam-0"]]
-    assert [cache.get_seq_length(index=i) for i in range(2)] == [3, 2]
-
-
-def test_beam_cache_reorder_works_with_application_level_blobs() -> None:
-    """Generic beam cache should reorder stored KV blobs for beam search."""
+def test_beam_cache_reorder_works_with_token_histories() -> None:
+    """Generic beam cache should reorder token histories for beam search."""
     cache = MobilintBeamCache(_FakeMxqModel(), batch_size=2)
-    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
-    cache._beam_seq_lengths = [2, 3]
+    cache.commit_beam_tokens(0, [10, 11])
+    cache.commit_beam_tokens(1, [20, 21, 22])
 
     cache.reorder_cache(torch.tensor([1, 0], dtype=torch.long))
 
-    assert cache._beam_cache_buffers == [[b"beam-1"], [b"beam-0"]]
+    assert [cache.get_beam_tokens(i) for i in range(2)] == [[20, 21, 22], [10, 11]]
     assert [cache.get_seq_length(index=i) for i in range(2)] == [3, 2]
 
 
@@ -132,46 +120,53 @@ def test_whisper_cache_reorder_rejects_invalid_beam_idx_shape() -> None:
         cache.reorder_cache(torch.tensor([[0, 1]], dtype=torch.long))
 
 
-def test_whisper_cache_reorder_reorders_application_level_blobs() -> None:
-    """Whisper beam reorder should reorder stored KV blobs."""
+def test_whisper_cache_reorder_reorders_token_histories() -> None:
+    """Whisper beam reorder should reorder token histories."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=3)
-    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
-    cache._beam_seq_lengths = [4, 5, 6]
+    cache.commit_beam_tokens(0, [10, 11, 12, 13])
+    cache.commit_beam_tokens(1, [20, 21, 22, 23, 24])
+    cache.commit_beam_tokens(2, [30, 31, 32, 33, 34, 35])
 
     result = cache.reorder_cache(torch.tensor([2, 0, 2], dtype=torch.long))
 
     assert result is cache
-    assert cache._beam_cache_buffers == [[b"beam-2"], [b"beam-0"], [b"beam-2"]]
-    assert cache._beam_cache_buffers[0] is not cache._beam_cache_buffers[2]
+    assert [cache.get_beam_tokens(i) for i in range(3)] == [
+        [30, 31, 32, 33, 34, 35],
+        [10, 11, 12, 13],
+        [30, 31, 32, 33, 34, 35],
+    ]
+    cache._beam_token_histories[0][0] = 99
+    assert cache.get_beam_tokens(2) == [30, 31, 32, 33, 34, 35]
     assert [cache.get_seq_length(index=i) for i in range(3)] == [6, 4, 6]
 
 
 def test_whisper_cache_reorder_identity_order_is_noop() -> None:
     """Whisper beam reorder should no-op for identity beam order."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=1)
-    cache.set_seq_length({0: 2, 1: 2, 2: 2})
-    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
+    cache.commit_beam_tokens(0, [10, 11])
+    cache.commit_beam_tokens(1, [20, 21])
+    cache.commit_beam_tokens(2, [30, 31])
 
     result = cache.reorder_cache(torch.tensor([0, 1, 2], dtype=torch.long))
 
     assert result is cache
     assert cache.batch_size == 3
-    assert cache._beam_cache_buffers == [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
+    assert [cache.get_beam_tokens(i) for i in range(3)] == [[10, 11], [20, 21], [30, 31]]
     assert [cache.get_seq_length(index=i) for i in range(3)] == [2, 2, 2]
 
 
-def test_whisper_cache_copy_preserves_beam_snapshots_safely() -> None:
-    """Whisper cache copy should clone beam snapshots without sharing mutable buffers."""
+def test_whisper_cache_copy_preserves_token_histories_safely() -> None:
+    """Whisper cache copy should clone token histories without sharing mutable lists."""
     cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
-    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
-    cache._beam_seq_lengths = [2, 3]
+    cache.commit_beam_tokens(0, [10, 11])
+    cache.commit_beam_tokens(1, [20, 21, 22])
 
     copied = cache.copy()
-    cache._beam_cache_buffers[0][0] = b"changed"
+    cache._beam_token_histories[0][0] = 99
     cache._beam_seq_lengths[0] = 99
 
     assert isinstance(copied, MobilintWhisperCache)
-    assert copied._beam_cache_buffers == [[b"beam-0"], [b"beam-1"]]
+    assert [copied.get_beam_tokens(i) for i in range(2)] == [[10, 11], [20, 21, 22]]
     assert copied._beam_seq_lengths == [2, 3]
 
 

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 import torch
 
-from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache, MobilintDeepStackCache, MobilintEagle3Cache
+from mblt_model_zoo.hf_transformers.utils.cache_utils import (
+    MobilintCache,
+    MobilintDeepStackCache,
+    MobilintEagle3Cache,
+    MobilintWhisperCache,
+)
 
 
 class _FakeMxqModel:
@@ -85,6 +90,112 @@ def test_fake_prefill_rejects_negative_length() -> None:
 
     with pytest.raises(ValueError, match="non-negative"):
         cache.fake_prefill(-1)
+
+
+def test_whisper_cache_reorder_works_without_replay_state() -> None:
+    """Whisper beam reorder should only require application-level KV blobs."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
+    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"]]
+    cache._beam_seq_lengths = [2, 3]
+
+    cache.reorder_cache(torch.tensor([1, 0], dtype=torch.long))
+
+    assert cache._beam_cache_buffers == [[b"beam-1"], [b"beam-0"]]
+    assert [cache.get_seq_length(index=i) for i in range(2)] == [3, 2]
+
+
+def test_whisper_cache_reorder_rejects_invalid_beam_idx_shape() -> None:
+    """Whisper beam reorder should only accept rank-1 beam indices."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
+    cache.configure_reorder_replay(
+        decoder_input_ids=torch.tensor([[1, 2], [1, 3]], dtype=torch.long),
+        decoder_forward=lambda **kwargs: None,
+        encoder_hidden_states=torch.ones(2, 1, 4, 3),
+    )
+
+    with pytest.raises(ValueError, match="rank 1"):
+        cache.reorder_cache(torch.tensor([[0, 1]], dtype=torch.long))
+
+
+def test_whisper_cache_reorder_reorders_application_level_blobs() -> None:
+    """Whisper beam reorder should reorder stored KV blobs without decoder replay."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=3)
+    replay_calls = 0
+
+    def fake_decoder_forward(**kwargs) -> None:
+        nonlocal replay_calls
+        replay_calls += 1
+        kwargs["past_key_values"].update_cache_position(kwargs["cache_position"])
+
+    cache.configure_reorder_replay(
+        decoder_input_ids=torch.tensor(
+            [
+                [10, 20, 30, 31],
+                [10, 20, 40, 41],
+                [10, 20, 50, 51],
+            ],
+            dtype=torch.long,
+        ),
+        decoder_forward=fake_decoder_forward,
+        encoder_hidden_states=torch.ones(3, 1, 4, 3),
+        device=torch.device("cpu"),
+    )
+    cache._beam_cache_buffers = [[b"beam-0"], [b"beam-1"], [b"beam-2"]]
+    cache._beam_seq_lengths = [4, 5, 6]
+
+    result = cache.reorder_cache(torch.tensor([2, 0, 2], dtype=torch.long))
+
+    assert result is cache
+    assert replay_calls == 0
+    assert cache._beam_cache_buffers == [[b"beam-2"], [b"beam-0"], [b"beam-2"]]
+    assert cache._beam_cache_buffers[0] is not cache._beam_cache_buffers[2]
+    assert [cache.get_seq_length(index=i) for i in range(3)] == [6, 4, 6]
+    assert torch.equal(
+        cache._replay_state.decoder_input_ids,
+        torch.tensor([[10, 20, 50, 51], [10, 20, 30, 31], [10, 20, 50, 51]], dtype=torch.long),
+    )
+
+
+def test_whisper_cache_reorder_skips_replay_for_identity_order_only() -> None:
+    """Whisper beam reorder should only skip replay when beam order is identity."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=1)
+    replay_calls = 0
+
+    def fake_decoder_forward(**kwargs) -> None:
+        nonlocal replay_calls
+        replay_calls += 1
+        kwargs["past_key_values"].update_cache_position(kwargs["cache_position"])
+
+    cache.configure_reorder_replay(
+        decoder_input_ids=torch.tensor([[10, 20], [10, 20], [10, 20]], dtype=torch.long),
+        decoder_forward=fake_decoder_forward,
+        encoder_hidden_states=torch.ones(3, 1, 4, 3),
+    )
+    cache.set_seq_length({0: 2, 1: 2, 2: 2})
+
+    result = cache.reorder_cache(torch.tensor([0, 1, 2], dtype=torch.long))
+
+    assert result is cache
+    assert replay_calls == 0
+    assert cache.batch_size == 3
+    assert [cache.get_seq_length(index=i) for i in range(3)] == [2, 2, 2]
+
+
+def test_whisper_cache_copy_preserves_replay_configuration_safely() -> None:
+    """Whisper cache copy should clone token history without sharing mutable tensors."""
+    cache = MobilintWhisperCache(_FakeMxqModel(), batch_size=2)
+    decoder_input_ids = torch.tensor([[1, 2], [1, 3]], dtype=torch.long)
+    cache.configure_reorder_replay(
+        decoder_input_ids=decoder_input_ids,
+        decoder_forward=lambda **kwargs: None,
+        encoder_hidden_states=torch.ones(2, 1, 4, 3),
+    )
+
+    copied = cache.copy()
+    decoder_input_ids[0, 0] = 99
+
+    assert isinstance(copied, MobilintWhisperCache)
+    assert torch.equal(copied._replay_state.decoder_input_ids, torch.tensor([[1, 2], [1, 3]], dtype=torch.long))
 
 
 def test_deepstack_cache_returns_real_chunk() -> None:


### PR DESCRIPTION
## Summary

- Integrate `MobilintBeamCache` with Whisper and Qwen ASR beam-search generation paths.
- Add token-history based beam cache replay/reorder handling for Mobilint NPU ASR decoders.
- Propagate encoder/decoder core-mode benchmark kwargs for Whisper ASR benchmark runs.
- Add focused tests for BeamCache behavior, ASR CLI core-mode propagation, and Whisper/Qwen ASR beam-search paths.
- Add `scripts/debug_whisper_beam_trace.py` for comparing GPU/NPU Whisper beam-search traces.

## GPU/NPU beam-search benchmark summary

Existing ASR benchmark results under `benchmark/transformers/results/{clean,other}` show a backend-specific beam-search trend:

- GPU `openai/whisper-*`: increasing `num_beams` from 1 to 5 reduces or preserves WER/CER.
- NPU `mobilint/whisper-*`: increasing `num_beams` from 1 to 5 can increase WER/CER.
- Qwen3-ASR does not show the same Whisper-specific degradation pattern, which narrows the issue to the Whisper NPU beam-search path or model/logit behavior rather than the benchmark harness globally.

### WER comparison

Lower is better. GPU Whisper consistently improves from beam1 to beam5, while NPU Whisper often regresses, especially on `other`.

| Dataset | Model | Beam 1 WER (%) | Beam 5 WER (%) | Direction |
| --- | --- | ---: | ---: | --- |
| clean | `openai/whisper-small` | 4.17 | 3.95 | improves |
| clean | `openai/whisper-medium` | 3.62 | 3.42 | improves |
| clean | `openai/whisper-large-v3-turbo` | 2.96 | 2.85 | improves |
| clean | `mobilint/whisper-small-single` | 6.17 | 6.07 | improves slightly |
| clean | `mobilint/whisper-medium-single` | 3.85 | 4.25 | regresses |
| clean | `mobilint/whisper-large-v3-turbo-single` | 13.87 | 13.97 | regresses slightly |
| other | `openai/whisper-small` | 8.54 | 8.00 | improves |
| other | `openai/whisper-medium` | 6.77 | 6.47 | improves |
| other | `openai/whisper-large-v3-turbo` | 5.12 | 5.00 | improves |
| other | `mobilint/whisper-small-single` | 7.95 | 8.67 | regresses |
| other | `mobilint/whisper-medium-single` | 6.27 | 6.51 | regresses |
| other | `mobilint/whisper-large-v3-turbo-single` | 13.37 | 15.78 | regresses |

<img width="3080" height="1232" alt="wer" src="https://github.com/user-attachments/assets/592ac9cb-1c1c-4d61-8635-d5f9569431e1" />

### CER comparison

Lower is better. CER follows the same pattern as WER: GPU beam5 improves, while NPU Whisper beam5 can increase character errors.

| Dataset | Model | Beam 1 CER (%) | Beam 5 CER (%) | Direction |
| --- | --- | ---: | ---: | --- |
| clean | `openai/whisper-small` | 1.66 | 1.50 | improves |
| clean | `openai/whisper-medium` | 1.48 | 1.31 | improves |
| clean | `openai/whisper-large-v3-turbo` | 1.08 | 1.00 | improves |
| clean | `mobilint/whisper-small-single` | 2.61 | 2.57 | improves slightly |
| clean | `mobilint/whisper-medium-single` | 1.62 | 1.72 | regresses |
| clean | `mobilint/whisper-large-v3-turbo-single` | 5.25 | 6.61 | regresses |
| other | `openai/whisper-small` | 3.95 | 3.65 | improves |
| other | `openai/whisper-medium` | 3.11 | 2.90 | improves |
| other | `openai/whisper-large-v3-turbo` | 1.99 | 1.95 | improves |
| other | `mobilint/whisper-small-single` | 3.56 | 4.13 | regresses |
| other | `mobilint/whisper-medium-single` | 2.17 | 2.27 | regresses |
| other | `mobilint/whisper-large-v3-turbo-single` | 5.03 | 5.59 | regresses |

<img width="3080" height="1232" alt="cer" src="https://github.com/user-attachments/assets/9b858c12-d1ae-499f-963d-aa088f7e903b" />

### RTF comparison

Lower is better. Beam5 increases decoding cost on both GPU and NPU, but NPU beam5 has a much larger RTF increase for the measured Whisper variants.

| Dataset | Model | Beam 1 RTF | Beam 5 RTF | Notes |
| --- | --- | ---: | ---: | --- |
| clean | `openai/whisper-small` | 0.0376 | 0.0526 | GPU cost increases modestly |
| clean | `openai/whisper-medium` | 0.0681 | 0.1010 | GPU cost increases modestly |
| clean | `openai/whisper-large-v3-turbo` | 0.0255 | 0.0332 | GPU cost increases modestly |
| clean | `mobilint/whisper-small-single` | 0.0715 | 0.4241 | NPU beam5 much slower |
| clean | `mobilint/whisper-medium-single` | 0.3522 | 1.1223 | NPU beam5 much slower |
| clean | `mobilint/whisper-large-v3-turbo-single` | 0.4007 | 0.6144 | NPU beam5 slower |
| other | `openai/whisper-small` | 0.0401 | 0.0548 | GPU cost increases modestly |
| other | `openai/whisper-medium` | 0.0711 | 0.1079 | GPU cost increases modestly |
| other | `openai/whisper-large-v3-turbo` | 0.0271 | 0.0352 | GPU cost increases modestly |
| other | `mobilint/whisper-small-single` | 0.1544 | 0.4474 | NPU beam5 slower |
| other | `mobilint/whisper-medium-single` | 0.3963 | 1.1791 | NPU beam5 much slower |
| other | `mobilint/whisper-large-v3-turbo-single` | 0.4783 | 0.7044 | NPU beam5 slower |

<img width="3080" height="1232" alt="rtf" src="https://github.com/user-attachments/assets/f9b2cd1d-888b-4539-8062-3c96c77d3562" />

## Whisper beam trace experiment

I added and used `scripts/debug_whisper_beam_trace.py` to compare one fixed LibriSpeech sample with GPU/NPU Whisper-small.

Configuration:

- Dataset: `openslr/librispeech_asr`, config `clean`, split `test`, shuffled with seed `0`.
- Sample id: `1284-1180-0021`.
- Model pair: `openai/whisper-small` vs `mobilint/whisper-small`.
- Generation: `num_beams=1/5`, `max_new_tokens=32`, task `transcribe`, language `en`.

Observed output:

- GPU beam1/beam5: `... catching mice, and may prove of some use`.
- NPU beam1: `... catching mice, and may prove of some use`.
- NPU beam5: `... catching mice and may prove of some use to`.

Key trace observation:

- Around the token after `mice`, NPU beam5 keeps both comma token `11` and `and` token `293` as near-tied candidates.
- The NPU logits show effectively tied top candidates in this region, e.g. token `293` and token `11` both appearing with nearly identical scores.
- Forcing full replay with `MBLT_WHISPER_BEAM_FORCE_FULL_REPLAY=1` did not change the NPU beam5 output.
- Passing `use_cache=False` also did not change the NPU beam5 output.

Conclusion from this experiment:

- The observed Whisper beam5 degradation is unlikely to be caused directly by MobilintBeamCache reorder/suffix replay corruption.
- The issue looks more consistent with beam search selecting a different near-tie punctuation path under NPU logits/quantization, especially around punctuation candidates.
- Further investigation should focus on logits parity, beam scoring tie-breaking, and Whisper punctuation/logits-processor behavior rather than cache memory replay alone.

## Validation

- `uv run ruff check mblt_model_zoo/hf_transformers/utils/cache_utils.py mblt_model_zoo/hf_transformers/models/whisper/modeling_whisper.py scripts/debug_whisper_beam_trace.py`
- Manual GPU/NPU trace runs with `scripts/debug_whisper_beam_trace.py` for beam1/beam5 Whisper-small sample comparison.