### PR TITLE
feat(llm): add HF-style logits_to_keep across LLM/VLM forwards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,35 @@ because they are the most consistently structured.
   `tests.npu_backend_options.build_vision_engine_kwargs()` so `dev_no`, `core_mode`,
   `target_cores`, and `target_clusters` stay aligned with the engine signature.
 
+#### Transformers Test Scope
+
+Pick the narrowest command that covers the change. `pytest tests/transformers` walks every
+category and takes several minutes; only run it when touching shared code such as
+`mblt_model_zoo/hf_transformers/utils/generation_utils.py`, base helpers in
+`mblt_model_zoo/hf_transformers/utils/`, or other cross-model utilities. Reserve
+`pytest tests/transformers --full-matrix` for the pre-merge or release gate, not per-change
+iteration. Pass `-x` (stop on first failure) as the default flag while iterating on a fix.
+
+Map the touched source path to a single test file where possible:
+
+- `mblt_model_zoo/hf_transformers/models/qwen2/**` -> `pytest tests/transformers/text_generation/non_batch/test_qwen2.py -k "0.5B"`
+- `mblt_model_zoo/hf_transformers/models/qwen3/**` -> `pytest tests/transformers/text_generation/non_batch/test_qwen3.py -k "0.6B"`
+- `mblt_model_zoo/hf_transformers/models/llama/**` -> `pytest tests/transformers/text_generation/non_batch/test_llama.py -k "1B"`
+- `mblt_model_zoo/hf_transformers/models/exaone/**` -> `pytest tests/transformers/text_generation/non_batch/test_exaone.py -k "2.4B"`
+- `mblt_model_zoo/hf_transformers/models/exaone4/**` -> `pytest tests/transformers/text_generation/non_batch/test_exaone4.py`
+- `mblt_model_zoo/hf_transformers/models/qwen2_eagle3/**` -> `pytest tests/transformers/text_generation/eagle3/test_qwen2_eagle3.py`
+- `mblt_model_zoo/hf_transformers/models/qwen2_vl/**` -> `pytest tests/transformers/image_text_to_text/test_qwen2_vl.py`
+- `mblt_model_zoo/hf_transformers/models/qwen3_vl/**` -> `pytest tests/transformers/image_text_to_text/test_qwen3_vl.py -k "2B"`
+- `mblt_model_zoo/hf_transformers/models/aya_vision/**` -> `pytest tests/transformers/image_text_to_text/test_aya.py`
+- `mblt_model_zoo/hf_transformers/models/blip/**` -> `pytest tests/transformers/image_to_text/test_blip.py`
+- `mblt_model_zoo/hf_transformers/models/whisper/**` -> `pytest tests/transformers/automatic_speech_recognition/test_whisper.py -k "small"`
+- `mblt_model_zoo/hf_transformers/models/qwen3_asr/**` -> `pytest tests/transformers/automatic_speech_recognition/test_qwen3_asr.py`
+- `mblt_model_zoo/hf_transformers/models/bert/**` -> `pytest tests/transformers/fill_mask/test_bert.py -k "bert-base-uncased"`
+
+For model families without a dedicated test file (e.g., `cohere2`, `siglip`) or for edits that
+span multiple families in one directory, consult `tests/transformers/TEST.md` for the closest
+subdirectory-level scope.
+
 ## Comment Style Guide
 
 ### Inline Comments
@@ -138,7 +167,7 @@ pre-commit run --files path/to/touched_file.py
 
 ```bash
 pytest tests/vision/test_resnet50.py
-pytest tests/transformers/text-generation/test_qwen2.py -k "0.5B"
+pytest tests/transformers/text_generation/non_batch/test_qwen2.py -k "0.5B"
 pytest tests/MeloTTS/test_melo.py -k "KR"
 ```
 

--- a/benchmark/transformers/asr_pipeline_utils.py
+++ b/benchmark/transformers/asr_pipeline_utils.py
@@ -183,7 +183,8 @@ def build_asr_pipeline(
             if missing == "qwen_asr" or missing.startswith("qwen_asr."):
                 raise ModuleNotFoundError(
                     "Qwen3-ASR original-model benchmarks require the optional 'qwen-asr' package. "
-                    "Install it with: pip install -U qwen-asr"
+                    "Install it with: uv sync --extra qwen-asr, or "
+                    "pip install -U \"mblt-model-zoo[qwen-asr]\""
                 ) from exc
             raise
 

--- a/benchmark/transformers/asr_pipeline_utils.py
+++ b/benchmark/transformers/asr_pipeline_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmark.transformers.asr_metrics import SampleTiming, add_device_efficiency_metrics
+from mblt_model_zoo.hf_transformers.models.qwen3_asr._errors import QWEN_ASR_INSTALL_HINT
 
 
 def asr_pipeline_inputs(sample: Mapping[str, Any]) -> list[tuple[Any, dict[str, Any]]]:
@@ -181,11 +182,7 @@ def build_asr_pipeline(
         except ModuleNotFoundError as exc:
             missing = exc.name or ""
             if missing == "qwen_asr" or missing.startswith("qwen_asr."):
-                raise ModuleNotFoundError(
-                    "Qwen3-ASR original-model benchmarks require the optional 'qwen-asr' package. "
-                    "Install it with: uv sync --extra qwen-asr, or "
-                    "pip install -U \"mblt-model-zoo[qwen-asr]\""
-                ) from exc
+                raise ModuleNotFoundError(QWEN_ASR_INSTALL_HINT) from exc
             raise
 
         quiet_apscheduler_info_logs()

--- a/benchmark/transformers/asr_qwen_utils.py
+++ b/benchmark/transformers/asr_qwen_utils.py
@@ -13,6 +13,8 @@ from typing import Any, Mapping
 
 import torch
 
+from mblt_model_zoo.hf_transformers.models.qwen3_asr._errors import QWEN_ASR_INSTALL_HINT
+
 
 _QWEN3_ASR_LANGUAGE_ALIASES = {
     "ar": "Arabic",
@@ -115,11 +117,7 @@ def ensure_qwen3_asr_backend_registered() -> None:
     except ModuleNotFoundError as exc:
         missing = exc.name or ""
         if missing == "qwen_asr" or missing.startswith("qwen_asr."):
-            raise ModuleNotFoundError(
-                "Qwen3-ASR original-model benchmarks require the optional 'qwen-asr' package. "
-                "Install it with: uv sync --extra qwen-asr, or "
-                "pip install -U \"mblt-model-zoo[qwen-asr]\""
-            ) from exc
+            raise ModuleNotFoundError(QWEN_ASR_INSTALL_HINT) from exc
         raise
 
     try:
@@ -143,11 +141,7 @@ def ensure_qwen3_asr_backend_registered() -> None:
     except ModuleNotFoundError as exc:
         missing = exc.name or ""
         if missing == "qwen_asr" or missing.startswith("qwen_asr."):
-            raise ModuleNotFoundError(
-                "Qwen3-ASR original-model benchmarks require the optional 'qwen-asr' package. "
-                "Install it with: uv sync --extra qwen-asr, or "
-                "pip install -U \"mblt-model-zoo[qwen-asr]\""
-            ) from exc
+            raise ModuleNotFoundError(QWEN_ASR_INSTALL_HINT) from exc
         raise
 
 

--- a/benchmark/transformers/asr_qwen_utils.py
+++ b/benchmark/transformers/asr_qwen_utils.py
@@ -117,7 +117,8 @@ def ensure_qwen3_asr_backend_registered() -> None:
         if missing == "qwen_asr" or missing.startswith("qwen_asr."):
             raise ModuleNotFoundError(
                 "Qwen3-ASR original-model benchmarks require the optional 'qwen-asr' package. "
-                "Install it with: pip install -U qwen-asr"
+                "Install it with: uv sync --extra qwen-asr, or "
+                "pip install -U \"mblt-model-zoo[qwen-asr]\""
             ) from exc
         raise
 
@@ -144,7 +145,8 @@ def ensure_qwen3_asr_backend_registered() -> None:
         if missing == "qwen_asr" or missing.startswith("qwen_asr."):
             raise ModuleNotFoundError(
                 "Qwen3-ASR original-model benchmarks require the optional 'qwen-asr' package. "
-                "Install it with: pip install -U qwen-asr"
+                "Install it with: uv sync --extra qwen-asr, or "
+                "pip install -U \"mblt-model-zoo[qwen-asr]\""
             ) from exc
         raise
 

--- a/mblt_model_zoo/hf_transformers/models/aya_vision/modeling_aya_vision.py
+++ b/mblt_model_zoo/hf_transformers/models/aya_vision/modeling_aya_vision.py
@@ -93,6 +93,13 @@ class MobilintAyaVisionForConditionalGeneration(PretrainedOnlyMixin, MobilintGen
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> Union[tuple, AyaVisionCausalLMOutputWithPast]:
+        """Run the Aya-Vision text decoder with HF-style ``logits_to_keep``.
+
+        Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
+        last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
+        safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
+        perplexity eval / logit collection inherit this cost on last-only builds.
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 

--- a/mblt_model_zoo/hf_transformers/models/aya_vision/modeling_aya_vision.py
+++ b/mblt_model_zoo/hf_transformers/models/aya_vision/modeling_aya_vision.py
@@ -93,9 +93,6 @@ class MobilintAyaVisionForConditionalGeneration(PretrainedOnlyMixin, MobilintGen
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> Union[tuple, AyaVisionCausalLMOutputWithPast]:
-        if logits_to_keep > 1:
-            logger.warning("logits_to_keep larger than 1 is not supported: %d" % logits_to_keep)
-        
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -129,6 +126,7 @@ class MobilintAyaVisionForConditionalGeneration(PretrainedOnlyMixin, MobilintGen
             inputs_embeds=inputs_embeds,
             use_cache=kwargs.pop('use_cache', None),
             cache_position=cache_position,
+            logits_to_keep=logits_to_keep,
             image_sizes=image_sizes,
             prefill_chunk_size=prefill_chunk_size,
             count_npu_time=count_npu_time,

--- a/mblt_model_zoo/hf_transformers/models/cohere2/modeling_cohere2.py
+++ b/mblt_model_zoo/hf_transformers/models/cohere2/modeling_cohere2.py
@@ -49,9 +49,6 @@ class MobilintCohere2ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         
-        if logits_to_keep > 1:
-            logger.warning("logits_to_keep larger than 1 is not supported: %d" % logits_to_keep)
-
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -84,6 +81,7 @@ class MobilintCohere2ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             prefill_chunk_size,
             count_npu_time=count_npu_time,
             attention_mask=effective_attention_mask,
+            logits_to_keep=logits_to_keep,
         )
         logits = logits * self.logit_scale  # main diff from Llama
 

--- a/mblt_model_zoo/hf_transformers/models/exaone/modeling_exaone.py
+++ b/mblt_model_zoo/hf_transformers/models/exaone/modeling_exaone.py
@@ -41,6 +41,7 @@ class MobilintExaoneForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
         prefill_chunk_size: Union[int, None] = None,
         count_npu_time: bool = False,
     ) -> Union[Tuple[Union[torch.Tensor, MobilintCache], ...], CausalLMOutputWithPast]:
@@ -83,6 +84,7 @@ class MobilintExaoneForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             prefill_chunk_size,
             count_npu_time=count_npu_time,
             attention_mask=effective_attention_mask,
+            logits_to_keep=logits_to_keep,
         )
 
         loss = None

--- a/mblt_model_zoo/hf_transformers/models/exaone/modeling_exaone.py
+++ b/mblt_model_zoo/hf_transformers/models/exaone/modeling_exaone.py
@@ -45,6 +45,13 @@ class MobilintExaoneForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
         prefill_chunk_size: Union[int, None] = None,
         count_npu_time: bool = False,
     ) -> Union[Tuple[Union[torch.Tensor, MobilintCache], ...], CausalLMOutputWithPast]:
+        """Run the Exaone causal LM with HF-style ``logits_to_keep``.
+
+        Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
+        last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
+        safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
+        perplexity eval / logit collection inherit this cost on last-only builds.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/mblt_model_zoo/hf_transformers/models/exaone4/modeling_exaone4.py
+++ b/mblt_model_zoo/hf_transformers/models/exaone4/modeling_exaone4.py
@@ -41,9 +41,6 @@ class MobilintExaone4ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> CausalLMOutputWithPast:
-        if logits_to_keep > 1:
-            logger.warning("logits_to_keep larger than 1 is not supported: %d" % logits_to_keep)
-
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -70,6 +67,7 @@ class MobilintExaone4ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             prefill_chunk_size,
             count_npu_time=count_npu_time,
             attention_mask=effective_attention_mask,
+            logits_to_keep=logits_to_keep,
         )
 
         loss = None

--- a/mblt_model_zoo/hf_transformers/models/llama/modeling_llama.py
+++ b/mblt_model_zoo/hf_transformers/models/llama/modeling_llama.py
@@ -41,9 +41,6 @@ class MobilintLlamaForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> CausalLMOutputWithPast:
-        if logits_to_keep > 1:
-            logger.warning("logits_to_keep larger than 1 is not supported: %d" % logits_to_keep)
-
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -71,6 +68,7 @@ class MobilintLlamaForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             prefill_chunk_size,
             count_npu_time=count_npu_time,
             attention_mask=effective_attention_mask,
+            logits_to_keep=logits_to_keep,
         )
 
         loss = None

--- a/mblt_model_zoo/hf_transformers/models/qwen2/modeling_qwen2.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2/modeling_qwen2.py
@@ -41,9 +41,6 @@ class MobilintQwen2ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> CausalLMOutputWithPast:
-        if logits_to_keep > 1:
-            logger.warning("logits_to_keep larger than 1 is not supported: %d" % logits_to_keep)
-
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -70,6 +67,7 @@ class MobilintQwen2ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             prefill_chunk_size,
             count_npu_time=count_npu_time,
             attention_mask=effective_attention_mask,
+            logits_to_keep=logits_to_keep,
         )
 
         loss = None

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -1,6 +1,6 @@
 import inspect
 from functools import lru_cache
-from typing import Union, cast
+from typing import Any, Union, cast
 
 import torch
 import torch.nn as nn
@@ -327,18 +327,59 @@ class MobilintQwen2VLForConditionalGeneration(
     @with_mobilint_generation_signature(Qwen2VLForConditionalGeneration.forward, "count_npu_time")
     def forward(
         self,
-        *args: object,
+        *args: Any,
         count_npu_time: bool = False,
-        **kwargs: object,
+        **kwargs: Any,
     ) -> Union[tuple, Qwen2VLCausalLMOutputWithPast]:
-        """Forward to upstream while injecting Mobilint decoder timing collection.
+        """Route ``logits_to_keep`` to the Mobilint text decoder.
 
-        The ``@wraps`` metadata preserves the installed upstream signature so Transformers'
-        generation helpers still see Qwen2-VL's real inputs such as ``position_ids`` and
-        ``logits_to_keep``.
+        Upstream ``Qwen2VLForConditionalGeneration.forward`` extracts ``logits_to_keep``
+        as a named argument and performs its own final slice on the text model output,
+        which bypasses the Mobilint decoder's position selection. To keep that decoder
+        in charge of picking positions, we pop ``logits_to_keep`` here and thread it
+        into ``self.model`` via kwargs (upstream ``Qwen2VLModel.forward`` forwards its
+        own ``**kwargs`` to the text model). All other arguments follow the upstream
+        signature by way of ``@with_mobilint_generation_signature``, so upstream
+        additions such as ``position_ids`` continue to pass through unchanged.
         """
-        kwargs["count_npu_time"] = count_npu_time
-        return super().forward(*args, **kwargs)
+        upstream_params = [
+            name
+            for name, parameter in inspect.signature(
+                Qwen2VLForConditionalGeneration.forward
+            ).parameters.items()
+            if name != "self" and parameter.kind != inspect.Parameter.VAR_KEYWORD
+        ]
+        for name, value in zip(upstream_params, args):
+            kwargs[name] = value
+
+        labels = kwargs.pop("labels", None)
+        logits_to_keep = kwargs.pop("logits_to_keep", 0)
+
+        outputs = self.model(
+            logits_to_keep=logits_to_keep,
+            count_npu_time=count_npu_time,
+            **kwargs,
+        )
+
+        # The Mobilint text decoder already returns logits sliced to the requested
+        # positions and ``self.lm_head`` is ``nn.Identity``, so skip the upstream
+        # ``hidden_states[:, slice_indices, :]`` step.
+        logits = cast(torch.FloatTensor, self.lm_head(outputs.last_hidden_state))
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
+            )
+
+        return Qwen2VLCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=outputs.rope_deltas,
+        )
 
 
 AutoModel.register(MobilintQwen2VLConfig, MobilintQwen2VLForConditionalGeneration)

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -345,6 +345,11 @@ class MobilintQwen2VLForConditionalGeneration(
         own ``**kwargs`` to the text model). All other arguments follow the upstream
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``position_ids`` continue to pass through unchanged.
+
+        Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
+        last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
+        safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
+        perplexity eval / logit collection inherit this cost on last-only builds.
         """
         for name, value in zip(upstream_positional_params(Qwen2VLForConditionalGeneration.forward), args):
             if name in kwargs:

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -351,7 +351,13 @@ class MobilintQwen2VLForConditionalGeneration(
         safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
         perplexity eval / logit collection inherit this cost on last-only builds.
         """
-        for name, value in zip(upstream_positional_params(Qwen2VLForConditionalGeneration.forward), args):
+        positional_params = upstream_positional_params(Qwen2VLForConditionalGeneration.forward)
+        if len(args) > len(positional_params):
+            raise TypeError(
+                f"forward() takes at most {len(positional_params)} positional arguments "
+                f"but {len(args)} were given"
+            )
+        for name, value in zip(positional_params, args):
             if name in kwargs:
                 raise TypeError(f"forward() got multiple values for argument {name!r}")
             kwargs[name] = value

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -20,7 +20,11 @@ from transformers.utils.generic import TransformersKwargs, logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
 from ...utils.cache_utils import MobilintCache
-from ...utils.generation_utils import MobilintGenerationMixin, with_mobilint_generation_signature
+from ...utils.generation_utils import (
+    MobilintGenerationMixin,
+    upstream_positional_params,
+    with_mobilint_generation_signature,
+)
 from ...utils.modeling_utils import MobilintModelMixin
 from .configuration_qwen2_vl import (
     MobilintQwen2VLConfig,
@@ -342,14 +346,7 @@ class MobilintQwen2VLForConditionalGeneration(
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``position_ids`` continue to pass through unchanged.
         """
-        upstream_params = [
-            name
-            for name, parameter in inspect.signature(
-                Qwen2VLForConditionalGeneration.forward
-            ).parameters.items()
-            if name != "self" and parameter.kind != inspect.Parameter.VAR_KEYWORD
-        ]
-        for name, value in zip(upstream_params, args):
+        for name, value in zip(upstream_positional_params(Qwen2VLForConditionalGeneration.forward), args):
             kwargs[name] = value
 
         labels = kwargs.pop("labels", None)

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -207,6 +207,7 @@ class MobilintQwen2VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
         output_hidden_states: Union[bool, None] = None,
         return_dict: Union[bool, None] = None,
         cache_position: Union[torch.LongTensor, None] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
         prefill_chunk_size: Union[int, None] = None,
         count_npu_time: bool = False,
     ) -> Union[tuple, BaseModelOutputWithPast]:
@@ -248,6 +249,7 @@ class MobilintQwen2VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
             cache_position,
             prefill_chunk_size,
             count_npu_time=count_npu_time,
+            logits_to_keep=logits_to_keep,
         )
 
         if not return_dict:

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -24,6 +24,7 @@ from ...utils.generation_utils import (
     MobilintGenerationMixin,
     build_loss_kwargs_dynamic,
     mirror_output_fields,
+    pop_loss_only_kwargs,
     upstream_positional_params,
     with_mobilint_generation_signature,
 )
@@ -382,6 +383,12 @@ class MobilintQwen2VLForConditionalGeneration(
 
         labels = kwargs.pop("labels", None)
         logits_to_keep = kwargs.pop("logits_to_keep", 0)
+        # Loss-only kwargs (``num_items_in_batch``, ``shift_labels``) must be
+        # stripped BEFORE ``self.model`` is called: upstream ``Qwen2VLModel``
+        # forwards its own ``**kwargs`` to ``self.language_model``, and
+        # ``MobilintQwen2VLTextModel.forward`` declares no ``**kwargs`` sink,
+        # so leaking these into that call would raise ``TypeError``.
+        loss_only_kwargs = pop_loss_only_kwargs(kwargs)
 
         outputs = self.model(
             logits_to_keep=logits_to_keep,
@@ -402,7 +409,7 @@ class MobilintQwen2VLForConditionalGeneration(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
-                    upstream_kwargs=kwargs,
+                    upstream_kwargs=loss_only_kwargs,
                 )
             )
 

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -22,6 +22,8 @@ from ...utils.base_utils import PretrainedOnlyMixin
 from ...utils.cache_utils import MobilintCache
 from ...utils.generation_utils import (
     MobilintGenerationMixin,
+    build_loss_kwargs_dynamic,
+    mirror_output_fields,
     upstream_positional_params,
     with_mobilint_generation_signature,
 )
@@ -346,6 +348,15 @@ class MobilintQwen2VLForConditionalGeneration(
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``position_ids`` continue to pass through unchanged.
 
+        Dynamic adaptation:
+            * Loss kwargs are built via :func:`build_loss_kwargs_dynamic`, so
+              upstream additions like ``num_items_in_batch`` / ``shift_labels``
+              flow through when the loss function accepts them.
+            * The returned ``Qwen2VLCausalLMOutputWithPast`` is assembled by
+              :func:`mirror_output_fields`, so new output fields (e.g. a future
+              ``image_hidden_states``) are mirrored from the upstream model
+              output automatically instead of requiring wrapper edits.
+
         Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
         last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
         safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
@@ -379,16 +390,20 @@ class MobilintQwen2VLForConditionalGeneration(
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
+                **build_loss_kwargs_dynamic(
+                    self.loss_function,
+                    logits=logits,
+                    labels=labels,
+                    vocab_size=self.config.text_config.vocab_size,
+                    upstream_kwargs=kwargs,
+                )
             )
 
-        return Qwen2VLCausalLMOutputWithPast(
+        return mirror_output_fields(
+            Qwen2VLCausalLMOutputWithPast,
+            outputs,
             loss=loss,
             logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-            rope_deltas=outputs.rope_deltas,
         )
 
 

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -347,6 +347,8 @@ class MobilintQwen2VLForConditionalGeneration(
         additions such as ``position_ids`` continue to pass through unchanged.
         """
         for name, value in zip(upstream_positional_params(Qwen2VLForConditionalGeneration.forward), args):
+            if name in kwargs:
+                raise TypeError(f"forward() got multiple values for argument {name!r}")
             kwargs[name] = value
 
         labels = kwargs.pop("labels", None)

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -16,7 +16,7 @@ from transformers.models.qwen2_vl.modeling_qwen2_vl import (
     Qwen2VLModel,
 )
 from transformers.processing_utils import Unpack
-from transformers.utils.generic import TransformersKwargs, logging
+from transformers.utils.generic import TransformersKwargs, can_return_tuple, logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
 from ...utils.cache_utils import MobilintCache
@@ -331,6 +331,7 @@ class MobilintQwen2VLForConditionalGeneration(
         return model_inputs
 
     @with_mobilint_generation_signature(Qwen2VLForConditionalGeneration.forward, "count_npu_time")
+    @can_return_tuple
     def forward(
         self,
         *args: Any,
@@ -347,6 +348,12 @@ class MobilintQwen2VLForConditionalGeneration(
         own ``**kwargs`` to the text model). All other arguments follow the upstream
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``position_ids`` continue to pass through unchanged.
+
+        Tuple mode: ``@can_return_tuple`` strips ``return_dict`` from kwargs before
+        the wrapper body runs (so ``self.model`` never returns a tuple) and converts
+        the assembled ``Qwen2VLCausalLMOutputWithPast`` back to a tuple when
+        ``return_dict=False`` was requested — matching the upstream forward's
+        contract.
 
         Dynamic adaptation:
             * Loss kwargs are built via :func:`build_loss_kwargs_dynamic`, so

--- a/mblt_model_zoo/hf_transformers/models/qwen3/modeling_qwen3.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3/modeling_qwen3.py
@@ -41,9 +41,6 @@ class MobilintQwen3ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> CausalLMOutputWithPast:
-        if logits_to_keep > 1:
-            logger.warning("logits_to_keep larger than 1 is not supported: %d" % logits_to_keep)
-
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -70,6 +67,7 @@ class MobilintQwen3ForCausalLM(MobilintModelMixin, MobilintGenerationMixin):
             prefill_chunk_size,
             count_npu_time=count_npu_time,
             attention_mask=effective_attention_mask,
+            logits_to_keep=logits_to_keep,
         )
 
         loss = None

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/_errors.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/_errors.py
@@ -5,9 +5,10 @@ from typing import Iterator
 
 QWEN_ASR_INSTALL_HINT = (
     "Mobilint Qwen3-ASR requires the upstream 'qwen-asr' package, "
-    "which is distributed separately on PyPI and is not bundled with "
-    "mblt_model_zoo[transformers]. "
-    "Install it with: pip install -U qwen-asr "
+    "which is exposed through the optional mblt-model-zoo 'qwen-asr' extra "
+    "and is not bundled with mblt_model_zoo[transformers]. "
+    "Install it with: uv sync --extra qwen-asr, or "
+    "pip install -U \"mblt-model-zoo[qwen-asr]\" "
     "(see https://huggingface.co/Qwen/Qwen3-ASR-1.7B for details)."
 )
 

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -236,6 +236,22 @@ class MobilintQwen3ASRTextModel(
         past_key_values.ensure_batch_size(batch_size)
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         mxq_model = self.npu_backend.mxq_model
+        # Mirror the 3-path dispatch in ``_run_chunked_logits_to_keep``: on a
+        # last-only MXQ each ``mxq_model.infer`` returns a single row instead
+        # of one row per input token, so the per-chunk concat would collapse
+        # a multi-chunk suffix to ``num_chunks`` rows and misalign every
+        # selector below. ``is_default_keep`` takes the last-token fast path
+        # on both backends; ``supports_all`` keeps the caller's chunk size;
+        # ``last_only_slow`` forces size-1 captures so each infer emits one
+        # row per suffix position and the outer alignment/selector logic
+        # sees the ``(1, suffix_length, vocab)`` shape it already expects.
+        window_length = int(input_ids.shape[1])
+        is_default_keep = self._is_last_only_selector(logits_to_keep, window_length)
+        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
+        last_only_slow = not is_default_keep and not supports_all
+        if last_only_slow:
+            self._warn_last_only_slow_path_once()
+        effective_chunk_size = 1 if last_only_slow else resolved_prefill_chunk_size
         logits_list: list[torch.Tensor] = []
         beam_offsets: list[int] = []
         logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], tuple[torch.Tensor, int]] = {}
@@ -292,7 +308,7 @@ class MobilintQwen3ASRTextModel(
 
             row_embeds_numpy = row_embeds.detach().type(torch.float32).cpu().numpy()
             row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
-            num_suffix_chunks = math.ceil(suffix_length / resolved_prefill_chunk_size)
+            num_suffix_chunks = math.ceil(suffix_length / effective_chunk_size)
             # Accumulate per-chunk logits so the selector below sees the full
             # suffix window. Overwriting a single ``row_logits_ndarray`` inside
             # the loop would silently drop every chunk except the last, so a
@@ -301,8 +317,8 @@ class MobilintQwen3ASRTextModel(
             chunk_logits_tensors: list[torch.Tensor] = []
 
             for chunk_index in range(num_suffix_chunks):
-                start_index = chunk_index * resolved_prefill_chunk_size
-                end_index = min(start_index + resolved_prefill_chunk_size, suffix_length)
+                start_index = chunk_index * effective_chunk_size
+                end_index = min(start_index + effective_chunk_size, suffix_length)
                 cache_size = prefix_length + start_index
                 chunk = row_embeds_numpy[:, :, start_index:end_index, :]
 
@@ -337,12 +353,27 @@ class MobilintQwen3ASRTextModel(
             past_key_values.commit_active_tokens(target_tokens, source_index=source_index)
             if not chunk_logits_tensors:
                 raise RuntimeError("Qwen3-ASR beam decode produced no logits.")
-            row_logits = torch.cat(chunk_logits_tensors, dim=1)
-            row_logits = row_logits[:, -int(input_ids.shape[1]) :, :]
+            if is_default_keep:
+                # Last-token fast path: on a static last-only MXQ the final
+                # chunk already emits ``(1, 1, vocab)``, and on a dynamic-axis
+                # MXQ the last row of the final chunk is the last-token logit.
+                # Skip the per-position concat + window slice below so the
+                # post-loop short-circuit returns ``(batch, 1, vocab)``.
+                row_logits = chunk_logits_tensors[-1][:, -1:, :]
+            else:
+                row_logits = torch.cat(chunk_logits_tensors, dim=1)
+                row_logits = row_logits[:, -window_length :, :]
             logits_list.append(row_logits)
             beam_offsets.append(local_start_index)
             logits_by_target_tokens[target_key] = (row_logits, local_start_index)
 
+        if is_default_keep:
+            # Every per-beam ``row_logits`` is already ``(1, 1, vocab)`` (the
+            # last-token logit). The cross-beam alignment and HF-selector
+            # block below would try to ``index_select`` window position
+            # ``window_length - 1`` from an axis that only has one row, so
+            # short-circuit here and stack the last-token logits directly.
+            return torch.cat(logits_list, dim=0)
         # Align beams to a shared suffix window before ``torch.cat``. When
         # one beam's active-cache prefix covered more of the input window
         # than another's, their row_logits have different shape[1]; front-
@@ -358,7 +389,6 @@ class MobilintQwen3ASRTextModel(
                 if drop:
                     logits_list[i] = logits_list[i][:, drop:, :]
         logits = torch.cat(logits_list, dim=0)
-        window_length = int(input_ids.shape[1])
         # HF-compatible selector against the current call's input window.
         # The empty-selector branch keeps the vocab axis (via a zero-width
         # slice of the already-produced logits) so callers stacking outputs

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -254,7 +254,6 @@ class MobilintQwen3ASRTextModel(
                 prefix_length = max(0, len(target_tokens) - int(input_ids.shape[1]))
             local_start_index = max(0, prefix_length - previous_length)
             timing_phase = "prefill" if prefix_length == 0 else "decode"
-            row_logits_ndarray: np.ndarray | None = None
 
             if prefix_length < previous_length:
                 suffix_tokens = torch.tensor(
@@ -275,6 +274,12 @@ class MobilintQwen3ASRTextModel(
             row_embeds_numpy = row_embeds.detach().type(torch.float32).cpu().numpy()
             row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
             num_suffix_chunks = math.ceil(suffix_length / resolved_prefill_chunk_size)
+            # Accumulate per-chunk logits so the selector below sees the full
+            # suffix window. Overwriting a single ``row_logits_ndarray`` inside
+            # the loop would silently drop every chunk except the last, so a
+            # selector referencing positions outside the final chunk would
+            # either raise or (worse) pick from the wrong window.
+            chunk_logits_tensors: list[torch.Tensor] = []
 
             for chunk_index in range(num_suffix_chunks):
                 start_index = chunk_index * resolved_prefill_chunk_size
@@ -293,20 +298,27 @@ class MobilintQwen3ASRTextModel(
                     result = mxq_model.infer([chunk], None, cache_size)
 
                 assert result is not None, "mxq infer result is None!"
-                row_logits_ndarray = result[0]
+                chunk_logits = torch.tensor(
+                    result[0], dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                )
+                while chunk_logits.ndim > 2:
+                    singleton_dims = [
+                        dim for dim, size in enumerate(chunk_logits.shape[:-1]) if int(size) == 1
+                    ]
+                    if not singleton_dims:
+                        raise ValueError(
+                            f"Unexpected Qwen3-ASR beam logits shape: {tuple(chunk_logits.shape)}"
+                        )
+                    chunk_logits = chunk_logits.squeeze(singleton_dims[0])
+                if chunk_logits.ndim == 2:
+                    chunk_logits = chunk_logits.unsqueeze(0)
+                chunk_logits_tensors.append(chunk_logits)
 
             past_key_values.commit_beam_tokens(beam_index, target_tokens)
             past_key_values.commit_active_tokens(target_tokens, source_index=source_index)
-            if row_logits_ndarray is None:
+            if not chunk_logits_tensors:
                 raise RuntimeError("Qwen3-ASR beam decode produced no logits.")
-            row_logits = torch.tensor(row_logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
-            while row_logits.ndim > 2:
-                singleton_dims = [dim for dim, size in enumerate(row_logits.shape[:-1]) if int(size) == 1]
-                if not singleton_dims:
-                    raise ValueError(f"Unexpected Qwen3-ASR beam logits shape: {tuple(row_logits.shape)}")
-                row_logits = row_logits.squeeze(singleton_dims[0])
-            if row_logits.ndim == 2:
-                row_logits = row_logits.unsqueeze(0)
+            row_logits = torch.cat(chunk_logits_tensors, dim=1)
             row_logits = row_logits[:, -int(input_ids.shape[1]) :, :]
             logits_list.append(row_logits)
             logits_by_target_tokens[target_key] = row_logits

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -318,6 +318,13 @@ class MobilintQwen3ASRTextModel(
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> Union[tuple, BaseModelOutputWithPast]:
+        """Run the Qwen3-ASR text decoder with HF-style ``logits_to_keep``.
+
+        Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
+        last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
+        safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
+        perplexity eval / logit collection inherit this cost on last-only builds.
+        """
         if input_ids is None and inputs_embeds is None:
             raise ValueError("You must specify input_ids, inputs_embeds, or both.")
 

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -313,6 +313,7 @@ class MobilintQwen3ASRTextModel(
         inputs_embeds: Optional[torch.FloatTensor] = None,
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
         prefill_chunk_size: Optional[int] = None,
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
@@ -365,6 +366,7 @@ class MobilintQwen3ASRTextModel(
                 prefill_chunk_size=prefill_chunk_size,
                 count_npu_time=count_npu_time,
                 attention_mask=None,
+                logits_to_keep=logits_to_keep,
             )
 
         return BaseModelOutputWithPast(

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -214,6 +214,16 @@ class MobilintQwen3ASRTextModel(
         last ``n``, and a tensor selects arbitrary positions. The selector
         is applied after per-beam suffix decode so beam-cache state advances
         identically regardless of which positions the caller keeps.
+
+        Beam-cache prefix reuse constraint: when the active beam cache already
+        represents a longer common prefix than a beam's own logical history
+        (``prefix_length > previous_length``), the NPU only forwards the
+        uncached suffix so window positions ``[0, beam_offset)`` are not
+        recoverable this call. Any selector referencing such a position
+        raises :class:`IndexError`, mirroring HF's out-of-range fancy-index
+        semantics. Callers needing keep-all or arbitrary early positions
+        should pass ``use_cache=False`` (or ``logits_to_keep=1`` for the
+        common last-token case, which is always safe).
         """
         if inputs_embeds.ndim != 3:
             raise ValueError(f"Expected rank-3 inputs_embeds for beam decode, got {tuple(inputs_embeds.shape)}")
@@ -227,7 +237,8 @@ class MobilintQwen3ASRTextModel(
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         mxq_model = self.npu_backend.mxq_model
         logits_list: list[torch.Tensor] = []
-        logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], torch.Tensor] = {}
+        beam_offsets: list[int] = []
+        logits_by_target_tokens: dict[tuple[int, tuple[int, ...]], tuple[torch.Tensor, int]] = {}
         self.npu_time = 0.0 if count_npu_time else None
         input_ids = input_ids.view(batch_size, -1)
         embedding_source_indices = self._resolve_source_indices(inputs_embeds)
@@ -247,7 +258,9 @@ class MobilintQwen3ASRTextModel(
             prefix_length = past_key_values.get_common_prefix_length(target_tokens, source_index=source_index)
             previous_length = len(previous_tokens)
             if prefix_length == len(target_tokens) and target_key in logits_by_target_tokens:
-                logits_list.append(logits_by_target_tokens[target_key])
+                cached_row_logits, cached_offset = logits_by_target_tokens[target_key]
+                logits_list.append(cached_row_logits)
+                beam_offsets.append(cached_offset)
                 past_key_values.commit_beam_tokens(beam_index, target_tokens)
                 continue
             if prefix_length == len(target_tokens):
@@ -270,6 +283,12 @@ class MobilintQwen3ASRTextModel(
                 row_embeds = inputs_embeds[beam_index : beam_index + 1, -1:, :]
                 suffix_length = 1
                 prefix_length = max(0, len(target_tokens) - 1)
+                # Only the last input window position is decoded, so the
+                # first ``window_length - 1`` window positions are outside
+                # the suffix. Keep ``local_start_index`` consistent with
+                # the actual produced suffix for downstream beam_offset
+                # alignment and selector validation.
+                local_start_index = max(0, int(input_ids.shape[1]) - 1)
 
             row_embeds_numpy = row_embeds.detach().type(torch.float32).cpu().numpy()
             row_embeds_numpy = np.expand_dims(row_embeds_numpy, 1)
@@ -321,8 +340,23 @@ class MobilintQwen3ASRTextModel(
             row_logits = torch.cat(chunk_logits_tensors, dim=1)
             row_logits = row_logits[:, -int(input_ids.shape[1]) :, :]
             logits_list.append(row_logits)
-            logits_by_target_tokens[target_key] = row_logits
+            beam_offsets.append(local_start_index)
+            logits_by_target_tokens[target_key] = (row_logits, local_start_index)
 
+        # Align beams to a shared suffix window before ``torch.cat``. When
+        # one beam's active-cache prefix covered more of the input window
+        # than another's, their row_logits have different shape[1]; front-
+        # trim each beam to ``[beam_offset, window_length)`` where
+        # ``beam_offset = max(local_start_index across beams)`` so the
+        # stacked tensor has shape ``(batch, window_length - beam_offset,
+        # vocab)``. When every beam had ``local_start_index == 0`` this is
+        # a no-op.
+        beam_offset = max(beam_offsets) if beam_offsets else 0
+        if beam_offset > 0:
+            for i, offset in enumerate(beam_offsets):
+                drop = beam_offset - offset
+                if drop:
+                    logits_list[i] = logits_list[i][:, drop:, :]
         logits = torch.cat(logits_list, dim=0)
         window_length = int(input_ids.shape[1])
         # HF-compatible selector against the current call's input window.
@@ -332,12 +366,33 @@ class MobilintQwen3ASRTextModel(
         output_positions = self._output_positions_for_logits_to_keep(
             logits_to_keep, window_length
         )
-        if len(output_positions) == window_length and output_positions == list(range(window_length)):
-            return logits
         if not output_positions:
             return logits[:, :0, :]
-        index = torch.tensor(output_positions, dtype=torch.long, device=logits.device)
-        return logits.index_select(1, index)
+        if beam_offset == 0:
+            if len(output_positions) == window_length and output_positions == list(range(window_length)):
+                return logits
+            index = torch.tensor(output_positions, dtype=torch.long, device=logits.device)
+            return logits.index_select(1, index)
+        # ``beam_offset > 0``: positions in ``[0, beam_offset)`` were not
+        # decoded for at least one beam. Refuse to fabricate them so the
+        # caller sees the same out-of-range signal HF fancy-indexing would
+        # give for a genuinely invalid position.
+        unsupported = [p for p in output_positions if p < beam_offset]
+        if unsupported:
+            raise IndexError(
+                f"logits_to_keep positions {unsupported} refer to window positions "
+                f"already covered by the active beam cache (beam cache offset = "
+                f"{beam_offset}); only positions in [{beam_offset}, {window_length}) "
+                f"are recoverable this call. Pass logits_to_keep=1 (HF .generate() "
+                f"default), restrict the selector to the suffix, or set "
+                f"use_cache=False to force a full recompute."
+            )
+        shifted = torch.tensor(
+            [p - beam_offset for p in output_positions],
+            dtype=torch.long,
+            device=logits.device,
+        )
+        return logits.index_select(1, shifted)
 
     def forward(
         self,

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -204,8 +204,17 @@ class MobilintQwen3ASRTextModel(
         cache_position: torch.Tensor,
         prefill_chunk_size: Optional[int] = None,
         count_npu_time: bool = False,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
     ) -> torch.Tensor:
-        """Run Qwen3-ASR decoder by forwarding only suffixes missing from active cache."""
+        """Run Qwen3-ASR decoder by forwarding only suffixes missing from active cache.
+
+        ``logits_to_keep`` follows HF semantics against the current call's
+        input window (``seq_len = input_ids.shape[1]``): ``0`` keeps every
+        position (default, matching the non-beam path), ``n > 0`` keeps the
+        last ``n``, and a tensor selects arbitrary positions. The selector
+        is applied after per-beam suffix decode so beam-cache state advances
+        identically regardless of which positions the caller keeps.
+        """
         if inputs_embeds.ndim != 3:
             raise ValueError(f"Expected rank-3 inputs_embeds for beam decode, got {tuple(inputs_embeds.shape)}")
 
@@ -302,7 +311,21 @@ class MobilintQwen3ASRTextModel(
             logits_list.append(row_logits)
             logits_by_target_tokens[target_key] = row_logits
 
-        return torch.cat(logits_list, dim=0)
+        logits = torch.cat(logits_list, dim=0)
+        window_length = int(input_ids.shape[1])
+        # HF-compatible selector against the current call's input window.
+        # The empty-selector branch keeps the vocab axis (via a zero-width
+        # slice of the already-produced logits) so callers stacking outputs
+        # across paths see a consistent ``(batch, 0, vocab)`` shape.
+        output_positions = self._output_positions_for_logits_to_keep(
+            logits_to_keep, window_length
+        )
+        if len(output_positions) == window_length and output_positions == list(range(window_length)):
+            return logits
+        if not output_positions:
+            return logits[:, :0, :]
+        index = torch.tensor(output_positions, dtype=torch.long, device=logits.device)
+        return logits.index_select(1, index)
 
     def forward(
         self,
@@ -364,6 +387,7 @@ class MobilintQwen3ASRTextModel(
                 cache_position=cache_position,
                 prefill_chunk_size=prefill_chunk_size,
                 count_npu_time=count_npu_time,
+                logits_to_keep=logits_to_keep,
             )
         else:
             logits = self.llm_forward(

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -23,6 +23,7 @@ from ...utils.generation_utils import (
     MobilintGenerationMixin,
     build_loss_kwargs_dynamic,
     mirror_output_fields,
+    pop_loss_only_kwargs,
     upstream_positional_params,
     with_mobilint_generation_signature,
 )
@@ -642,6 +643,11 @@ class MobilintQwen3VLForConditionalGeneration(
 
         labels = kwargs.pop("labels", None)
         logits_to_keep = kwargs.pop("logits_to_keep", 0)
+        # Loss-only kwargs (``num_items_in_batch``, ``shift_labels``) must be
+        # stripped BEFORE ``self.model`` is called so they don't reach the
+        # inner text model via upstream ``Qwen3VLModel``'s ``**kwargs`` pass-
+        # through. Keeps parity with the Qwen2-VL wrapper.
+        loss_only_kwargs = pop_loss_only_kwargs(kwargs)
 
         outputs = self.model(
             logits_to_keep=logits_to_keep,
@@ -662,7 +668,7 @@ class MobilintQwen3VLForConditionalGeneration(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
-                    upstream_kwargs=kwargs,
+                    upstream_kwargs=loss_only_kwargs,
                 )
             )
 

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -19,7 +19,11 @@ from transformers.utils.generic import TransformersKwargs, logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
 from ...utils.cache_utils import MobilintDeepStackCache
-from ...utils.generation_utils import MobilintGenerationMixin, with_mobilint_generation_signature
+from ...utils.generation_utils import (
+    MobilintGenerationMixin,
+    upstream_positional_params,
+    with_mobilint_generation_signature,
+)
 from ...utils.modeling_utils import MobilintModelMixin
 from .configuration_qwen3_vl import (
     MobilintQwen3VLConfig,
@@ -595,14 +599,7 @@ class MobilintQwen3VLForConditionalGeneration(
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``mm_token_type_ids`` continue to pass through unchanged.
         """
-        upstream_params = [
-            name
-            for name, parameter in inspect.signature(
-                Qwen3VLForConditionalGeneration.forward
-            ).parameters.items()
-            if name != "self" and parameter.kind != inspect.Parameter.VAR_KEYWORD
-        ]
-        for name, value in zip(upstream_params, args):
+        for name, value in zip(upstream_positional_params(Qwen3VLForConditionalGeneration.forward), args):
             kwargs[name] = value
 
         labels = kwargs.pop("labels", None)

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -15,7 +15,7 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLPreTrainedModel,
 )
 from transformers.processing_utils import Unpack
-from transformers.utils.generic import TransformersKwargs, logging
+from transformers.utils.generic import TransformersKwargs, can_return_tuple, logging
 
 from ...utils.base_utils import PretrainedOnlyMixin
 from ...utils.cache_utils import MobilintDeepStackCache
@@ -591,6 +591,7 @@ class MobilintQwen3VLForConditionalGeneration(
         return model_inputs
 
     @with_mobilint_generation_signature(Qwen3VLForConditionalGeneration.forward, "count_npu_time")
+    @can_return_tuple
     def forward(
         self,
         *args: Any,
@@ -607,6 +608,12 @@ class MobilintQwen3VLForConditionalGeneration(
         own ``**kwargs`` to the text model). All other arguments follow the upstream
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``mm_token_type_ids`` continue to pass through unchanged.
+
+        Tuple mode: ``@can_return_tuple`` strips ``return_dict`` from kwargs before
+        the wrapper body runs (so ``self.model`` never returns a tuple) and converts
+        the assembled ``Qwen3VLCausalLMOutputWithPast`` back to a tuple when
+        ``return_dict=False`` was requested — matching the upstream forward's
+        contract.
 
         Dynamic adaptation:
             * Loss kwargs are built via :func:`build_loss_kwargs_dynamic`, so

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -600,6 +600,8 @@ class MobilintQwen3VLForConditionalGeneration(
         additions such as ``mm_token_type_ids`` continue to pass through unchanged.
         """
         for name, value in zip(upstream_positional_params(Qwen3VLForConditionalGeneration.forward), args):
+            if name in kwargs:
+                raise TypeError(f"forward() got multiple values for argument {name!r}")
             kwargs[name] = value
 
         labels = kwargs.pop("labels", None)

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -627,7 +627,7 @@ class MobilintQwen3VLForConditionalGeneration(
         # The Mobilint text decoder already returns logits sliced to the requested
         # positions and ``self.lm_head`` is ``nn.Identity``, so skip the upstream
         # ``hidden_states[:, slice_indices, :]`` step.
-        logits = cast(torch.FloatTensor, self.lm_head(outputs[0]))
+        logits = cast(torch.FloatTensor, self.lm_head(outputs.last_hidden_state))
 
         loss = None
         if labels is not None:

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -336,6 +336,7 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
         cache_position: Optional[torch.LongTensor] = None,
         visual_pos_masks: Optional[torch.Tensor] = None,
         deepstack_visual_embeds: Optional[list[torch.Tensor]] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
         prefill_chunk_size: Optional[int] = None,
         count_npu_time: bool = False,
         **kwargs: Unpack[TransformersKwargs],
@@ -367,6 +368,7 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
             count_npu_time=count_npu_time,
             deepstack_visual_embeds=deepstack_visual_embeds,
             visual_pos_masks=visual_pos_masks,
+            logits_to_keep=logits_to_keep,
         )
 
         return BaseModelOutputWithPast(
@@ -383,8 +385,14 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
         cache_position: torch.Tensor,
         prefill_chunk_size: Optional[int] = None,
         count_npu_time: bool = False,
+        logits_to_keep: Union[int, torch.Tensor] = 1,
     ) -> torch.Tensor:
-        """Run the dual-input MXQ decoder.
+        """Run the dual-input MXQ decoder with HF-style ``logits_to_keep``.
+
+        ``logits_to_keep`` follows the ``transformers`` semantics: ``1``
+        (default) returns only the last-token logits; ``0`` returns every
+        position; ``>1`` returns the last N positions; a ``torch.Tensor``
+        selects specific positions.
 
         Args:
             inputs_embeds: Token embeddings of shape `(batch, seq_len, hidden)`.
@@ -394,9 +402,11 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
             cache_position: Cache position range.
             prefill_chunk_size: Optional chunk size.
             count_npu_time: Whether to accumulate NPU time.
+            logits_to_keep: HF-style position selector; see the shared
+                :meth:`MobilintModelMixin.llm_forward` for details.
 
         Returns:
-            Decoder logits for the most recent token positions.
+            Decoder logits for the requested token positions.
         """
         if inputs_embeds.ndim != 3:
             raise ValueError(f"Expected inputs_embeds rank 3, got shape {tuple(inputs_embeds.shape)}")
@@ -414,19 +424,18 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
             past_key_values.set_deepstack_tensor(deepstack_tensor)
 
         inputs_np = inputs_embeds.type(torch.float32).cpu().numpy()
+        seq_len = int(inputs_np.shape[1])
 
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
-        num_chunks = int(np.ceil(inputs_np.shape[1] / resolved_prefill_chunk_size))
 
         mxq_model = self.get_mxq_model()
         self.npu_time = 0.0 if count_npu_time else None
-        logits_ndarray = None
 
-        for chunk_idx in range(num_chunks):
-            start_index = chunk_idx * resolved_prefill_chunk_size
-            end_index = min(start_index + resolved_prefill_chunk_size, inputs_np.shape[1])
+        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
+        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
+
+        def _do_infer(start_index: int, end_index: int) -> np.ndarray:
             cache_size = past_key_values.get_seq_length() if past_key_values is not None else 0
-
             inputs_chunk = inputs_np[:, start_index:end_index, :]
             if past_key_values is None:
                 deepstack_chunk = deepstack_tensor[:, start_index:end_index, :].to(dtype=torch.float32).cpu().numpy()
@@ -443,20 +452,61 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
 
                 t1 = time.perf_counter()
                 result = mxq_model.infer([inputs_chunk, deepstack_chunk], None, cache_size)
+                assert self.npu_time is not None
                 self.npu_time += time.perf_counter() - t1
             else:
                 result = mxq_model.infer([inputs_chunk, deepstack_chunk], None, cache_size)
 
             if result is None:
                 raise RuntimeError("Text MXQ inference returned None.")
-            logits_ndarray = result[0]
-
             if past_key_values is not None:
                 past_key_values.update_cache_position(cache_position[start_index:end_index])
+            return result[0]
 
-        if logits_ndarray is None:
-            raise RuntimeError("Text MXQ inference did not produce logits.")
+        # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
+        # additionally collects every chunk's output so the concatenation
+        # covers the full input.
+        if is_default_keep or supports_all:
+            num_chunks = int(np.ceil(seq_len / resolved_prefill_chunk_size))
+            per_chunk_logits: list[np.ndarray] = []
+            logits_ndarray: Optional[np.ndarray] = None
+            for chunk_idx in range(num_chunks):
+                start_index = chunk_idx * resolved_prefill_chunk_size
+                end_index = min(start_index + resolved_prefill_chunk_size, seq_len)
+                logits_ndarray = _do_infer(start_index, end_index)
+                if supports_all:
+                    per_chunk_logits.append(logits_ndarray)
 
+            if supports_all:
+                logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
+                positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+                token_axis = logits_ndarray.ndim - 2
+                logits_ndarray = np.take(logits_ndarray, positions_to_keep, axis=token_axis)
+
+            if logits_ndarray is None:
+                raise RuntimeError("Text MXQ inference did not produce logits.")
+            return torch.tensor(logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
+
+        # Path 3: fallback. Interleave normal chunks (advancing only the KV
+        # cache) with size-1 infer calls at each kept position.
+        positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+        per_position_logits: dict[int, np.ndarray] = {}
+        cursor = 0
+        for p in positions_to_keep:
+            while cursor < p:
+                end_index = min(cursor + resolved_prefill_chunk_size, p)
+                _do_infer(cursor, end_index)
+                cursor = end_index
+            per_position_logits[p] = _do_infer(cursor, cursor + 1)
+            cursor += 1
+        while cursor < seq_len:
+            end_index = min(cursor + resolved_prefill_chunk_size, seq_len)
+            _do_infer(cursor, end_index)
+            cursor = end_index
+
+        logits_ndarray = np.concatenate(
+            [per_position_logits[p] for p in positions_to_keep], axis=-2
+        )
         return torch.tensor(logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
 
     def _build_deepstack_tensor(
@@ -566,18 +616,59 @@ class MobilintQwen3VLForConditionalGeneration(
     @with_mobilint_generation_signature(Qwen3VLForConditionalGeneration.forward, "count_npu_time")
     def forward(
         self,
-        *args: object,
+        *args: Any,
         count_npu_time: bool = False,
-        **kwargs: object,
+        **kwargs: Any,
     ) -> Union[tuple, Qwen3VLCausalLMOutputWithPast]:
-        """Forward to upstream while injecting Mobilint decoder timing collection.
+        """Route ``logits_to_keep`` to the Mobilint text decoder.
 
-        The ``@wraps`` metadata preserves the installed upstream signature so Transformers'
-        generation helpers still see Qwen3-VL's real inputs such as ``mm_token_type_ids`` and
-        ``logits_to_keep``.
+        Upstream ``Qwen3VLForConditionalGeneration.forward`` extracts ``logits_to_keep``
+        as a named argument and performs its own final slice on the text model output,
+        which bypasses the Mobilint decoder's position selection. To keep that decoder
+        in charge of picking positions, we pop ``logits_to_keep`` here and thread it
+        into ``self.model`` via kwargs (upstream ``Qwen3VLModel.forward`` forwards its
+        own ``**kwargs`` to the text model). All other arguments follow the upstream
+        signature by way of ``@with_mobilint_generation_signature``, so upstream
+        additions such as ``mm_token_type_ids`` continue to pass through unchanged.
         """
-        kwargs["count_npu_time"] = count_npu_time
-        return super().forward(*args, **kwargs)
+        upstream_params = [
+            name
+            for name, parameter in inspect.signature(
+                Qwen3VLForConditionalGeneration.forward
+            ).parameters.items()
+            if name != "self" and parameter.kind != inspect.Parameter.VAR_KEYWORD
+        ]
+        for name, value in zip(upstream_params, args):
+            kwargs[name] = value
+
+        labels = kwargs.pop("labels", None)
+        logits_to_keep = kwargs.pop("logits_to_keep", 0)
+
+        outputs = self.model(
+            logits_to_keep=logits_to_keep,
+            count_npu_time=count_npu_time,
+            **kwargs,
+        )
+
+        # The Mobilint text decoder already returns logits sliced to the requested
+        # positions and ``self.lm_head`` is ``nn.Identity``, so skip the upstream
+        # ``hidden_states[:, slice_indices, :]`` step.
+        logits = cast(torch.FloatTensor, self.lm_head(outputs[0]))
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
+            )
+
+        return Qwen3VLCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=outputs.rope_deltas,
+        )
 
 
 AutoModel.register(MobilintQwen3VLVisionConfig, MobilintQwen3VLVisionModel)

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -598,6 +598,11 @@ class MobilintQwen3VLForConditionalGeneration(
         own ``**kwargs`` to the text model). All other arguments follow the upstream
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``mm_token_type_ids`` continue to pass through unchanged.
+
+        Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
+        last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
+        safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
+        perplexity eval / logit collection inherit this cost on last-only builds.
         """
         for name, value in zip(upstream_positional_params(Qwen3VLForConditionalGeneration.forward), args):
             if name in kwargs:

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -604,7 +604,13 @@ class MobilintQwen3VLForConditionalGeneration(
         safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
         perplexity eval / logit collection inherit this cost on last-only builds.
         """
-        for name, value in zip(upstream_positional_params(Qwen3VLForConditionalGeneration.forward), args):
+        positional_params = upstream_positional_params(Qwen3VLForConditionalGeneration.forward)
+        if len(args) > len(positional_params):
+            raise TypeError(
+                f"forward() takes at most {len(positional_params)} positional arguments "
+                f"but {len(args)} were given"
+            )
+        for name, value in zip(positional_params, args):
             if name in kwargs:
                 raise TypeError(f"forward() got multiple values for argument {name!r}")
             kwargs[name] = value

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -504,6 +504,17 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
             _do_infer(cursor, end_index)
             cursor = end_index
 
+        if not positions_to_keep:
+            # Empty selection (empty tensor or all indices out-of-range): the
+            # KV cache has already been advanced through the entire input by
+            # the trailing loop above. Return a (batch, 0, 0) placeholder
+            # rather than calling np.concatenate on an empty list.
+            return torch.zeros(
+                (int(inputs_embeds.shape[0]), 0, 0),
+                dtype=inputs_embeds.dtype,
+                device=inputs_embeds.device,
+            )
+
         logits_ndarray = np.concatenate(
             [per_position_logits[p] for p in positions_to_keep], axis=-2
         )

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -431,9 +431,6 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
         mxq_model = self.get_mxq_model()
         self.npu_time = 0.0 if count_npu_time else None
 
-        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
-        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
-
         def _do_infer(start_index: int, end_index: int) -> np.ndarray:
             cache_size = past_key_values.get_seq_length() if past_key_values is not None else 0
             inputs_chunk = inputs_np[:, start_index:end_index, :]
@@ -463,62 +460,18 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
                 past_key_values.update_cache_position(cache_position[start_index:end_index])
             return result[0]
 
-        # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
-        # additionally collects every chunk's output so the concatenation
-        # covers the full input.
-        if is_default_keep or supports_all:
-            num_chunks = int(np.ceil(seq_len / resolved_prefill_chunk_size))
-            per_chunk_logits: list[np.ndarray] = []
-            logits_ndarray: Optional[np.ndarray] = None
-            for chunk_idx in range(num_chunks):
-                start_index = chunk_idx * resolved_prefill_chunk_size
-                end_index = min(start_index + resolved_prefill_chunk_size, seq_len)
-                logits_ndarray = _do_infer(start_index, end_index)
-                if supports_all:
-                    per_chunk_logits.append(logits_ndarray)
-
-            if supports_all:
-                logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
-                positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
-                token_axis = logits_ndarray.ndim - 2
-                logits_ndarray = np.take(logits_ndarray, positions_to_keep, axis=token_axis)
-
-            if logits_ndarray is None:
-                raise RuntimeError("Text MXQ inference did not produce logits.")
-            return torch.tensor(logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
-
-        # Path 3: fallback. Interleave normal chunks (advancing only the KV
-        # cache) with size-1 infer calls at each kept position.
-        positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
-        per_position_logits: dict[int, np.ndarray] = {}
-        cursor = 0
-        for p in positions_to_keep:
-            while cursor < p:
-                end_index = min(cursor + resolved_prefill_chunk_size, p)
-                _do_infer(cursor, end_index)
-                cursor = end_index
-            per_position_logits[p] = _do_infer(cursor, cursor + 1)
-            cursor += 1
-        while cursor < seq_len:
-            end_index = min(cursor + resolved_prefill_chunk_size, seq_len)
-            _do_infer(cursor, end_index)
-            cursor = end_index
-
-        if not positions_to_keep:
-            # Empty selection (empty tensor or all indices out-of-range): the
-            # KV cache has already been advanced through the entire input by
-            # the trailing loop above. Return a (batch, 0, 0) placeholder
-            # rather than calling np.concatenate on an empty list.
-            return torch.zeros(
-                (int(inputs_embeds.shape[0]), 0, 0),
-                dtype=inputs_embeds.dtype,
-                device=inputs_embeds.device,
-            )
-
-        logits_ndarray = np.concatenate(
-            [per_position_logits[p] for p in positions_to_keep], axis=-2
+        # The 3-path dispatch (fast / dynamic-axis / fallback) lives in the
+        # shared helper so single-input and dual-input decoders stay in sync.
+        # Unlike the single-input caller, we keep the leading batch axis
+        # produced by ``do_infer``.
+        return self._run_chunked_logits_to_keep(
+            do_infer=_do_infer,
+            seq_len=seq_len,
+            prefill_chunk_size=resolved_prefill_chunk_size,
+            logits_to_keep=logits_to_keep,
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
         )
-        return torch.tensor(logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
 
     def _build_deepstack_tensor(
         self,

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -438,7 +438,14 @@ class MobilintQwen3VLTextModel(MobilintModelMixin, MobilintGenerationMixin, Mobi
         self.npu_time = 0.0 if count_npu_time else None
 
         def _do_infer(start_index: int, end_index: int) -> np.ndarray:
-            cache_size = past_key_values.get_seq_length() if past_key_values is not None else 0
+            # See modeling_utils.llm_forward._do_infer: without a caller cache,
+            # start_index is the running "processed so far" count within this
+            # call, so use it as the KV cache_size — otherwise Path 3's prefix
+            # walks would pass 0 to every chunk and the size-1 kept-position
+            # captures would see no left context.
+            cache_size = (
+                past_key_values.get_seq_length() if past_key_values is not None else start_index
+            )
             inputs_chunk = inputs_np[:, start_index:end_index, :]
             if past_key_values is None:
                 deepstack_chunk = deepstack_tensor[:, start_index:end_index, :].to(dtype=torch.float32).cpu().numpy()

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -21,6 +21,8 @@ from ...utils.base_utils import PretrainedOnlyMixin
 from ...utils.cache_utils import MobilintDeepStackCache
 from ...utils.generation_utils import (
     MobilintGenerationMixin,
+    build_loss_kwargs_dynamic,
+    mirror_output_fields,
     upstream_positional_params,
     with_mobilint_generation_signature,
 )
@@ -599,6 +601,15 @@ class MobilintQwen3VLForConditionalGeneration(
         signature by way of ``@with_mobilint_generation_signature``, so upstream
         additions such as ``mm_token_type_ids`` continue to pass through unchanged.
 
+        Dynamic adaptation:
+            * Loss kwargs are built via :func:`build_loss_kwargs_dynamic`, so
+              upstream additions like ``num_items_in_batch`` / ``shift_labels``
+              flow through when the loss function accepts them.
+            * The returned ``Qwen3VLCausalLMOutputWithPast`` is assembled by
+              :func:`mirror_output_fields`, so new output fields (e.g. a future
+              ``image_hidden_states``) are mirrored from the upstream model
+              output automatically instead of requiring wrapper edits.
+
         Performance: the default ``logits_to_keep=0`` (keep-all) matches HF but on
         last-only MXQ triggers a size-1 infer per input token. ``.generate()`` is
         safe (HF passes ``logits_to_keep=1``); manual ``.forward()`` callers doing
@@ -632,16 +643,20 @@ class MobilintQwen3VLForConditionalGeneration(
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
+                **build_loss_kwargs_dynamic(
+                    self.loss_function,
+                    logits=logits,
+                    labels=labels,
+                    vocab_size=self.config.text_config.vocab_size,
+                    upstream_kwargs=kwargs,
+                )
             )
 
-        return Qwen3VLCausalLMOutputWithPast(
+        return mirror_output_fields(
+            Qwen3VLCausalLMOutputWithPast,
+            outputs,
             loss=loss,
             logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-            rope_deltas=outputs.rope_deltas,
         )
 
 

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -1,7 +1,8 @@
+import dataclasses
 import inspect
 from abc import ABC
 from functools import lru_cache, wraps
-from typing import Any, Callable, Dict, Optional, cast
+from typing import Any, Callable, Dict, Mapping, Optional, cast
 
 import qbruntime
 import torch
@@ -136,6 +137,142 @@ def upstream_positional_params(func: Callable) -> tuple[str, ...]:
         if name != "self"
         and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
     )
+
+
+@lru_cache(maxsize=None)
+def _loss_function_parameter_names(loss_function: Callable) -> tuple[str, ...]:
+    """Return the named parameters of ``loss_function`` (excluding ``*args``/``**kwargs``).
+
+    Only ``POSITIONAL_ONLY``, ``POSITIONAL_OR_KEYWORD``, and ``KEYWORD_ONLY``
+    parameters are returned. Variadic parameters (``*args``, ``**kwargs``) are
+    excluded because they do not carry a fixed name we can supply against.
+
+    Caching policy:
+        ``inspect.signature`` is memoized per ``loss_function`` because
+        :func:`build_loss_kwargs_dynamic` is called on the hot decoding path,
+        while the underlying signature is static per loss implementation.
+
+    Boundedness assumption:
+        Callers pass a small, fixed set of upstream loss callables
+        (``ForCausalLMLoss`` and siblings), so the unbounded cache saturates
+        at a handful of entries. Do **not** pass freshly constructed callables
+        here (lambdas, ``functools.partial`` results, per-call closures) — each
+        distinct object is a new cache key and would leak memory.
+    """
+    parameters = inspect.signature(loss_function).parameters
+    return tuple(
+        name
+        for name, parameter in parameters.items()
+        if parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    )
+
+
+# Kwarg names that :func:`build_loss_kwargs_dynamic` knows how to supply to
+# upstream loss functions. Exposed so contract tests can assert that all
+# required loss parameters upstream currently declares are covered here.
+# Extend this set (and update the helper below) when a newly-required loss
+# parameter needs a value source beyond the outer ``forward``'s ``kwargs``.
+LOSS_KWARG_SUPPLY_NAMES: frozenset[str] = frozenset(
+    {"logits", "labels", "vocab_size", "num_items_in_batch", "shift_labels"}
+)
+
+
+def build_loss_kwargs_dynamic(
+    loss_function: Callable,
+    *,
+    logits: Any,
+    labels: Any,
+    vocab_size: int,
+    upstream_kwargs: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Compute the keyword arguments to pass into ``loss_function``.
+
+    The wrapper introspects the loss function's signature so upstream additions
+    (e.g. ``num_items_in_batch``, ``shift_labels``) are picked up automatically
+    when present. Names absent from the signature are silently dropped so we do
+    not pass unexpected kwargs into older loss implementations.
+
+    Args:
+        loss_function: Bound (or unbound) loss callable from the upstream model.
+        logits: Model output logits to score.
+        labels: Ground-truth labels for the loss.
+        vocab_size: Vocabulary size expected by the loss function.
+        upstream_kwargs: Kwargs the outer ``forward`` was invoked with; supplies
+            optional loss inputs like ``num_items_in_batch`` and ``shift_labels``
+            when the upstream caller threaded them in.
+
+    Returns:
+        Kwargs dict restricted to names actually accepted by ``loss_function``.
+
+    Drift coverage:
+        * Silently absorbs upstream additions that appear in ``upstream_kwargs``
+          and are also declared on the loss signature.
+        * Does **not** cover newly-required parameters whose values must be
+          derived from something other than ``upstream_kwargs``. Extend
+          :data:`LOSS_KWARG_SUPPLY_NAMES` and the ``supply`` dict below in
+          lockstep when a new required source needs plumbing.
+    """
+    supply: Dict[str, Any] = {
+        "logits": logits,
+        "labels": labels,
+        "vocab_size": vocab_size,
+        "num_items_in_batch": upstream_kwargs.get("num_items_in_batch"),
+        "shift_labels": upstream_kwargs.get("shift_labels"),
+    }
+    assert set(supply) == LOSS_KWARG_SUPPLY_NAMES, (
+        "build_loss_kwargs_dynamic supply dict must stay in sync with "
+        "LOSS_KWARG_SUPPLY_NAMES; update both together."
+    )
+    accepted = set(_loss_function_parameter_names(loss_function))
+    return {name: value for name, value in supply.items() if name in accepted}
+
+
+def mirror_output_fields(
+    output_cls: type,
+    source_output: Any,
+    **overrides: Any,
+) -> Any:
+    """Construct ``output_cls`` by mirroring fields from ``source_output``.
+
+    For each field declared on ``output_cls`` (which must be a dataclass, as HF
+    ``ModelOutput`` subclasses are), the value is chosen in this order:
+
+    1. Use the caller-supplied override if the field name is in ``overrides``.
+    2. Otherwise, copy ``getattr(source_output, name)`` when present.
+    3. Otherwise, omit the field and let the dataclass default apply. If the
+       field has no default, dataclass ``__init__`` raises ``TypeError``, which
+       intentionally makes the drift loud instead of silently zero-filling.
+
+    Drift coverage:
+        * Silently mirrors new optional fields added to both the source model
+          output and ``output_cls`` (e.g. a future ``image_hidden_states``).
+        * Loudly fails when ``output_cls`` grows a new *required* field that
+          the source model output does not carry — signaling that the wrapper
+          needs to supply that field explicitly via ``overrides``.
+
+    Args:
+        output_cls: Dataclass type (typically an HF ``ModelOutput`` subclass).
+        source_output: Object whose attributes populate non-override fields.
+            Duck-typed via ``hasattr``/``getattr`` so tests can pass simple
+            namespaces in place of real HF outputs.
+        **overrides: Field values that take precedence over ``source_output``.
+
+    Returns:
+        An instance of ``output_cls`` with mirrored + overridden fields.
+    """
+    kwargs: Dict[str, Any] = {}
+    for field in dataclasses.fields(output_cls):
+        name = field.name
+        if name in overrides:
+            kwargs[name] = overrides[name]
+        elif hasattr(source_output, name):
+            kwargs[name] = getattr(source_output, name)
+    return output_cls(**kwargs)
 
 
 def with_mobilint_generation_signature(wrapped: Callable, *extra_keyword_names: str) -> Callable:

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -99,17 +99,21 @@ def llm_eagle3_forward(
 
 @lru_cache(maxsize=None)
 def upstream_positional_params(func: Callable) -> tuple[str, ...]:
-    """Return the non-``self`` positional parameter names of ``func``.
+    """Return the positional-bindable parameter names of ``func`` (excluding ``self``).
 
-    ``*args`` (``VAR_POSITIONAL``) and ``**kwargs`` (``VAR_KEYWORD``) parameters are
-    excluded. Cached per callable so ``inspect.signature`` is not re-parsed on every
-    wrapper call in the generation loop.
+    Only ``POSITIONAL_ONLY`` and ``POSITIONAL_OR_KEYWORD`` parameters are returned —
+    i.e. names that a caller's positional ``*args`` can bind to under normal Python
+    semantics. ``KEYWORD_ONLY``, ``VAR_POSITIONAL`` (``*args``), and ``VAR_KEYWORD``
+    (``**kwargs``) parameters are excluded, so ``zip``-ing the result with a caller's
+    positional args cannot silently misbind a value to a keyword-only parameter.
+    Cached per callable so ``inspect.signature`` is not re-parsed on every wrapper
+    call in the generation loop.
     """
     return tuple(
         name
         for name, parameter in inspect.signature(func).parameters.items()
         if name != "self"
-        and parameter.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+        and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
     )
 
 

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -99,6 +99,21 @@ def llm_eagle3_forward(
 
 
 @lru_cache(maxsize=None)
+def _upstream_positional_params_cached(func: Callable) -> tuple[str, ...]:
+    """Cached body of :func:`upstream_positional_params`.
+
+    Callers must pass an already ``inspect.unwrap``-ed callable; the public
+    wrapper is responsible for that normalization so wrapped and underlying
+    functions share this cache entry (see :func:`upstream_positional_params`).
+    """
+    return tuple(
+        name
+        for name, parameter in inspect.signature(func).parameters.items()
+        if name != "self"
+        and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    )
+
+
 def upstream_positional_params(func: Callable) -> tuple[str, ...]:
     """Return the positional-bindable parameter names of ``func`` (excluding ``self``).
 
@@ -109,12 +124,15 @@ def upstream_positional_params(func: Callable) -> tuple[str, ...]:
     positional args cannot silently misbind a value to a keyword-only parameter.
 
     Caching policy:
-        ``@lru_cache(maxsize=None)`` gives us per-callable memoization so
+        The signature parse is memoized on the unwrapped callable so
         ``inspect.signature`` is not re-parsed on every wrapper invocation inside
         the generation loop (this helper is called on the hot path of each
         ``prepare_inputs_for_generation`` / ``forward`` call). ``inspect.unwrap``
-        collapses ``__wrapped__`` chains so ``@functools.wraps``-decorated wrappers
-        share a cache entry with their underlying function.
+        runs in this outer wrapper — **before** the cache lookup — so
+        ``@functools.wraps``-decorated wrappers and their underlying function
+        share a cache entry. Doing the unwrap inside a cached body would not
+        achieve this: ``functools.lru_cache`` keys on the arguments the wrapper
+        receives, so wrapped and unwrapped callables would occupy distinct entries.
 
     Boundedness assumption:
         The unbounded cache is safe **only** because callers are expected to invoke
@@ -133,40 +151,17 @@ def upstream_positional_params(func: Callable) -> tuple[str, ...]:
         ``Signature`` object. If such dynamic callables must be supported in the
         future, switch to a bounded ``maxsize`` or a ``WeakKeyDictionary``-based cache.
     """
-    func = inspect.unwrap(func)
-    return tuple(
-        name
-        for name, parameter in inspect.signature(func).parameters.items()
-        if name != "self"
-        and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-    )
+    return _upstream_positional_params_cached(inspect.unwrap(func))
 
 
 @lru_cache(maxsize=None)
-def _loss_function_parameter_names(loss_function: Callable) -> tuple[str, ...]:
-    """Return the named parameters of ``loss_function`` (excluding ``*args``/``**kwargs``).
+def _loss_function_parameter_names_cached(loss_function: Callable) -> tuple[str, ...]:
+    """Cached body of :func:`_loss_function_parameter_names`.
 
-    Only ``POSITIONAL_ONLY``, ``POSITIONAL_OR_KEYWORD``, and ``KEYWORD_ONLY``
-    parameters are returned. Variadic parameters (``*args``, ``**kwargs``) are
-    excluded because they do not carry a fixed name we can supply against.
-
-    Caching policy:
-        ``inspect.signature`` is memoized per ``loss_function`` because
-        :func:`build_loss_kwargs_dynamic` is called on the hot decoding path,
-        while the underlying signature is static per loss implementation.
-        ``inspect.unwrap`` collapses ``__wrapped__`` chains so
-        ``@functools.wraps``-decorated loss wrappers share a cache entry with
-        their underlying function.
-
-    Boundedness assumption:
-        Callers pass a small, fixed set of upstream loss callables
-        (``ForCausalLMLoss`` and siblings), so the unbounded cache saturates
-        at a handful of entries. Do **not** pass freshly constructed callables
-        that ``inspect.unwrap`` cannot normalize (lambdas, ``functools.partial``
-        results, per-call closures) — each distinct object is a new cache key
-        and would leak memory.
+    Callers must pass an already ``inspect.unwrap``-ed callable; the public
+    wrapper is responsible for that normalization so wrapped and underlying
+    loss functions share this cache entry.
     """
-    loss_function = inspect.unwrap(loss_function)
     parameters = inspect.signature(loss_function).parameters
     return tuple(
         name
@@ -178,6 +173,34 @@ def _loss_function_parameter_names(loss_function: Callable) -> tuple[str, ...]:
             inspect.Parameter.KEYWORD_ONLY,
         )
     )
+
+
+def _loss_function_parameter_names(loss_function: Callable) -> tuple[str, ...]:
+    """Return the named parameters of ``loss_function`` (excluding ``*args``/``**kwargs``).
+
+    Only ``POSITIONAL_ONLY``, ``POSITIONAL_OR_KEYWORD``, and ``KEYWORD_ONLY``
+    parameters are returned. Variadic parameters (``*args``, ``**kwargs``) are
+    excluded because they do not carry a fixed name we can supply against.
+
+    Caching policy:
+        ``inspect.signature`` is memoized per unwrapped ``loss_function`` because
+        :func:`build_loss_kwargs_dynamic` is called on the hot decoding path,
+        while the underlying signature is static per loss implementation.
+        ``inspect.unwrap`` runs in this outer wrapper — **before** the cache
+        lookup — so ``@functools.wraps``-decorated loss wrappers share a cache
+        entry with their underlying function. Unwrapping inside a cached body
+        would not achieve this: ``functools.lru_cache`` keys on the arguments
+        the wrapper receives.
+
+    Boundedness assumption:
+        Callers pass a small, fixed set of upstream loss callables
+        (``ForCausalLMLoss`` and siblings), so the unbounded cache saturates
+        at a handful of entries. Do **not** pass freshly constructed callables
+        that ``inspect.unwrap`` cannot normalize (lambdas, ``functools.partial``
+        results, per-call closures) — each distinct object is a new cache key
+        and would leak memory.
+    """
+    return _loss_function_parameter_names_cached(inspect.unwrap(loss_function))
 
 
 # Kwarg names that :func:`build_loss_kwargs_dynamic` knows how to supply to

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -1,6 +1,6 @@
 import inspect
 from abc import ABC
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import Any, Callable, Dict, Optional, cast
 
 import qbruntime
@@ -94,6 +94,20 @@ def llm_eagle3_forward(
         past_key_values=past_key_values,
         hidden_states=hidden_states,
         attentions=None,
+    )
+
+
+@lru_cache(maxsize=None)
+def upstream_positional_params(func: Callable) -> tuple[str, ...]:
+    """Return the non-``self`` positional parameter names of ``func``.
+
+    ``**kwargs`` (``VAR_KEYWORD``) parameters are excluded. Cached per callable so
+    ``inspect.signature`` is not re-parsed on every wrapper call in the generation loop.
+    """
+    return tuple(
+        name
+        for name, parameter in inspect.signature(func).parameters.items()
+        if name != "self" and parameter.kind != inspect.Parameter.VAR_KEYWORD
     )
 
 

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -262,19 +262,30 @@ def mirror_output_fields(
     Args:
         output_cls: Dataclass type (typically an HF ``ModelOutput`` subclass).
         source_output: Object whose attributes populate non-override fields.
-            Duck-typed via ``hasattr``/``getattr`` so tests can pass simple
-            namespaces in place of real HF outputs.
+            When ``source_output`` is itself a dataclass (the prod case — HF
+            ``ModelOutput`` subclasses are dataclasses), only its declared
+            fields are eligible for mirroring, so future upstream additions of
+            non-field attributes whose names collide with ``output_cls`` fields
+            (e.g. ``to_tuple``, ``keys``) cannot silently smuggle a wrong value
+            through. Non-dataclass sources fall back to ``hasattr``/``getattr``
+            so tests can pass simple namespaces in place of real HF outputs.
         **overrides: Field values that take precedence over ``source_output``.
 
     Returns:
         An instance of ``output_cls`` with mirrored + overridden fields.
     """
+    if dataclasses.is_dataclass(source_output):
+        mirrorable = {field.name for field in dataclasses.fields(source_output)}
+        is_mirrorable = mirrorable.__contains__
+    else:
+        is_mirrorable = lambda name: hasattr(source_output, name)  # noqa: E731
+
     kwargs: Dict[str, Any] = {}
     for field in dataclasses.fields(output_cls):
         name = field.name
         if name in overrides:
             kwargs[name] = overrides[name]
-        elif hasattr(source_output, name):
+        elif is_mirrorable(name):
             kwargs[name] = getattr(source_output, name)
     return output_cls(**kwargs)
 

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -101,13 +101,15 @@ def llm_eagle3_forward(
 def upstream_positional_params(func: Callable) -> tuple[str, ...]:
     """Return the non-``self`` positional parameter names of ``func``.
 
-    ``**kwargs`` (``VAR_KEYWORD``) parameters are excluded. Cached per callable so
-    ``inspect.signature`` is not re-parsed on every wrapper call in the generation loop.
+    ``*args`` (``VAR_POSITIONAL``) and ``**kwargs`` (``VAR_KEYWORD``) parameters are
+    excluded. Cached per callable so ``inspect.signature`` is not re-parsed on every
+    wrapper call in the generation loop.
     """
     return tuple(
         name
         for name, parameter in inspect.signature(func).parameters.items()
-        if name != "self" and parameter.kind != inspect.Parameter.VAR_KEYWORD
+        if name != "self"
+        and parameter.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
     )
 
 

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -112,7 +112,9 @@ def upstream_positional_params(func: Callable) -> tuple[str, ...]:
         ``@lru_cache(maxsize=None)`` gives us per-callable memoization so
         ``inspect.signature`` is not re-parsed on every wrapper invocation inside
         the generation loop (this helper is called on the hot path of each
-        ``prepare_inputs_for_generation`` / ``forward`` call).
+        ``prepare_inputs_for_generation`` / ``forward`` call). ``inspect.unwrap``
+        collapses ``__wrapped__`` chains so ``@functools.wraps``-decorated wrappers
+        share a cache entry with their underlying function.
 
     Boundedness assumption:
         The unbounded cache is safe **only** because callers are expected to invoke
@@ -124,13 +126,14 @@ def upstream_positional_params(func: Callable) -> tuple[str, ...]:
 
     Warning:
         Do **not** call this function in a loop with freshly constructed callables
-        (e.g. ``lambda``\ s, ``functools.partial`` results, or dynamically wrapped
-        methods created per iteration). Each distinct callable is a new cache key,
-        and because ``maxsize=None`` never evicts, this would leak memory
-        indefinitely by pinning the callable and its parsed ``Signature`` object.
-        If dynamic callables must be supported in the future, switch to a bounded
-        ``maxsize`` or a ``WeakKeyDictionary``-based cache.
+        that ``inspect.unwrap`` cannot normalize — e.g. ``lambda``\ s,
+        ``functools.partial`` results, or per-iteration closures. Each distinct
+        callable is a new cache key, and because ``maxsize=None`` never evicts,
+        this would leak memory indefinitely by pinning the callable and its parsed
+        ``Signature`` object. If such dynamic callables must be supported in the
+        future, switch to a bounded ``maxsize`` or a ``WeakKeyDictionary``-based cache.
     """
+    func = inspect.unwrap(func)
     return tuple(
         name
         for name, parameter in inspect.signature(func).parameters.items()
@@ -151,14 +154,19 @@ def _loss_function_parameter_names(loss_function: Callable) -> tuple[str, ...]:
         ``inspect.signature`` is memoized per ``loss_function`` because
         :func:`build_loss_kwargs_dynamic` is called on the hot decoding path,
         while the underlying signature is static per loss implementation.
+        ``inspect.unwrap`` collapses ``__wrapped__`` chains so
+        ``@functools.wraps``-decorated loss wrappers share a cache entry with
+        their underlying function.
 
     Boundedness assumption:
         Callers pass a small, fixed set of upstream loss callables
         (``ForCausalLMLoss`` and siblings), so the unbounded cache saturates
         at a handful of entries. Do **not** pass freshly constructed callables
-        here (lambdas, ``functools.partial`` results, per-call closures) — each
-        distinct object is a new cache key and would leak memory.
+        that ``inspect.unwrap`` cannot normalize (lambdas, ``functools.partial``
+        results, per-call closures) — each distinct object is a new cache key
+        and would leak memory.
     """
+    loss_function = inspect.unwrap(loss_function)
     parameters = inspect.signature(loss_function).parameters
     return tuple(
         name

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -106,8 +106,29 @@ def upstream_positional_params(func: Callable) -> tuple[str, ...]:
     semantics. ``KEYWORD_ONLY``, ``VAR_POSITIONAL`` (``*args``), and ``VAR_KEYWORD``
     (``**kwargs``) parameters are excluded, so ``zip``-ing the result with a caller's
     positional args cannot silently misbind a value to a keyword-only parameter.
-    Cached per callable so ``inspect.signature`` is not re-parsed on every wrapper
-    call in the generation loop.
+
+    Caching policy:
+        ``@lru_cache(maxsize=None)`` gives us per-callable memoization so
+        ``inspect.signature`` is not re-parsed on every wrapper invocation inside
+        the generation loop (this helper is called on the hot path of each
+        ``prepare_inputs_for_generation`` / ``forward`` call).
+
+    Boundedness assumption:
+        The unbounded cache is safe **only** because callers are expected to invoke
+        this function with a small, fixed set of upstream methods — e.g.
+        ``Qwen2VLForConditionalGeneration.forward`` or
+        ``GenerationMixin.prepare_inputs_for_generation`` — whose function objects
+        are module-level and interned for the lifetime of the process. Under that
+        contract the cache saturates at a handful of entries and never grows.
+
+    Warning:
+        Do **not** call this function in a loop with freshly constructed callables
+        (e.g. ``lambda``\ s, ``functools.partial`` results, or dynamically wrapped
+        methods created per iteration). Each distinct callable is a new cache key,
+        and because ``maxsize=None`` never evicts, this would leak memory
+        indefinitely by pinning the callable and its parsed ``Signature`` object.
+        If dynamic callables must be supported in the future, switch to a bounded
+        ``maxsize`` or a ``WeakKeyDictionary``-based cache.
     """
     return tuple(
         name

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -2,7 +2,7 @@ import dataclasses
 import inspect
 from abc import ABC
 from functools import lru_cache, wraps
-from typing import Any, Callable, Dict, Mapping, Optional, cast
+from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional, cast
 
 import qbruntime
 import torch
@@ -203,14 +203,45 @@ def _loss_function_parameter_names(loss_function: Callable) -> tuple[str, ...]:
     return _loss_function_parameter_names_cached(inspect.unwrap(loss_function))
 
 
+# Kwarg names that :func:`build_loss_kwargs_dynamic` reads from the outer
+# ``forward``'s ``kwargs`` mapping. These are LOSS-ONLY: they carry no meaning
+# for the inner text model and MUST NOT be forwarded to it — some inner text
+# models (e.g. ``MobilintQwen2VLTextModel``) declare no ``**kwargs`` sink and
+# would raise ``TypeError`` on unexpected loss-only kwargs. Wrappers should
+# strip these names via :func:`pop_loss_only_kwargs` before calling
+# ``self.model``.
+LOSS_ONLY_UPSTREAM_KWARG_NAMES: frozenset[str] = frozenset(
+    {"num_items_in_batch", "shift_labels"}
+)
+
 # Kwarg names that :func:`build_loss_kwargs_dynamic` knows how to supply to
 # upstream loss functions. Exposed so contract tests can assert that all
 # required loss parameters upstream currently declares are covered here.
 # Extend this set (and update the helper below) when a newly-required loss
 # parameter needs a value source beyond the outer ``forward``'s ``kwargs``.
-LOSS_KWARG_SUPPLY_NAMES: frozenset[str] = frozenset(
-    {"logits", "labels", "vocab_size", "num_items_in_batch", "shift_labels"}
+LOSS_KWARG_SUPPLY_NAMES: frozenset[str] = (
+    frozenset({"logits", "labels", "vocab_size"}) | LOSS_ONLY_UPSTREAM_KWARG_NAMES
 )
+
+
+def pop_loss_only_kwargs(kwargs: MutableMapping[str, Any]) -> Dict[str, Any]:
+    """Pop loss-only kwargs out of ``kwargs`` into a separate mapping.
+
+    The names in :data:`LOSS_ONLY_UPSTREAM_KWARG_NAMES` are consumed by
+    :func:`build_loss_kwargs_dynamic` and must not flow into the wrapper's
+    inner model call — the upstream VL ``Model.forward`` forwards its own
+    ``**kwargs`` to ``self.language_model``, and the Mobilint text models
+    accept only a fixed set of named parameters. Loss-only kwargs like
+    ``num_items_in_batch`` would otherwise raise ``TypeError`` there.
+
+    Args:
+        kwargs: The outer ``forward`` wrapper's live ``kwargs`` mapping.
+
+    Returns:
+        A new dict containing the popped loss-only kwargs; suitable to pass as
+        ``upstream_kwargs`` to :func:`build_loss_kwargs_dynamic`.
+    """
+    return {name: kwargs.pop(name) for name in LOSS_ONLY_UPSTREAM_KWARG_NAMES if name in kwargs}
 
 
 def build_loss_kwargs_dynamic(
@@ -235,7 +266,9 @@ def build_loss_kwargs_dynamic(
         vocab_size: Vocabulary size expected by the loss function.
         upstream_kwargs: Kwargs the outer ``forward`` was invoked with; supplies
             optional loss inputs like ``num_items_in_batch`` and ``shift_labels``
-            when the upstream caller threaded them in.
+            when the upstream caller threaded them in. Callers should first
+            strip these with :func:`pop_loss_only_kwargs` so they don't leak
+            into the inner model, then pass the popped mapping here.
 
     Returns:
         Kwargs dict restricted to names actually accepted by ``loss_function``.
@@ -245,16 +278,18 @@ def build_loss_kwargs_dynamic(
           and are also declared on the loss signature.
         * Does **not** cover newly-required parameters whose values must be
           derived from something other than ``upstream_kwargs``. Extend
-          :data:`LOSS_KWARG_SUPPLY_NAMES` and the ``supply`` dict below in
-          lockstep when a new required source needs plumbing.
+          :data:`LOSS_ONLY_UPSTREAM_KWARG_NAMES` when a new upstream-sourced
+          loss kwarg needs plumbing, or :data:`LOSS_KWARG_SUPPLY_NAMES` and
+          the ``supply`` dict below in lockstep when a new required source
+          needs to come from somewhere other than ``upstream_kwargs``.
     """
     supply: Dict[str, Any] = {
         "logits": logits,
         "labels": labels,
         "vocab_size": vocab_size,
-        "num_items_in_batch": upstream_kwargs.get("num_items_in_batch"),
-        "shift_labels": upstream_kwargs.get("shift_labels"),
     }
+    for name in LOSS_ONLY_UPSTREAM_KWARG_NAMES:
+        supply[name] = upstream_kwargs.get(name)
     accepted = set(_loss_function_parameter_names(loss_function))
     return {name: value for name, value in supply.items() if name in accepted}
 

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -224,10 +224,6 @@ def build_loss_kwargs_dynamic(
         "num_items_in_batch": upstream_kwargs.get("num_items_in_batch"),
         "shift_labels": upstream_kwargs.get("shift_labels"),
     }
-    assert set(supply) == LOSS_KWARG_SUPPLY_NAMES, (
-        "build_loss_kwargs_dynamic supply dict must stay in sync with "
-        "LOSS_KWARG_SUPPLY_NAMES; update both together."
-    )
     accepted = set(_loss_function_parameter_names(loss_function))
     return {name: value for name, value in supply.items() if name in accepted}
 

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -199,7 +199,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             "build triggers a fallback that runs one MXQ infer per kept "
             "position and is dramatically slower than the last-token fast "
             "path (`logits_to_keep=1`) on long prefills. Model `.forward()` "
-            "wrappers (e.g. Qwen2/EXAONE4/Cohere2/BLIP) default to "
+            "wrappers (e.g. Qwen2/EXAONE4/Cohere2) default to "
             "`logits_to_keep=0` (HF-style keep-all), which lands on this "
             "slow path; pass `logits_to_keep=1` for last-token workloads. "
             "HF `.generate()` already sets this automatically, so this "

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -187,13 +187,16 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         if getattr(self, "_mxq_last_only_slow_path_warned", False):
             return
         warnings.warn(
-            "Non-default `logits_to_keep` on a last-only MXQ build triggers a "
-            "fallback that runs one MXQ infer per kept position and is "
-            "dramatically slower than the default on long prefills. Pass "
-            "`logits_to_keep=1` for last-token workloads; HF `.generate()` "
-            "already sets this automatically, so this warning does not "
-            "indicate a bug in generation. This message fires once per "
-            "model instance.",
+            "Keep-all or multi-position `logits_to_keep` on a last-only MXQ "
+            "build triggers a fallback that runs one MXQ infer per kept "
+            "position and is dramatically slower than the last-token fast "
+            "path (`logits_to_keep=1`) on long prefills. Model `.forward()` "
+            "wrappers (e.g. Qwen2/EXAONE4/Cohere2/BLIP) default to "
+            "`logits_to_keep=0` (HF-style keep-all), which lands on this "
+            "slow path; pass `logits_to_keep=1` for last-token workloads. "
+            "HF `.generate()` already sets this automatically, so this "
+            "warning does not indicate a bug in generation. This message "
+            "fires once per model instance.",
             category=UserWarning,
             stacklevel=4,
         )

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -621,6 +621,20 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             inputs_embeds_masked = [inputs_embeds[i, :, :] for i in range(batch_size)]
             sequence_lengths = [1 for _ in range(batch_size)]
 
+        # Fire before any is_default_keep / supports_all decisions so the three
+        # paths agree: a zero-length row is a hard error regardless of the
+        # logits_to_keep selector. Previously only Path 1 raised while Path 2
+        # and Path 3 silently right-padded such rows with -inf, so the same
+        # batch could fail on logits_to_keep=1 and pass on logits_to_keep=0.
+        zero_length_rows = [
+            row_index for row_index, sequence_length in enumerate(sequence_lengths) if sequence_length == 0
+        ]
+        if zero_length_rows:
+            raise ValueError(
+                "Batched LLM inputs contain empty sequences after applying attention_mask. "
+                f"Zero-length rows: {zero_length_rows}"
+            )
+
         if debug_enabled:
             logger.debug(
                 "[BATCH-LLM][START] inputs_embeds=%s attention_mask=%s batch_size=%d sequence_lengths=%s",
@@ -707,14 +721,6 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # contract regressions stay visible.
         # ------------------------------------------------------------------
         if is_default_keep:
-            zero_length_rows = [
-                row_index for row_index, sequence_length in enumerate(sequence_lengths) if sequence_length == 0
-            ]
-            if zero_length_rows:
-                raise ValueError(
-                    "Batched LLM inputs contain empty sequences after applying attention_mask. "
-                    f"Zero-length rows: {zero_length_rows}"
-                )
             num_of_chunks = math.ceil(max_sequence_length / prefill_chunk_size)
             logits_dict: dict[int, torch.Tensor] = {}
 

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -1187,14 +1187,17 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             max_keep_len = max((item.shape[0] for item in per_item_sliced), default=0)
             if max_keep_len == 0:
                 # No batch item had any kept positions (e.g. empty-tensor
-                # selector). Return the (batch, 0, 0) shape contract explicitly
-                # so we don't rely on the torch.full((0, 0), -inf) idiom in the
-                # padding loop silently degenerating to a no-op when future
-                # refactors change how max_keep_len / vocab_size are computed.
+                # selector). Return (batch, 0, vocab) so the compiled vocab
+                # axis is preserved — Path 3's empty-selector fallback and
+                # HF's ``hidden_states[:, empty, :]`` -> LM head both keep
+                # the vocab dim, and dropping it here would make the same
+                # ``logits_to_keep=torch.tensor([])`` request return a
+                # different last-dim depending on the batched vs single
+                # entry point.
                 return cast(
                     torch.FloatTensor,
                     torch.zeros(
-                        (batch_size, 0, 0),
+                        (batch_size, 0, mxq_vocab_size),
                         dtype=inputs_embeds.dtype,
                         device=inputs_embeds.device,
                     ),
@@ -1341,14 +1344,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         max_keep_len = max((item.shape[0] for item in per_item_final), default=0)
         if max_keep_len == 0:
             # No batch item had any kept positions (e.g. empty-tensor selector).
-            # Return the (batch, 0, 0) shape contract explicitly so we don't
-            # rely on the torch.full((0, 0), -inf) idiom in the padding loop
-            # silently degenerating to a no-op when future refactors change
-            # how max_keep_len / vocab_size are computed.
+            # Return (batch, 0, vocab) so the compiled vocab axis is preserved,
+            # matching Path 2's batched empty branch, Path 3's single-input
+            # fallback (see :meth:`_mxq_static_vocab_size`), and HF's
+            # ``hidden_states[:, empty, :]`` -> LM head -> ``(batch, 0, vocab)``
+            # contract.
             return cast(
                 torch.FloatTensor,
                 torch.zeros(
-                    (batch_size, 0, 0),
+                    (batch_size, 0, self._mxq_static_vocab_size()),
                     dtype=inputs_embeds.dtype,
                     device=inputs_embeds.device,
                 ),

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -461,8 +461,11 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             A ``torch.Tensor`` with a leading batch axis of size 1. The
             trailing shape depends on which path ran:
 
-            * Path 1 (last-only fast): ``(1, 1, vocab)`` — the raw
-              last-chunk ``do_infer`` output, returned as-is.
+            * Path 1 (last-only fast): ``(1, 1, vocab)`` — the last row
+              of the final chunk's ``do_infer`` output. Static last-only
+              MXQ already emits a single-row payload; dynamic-axis MXQ
+              returns the whole chunk, so the token axis is sliced to
+              ``[-1:]`` before returning.
             * Path 2 (dynamic-axis): ``(1, kept_positions, vocab)`` where
               ``kept_positions == len(_output_positions_for_logits_to_keep(
               logits_to_keep, seq_len))`` (caller order and duplicates are
@@ -527,6 +530,16 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                     assert logits_ndarray is not None
                     token_axis = logits_ndarray.ndim - 2
                     logits_ndarray = np.take(logits_ndarray, [], axis=token_axis)
+            else:
+                # Path 1 (keep-last): a static last-only MXQ already emits a
+                # single-row payload, but a dynamic-axis MXQ returns every
+                # position of the final chunk. Slice down to the last row so
+                # the returned shape stays (1, 1, vocab) regardless of the
+                # backend's token-axis shape.
+                assert logits_ndarray is not None
+                token_axis = logits_ndarray.ndim - 2
+                if logits_ndarray.shape[token_axis] > 1:
+                    logits_ndarray = np.take(logits_ndarray, [-1], axis=token_axis)
 
             assert logits_ndarray is not None
             return torch.tensor(logits_ndarray, dtype=dtype, device=device)

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -250,6 +250,13 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         ``torch.tensor([seq_len - 1])`` are asking for the same last-token
         logit as ``logits_to_keep=1`` and should hit Path 1 identically
         rather than probing the dynamic axis and taking Path 2/3.
+
+        Note: call sites may pre-filter ``int==1`` before calling this
+        helper. ``_llm_forward_batch`` does (its fast pre-check short-
+        circuits before reaching here, so this method only meaningfully
+        evaluates tensor selectors there), while the single-input
+        dispatch in ``_run_chunked_logits_to_keep`` does not — so the
+        ``int==1`` branch below is not globally dead.
         """
         if isinstance(logits_to_keep, int) and logits_to_keep == 1:
             return True
@@ -612,6 +619,8 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         if isinstance(logits_to_keep, int) and logits_to_keep == 1:
             is_default_keep = True
         else:
+            # int==1 is handled by the fast pre-check above, so the call
+            # below only meaningfully evaluates torch.Tensor selectors.
             lens_equal = all(sl == sequence_lengths[0] for sl in sequence_lengths)
             is_default_keep = lens_equal and self._is_last_only_selector(
                 logits_to_keep, sequence_lengths[0]

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import time
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Optional, Union, cast
 
 import numpy as np
@@ -167,7 +168,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         timing[f"{phase}_calls"] = int(timing.get(f"{phase}_calls", 0)) + 1
 
     def _warn_last_only_slow_path_once(self) -> None:
-        """Emit a one-shot WARNING when a call enters the last-only MXQ Path 3.
+        """Emit a one-shot ``UserWarning`` when a call enters the last-only MXQ Path 3.
 
         Path 3 runs one MXQ infer per kept position, so a manual
         ``.forward()`` with the default ``logits_to_keep=0`` on a
@@ -175,17 +176,26 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         HF-generate case (which sets ``logits_to_keep=1``). Docstrings
         alone don't surface this; a stderr warning does. Fires at most
         once per instance so long training / eval loops don't spam.
+
+        Uses ``warnings.warn`` (not ``logger.warning``) so the reported
+        location is the caller's, not this file — that reveals *which*
+        user call triggered the slow path. ``stacklevel=4`` skips this
+        helper, the Path 3 site inside ``_run_chunked_logits_to_keep`` /
+        ``_llm_forward_batch``, and the ``llm_forward`` dispatcher, so
+        the warning is attributed to whoever invoked ``llm_forward``.
         """
         if getattr(self, "_mxq_last_only_slow_path_warned", False):
             return
-        logger.warning(
+        warnings.warn(
             "Non-default `logits_to_keep` on a last-only MXQ build triggers a "
             "fallback that runs one MXQ infer per kept position and is "
             "dramatically slower than the default on long prefills. Pass "
             "`logits_to_keep=1` for last-token workloads; HF `.generate()` "
             "already sets this automatically, so this warning does not "
             "indicate a bug in generation. This message fires once per "
-            "model instance."
+            "model instance.",
+            category=UserWarning,
+            stacklevel=4,
         )
         self._mxq_last_only_slow_path_warned = True
 

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -568,7 +568,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             sequence_lengths_chunks_l: list[int],
             cache_sizes_chunks_l: list[int],
             inputs_embeds_chunks_l: list[torch.Tensor],
-        ) -> np.ndarray:
+        ) -> tuple[np.ndarray, tuple[int, ...]]:
             inputs_embeds_concat_l = torch.concat(inputs_embeds_chunks_l, dim=0).unsqueeze(0)
             inputs_embeds_numpy_l: np.ndarray = inputs_embeds_concat_l.type(torch.float32).cpu().numpy()
             if inputs_embeds_numpy_l.ndim == 3:
@@ -596,7 +596,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             else:
                 result_l = mxq_model.infer([inputs_embeds_numpy_l], None, 0, batch_params_l)
             assert result_l is not None, "mxq infer result is None!"
-            return result_l[0]
+            return result_l[0], inputs_embeds_numpy_l.shape
 
         # ------------------------------------------------------------------
         # Path 1: default fast path (logits_to_keep == 1). Preserved
@@ -640,11 +640,17 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 if len(inputs_embeds_chunks) == 0:
                     continue
 
+                raw_output, inputs_embeds_numpy_shape = _run_batch_infer(
+                    cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
+                )
+                logits_chunks = cast(
+                    torch.FloatTensor,
+                    torch.tensor(raw_output, dtype=inputs_embeds.dtype, device=inputs_embeds.device).reshape(
+                        [len(cache_ids), 1, -1]
+                    ),
+                )
+
                 if debug_enabled:
-                    inputs_embeds_concat_dbg = torch.concat(inputs_embeds_chunks, dim=0).unsqueeze(0)
-                    inputs_embeds_numpy_dbg = inputs_embeds_concat_dbg.type(torch.float32).cpu().numpy()
-                    if inputs_embeds_numpy_dbg.ndim == 3:
-                        inputs_embeds_numpy_dbg = np.expand_dims(inputs_embeds_numpy_dbg, 1)
                     batch_seq_sum = sum(sequence_lengths_chunks)
                     logger.debug(
                         (
@@ -659,7 +665,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                         sequence_lengths_chunks,
                         cache_sizes_chunks,
                         prefill_masks,
-                        tuple(inputs_embeds_numpy_dbg.shape),
+                        tuple(inputs_embeds_numpy_shape),
                         batch_seq_sum,
                     )
                     logger.debug(
@@ -686,18 +692,6 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                         num_of_chunks,
                         input_batch_same,
                     )
-
-                raw_output = _run_batch_infer(
-                    cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
-                )
-                logits_chunks = cast(
-                    torch.FloatTensor,
-                    torch.tensor(raw_output, dtype=inputs_embeds.dtype, device=inputs_embeds.device).reshape(
-                        [len(cache_ids), 1, -1]
-                    ),
-                )
-
-                if debug_enabled:
                     first_logits = logits_chunks[0]
                     result_batch_same = all(torch.equal(chunk, first_logits) for chunk in logits_chunks[1:])
                     next_tokens = logits_chunks[:, -1, :].argmax(dim=-1).tolist()
@@ -802,7 +796,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 if len(inputs_embeds_chunks) == 0:
                     continue
 
-                raw_output = _run_batch_infer(
+                raw_output, _ = _run_batch_infer(
                     cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
                 )
 
@@ -941,7 +935,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 cursor += chunk
                 continue
 
-            raw_output = _run_batch_infer(
+            raw_output, _ = _run_batch_infer(
                 cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
             )
             logits_chunks = cast(

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -199,10 +199,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                     and int(first_shape[_MXQ_TOKEN_AXIS_INDEX]) == _MXQ_DYNAMIC_AXIS_SENTINEL
                 ):
                     supports = True
-        except (AttributeError, RuntimeError):
+        except (AttributeError, qbruntime.QbRuntimeError):
             # AttributeError: backend or ``get_model_output_shape`` missing.
-            # RuntimeError: backend refused the probe (``qbruntime.QbRuntimeError``
-            # is a ``RuntimeError`` subclass). Any other exception is a real bug
+            # QbRuntimeError: backend refused the probe. Only backend-specific
+            # probe failures are swallowed; any other exception is a real bug
             # and should propagate.
             supports = False
         self._mxq_all_logits_cached = supports

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -821,6 +821,20 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 )
 
             max_keep_len = max((item.shape[0] for item in per_item_sliced), default=0)
+            if max_keep_len == 0:
+                # No batch item had any kept positions (e.g. empty-tensor
+                # selector). Return the (batch, 0, 0) shape contract explicitly
+                # so we don't rely on the torch.full((0, 0), -inf) idiom in the
+                # padding loop silently degenerating to a no-op when future
+                # refactors change how max_keep_len / vocab_size are computed.
+                return cast(
+                    torch.FloatTensor,
+                    torch.zeros(
+                        (batch_size, 0, 0),
+                        dtype=inputs_embeds.dtype,
+                        device=inputs_embeds.device,
+                    ),
+                )
             padded: list[torch.Tensor] = []
             for item in per_item_sliced:
                 if item.shape[0] < max_keep_len:
@@ -947,6 +961,20 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             per_item_final.append(item_logits)
 
         max_keep_len = max((item.shape[0] for item in per_item_final), default=0)
+        if max_keep_len == 0:
+            # No batch item had any kept positions (e.g. empty-tensor selector).
+            # Return the (batch, 0, 0) shape contract explicitly so we don't
+            # rely on the torch.full((0, 0), -inf) idiom in the padding loop
+            # silently degenerating to a no-op when future refactors change
+            # how max_keep_len / vocab_size are computed.
+            return cast(
+                torch.FloatTensor,
+                torch.zeros(
+                    (batch_size, 0, 0),
+                    dtype=inputs_embeds.dtype,
+                    device=inputs_embeds.device,
+                ),
+            )
         padded_final: list[torch.Tensor] = []
         for item in per_item_final:
             if item.shape[0] < max_keep_len:

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -983,6 +983,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             inputs_embeds_chunks = []
             seen_tokens = {}
 
+            # Every item still within its sequence gets an infer call at this
+            # cursor so its KV cache advances monotonically through all positions;
+            # this holds even when ptr == len(walk_positions_by_item[j]) — the
+            # size-1 kept-logit capture is gated later by positions_j[ptr] == cursor.
             for j in range(batch_size):
                 end_j = min(cursor + chunk, sequence_lengths[j])
                 if cursor < sequence_lengths[j] and end_j <= sequence_lengths[j]:

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -149,6 +149,29 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         timing[f"{phase}_time"] = float(timing.get(f"{phase}_time", 0.0)) + float(elapsed)
         timing[f"{phase}_calls"] = int(timing.get(f"{phase}_calls", 0)) + 1
 
+    def _warn_last_only_slow_path_once(self) -> None:
+        """Emit a one-shot WARNING when a call enters the last-only MXQ Path 3.
+
+        Path 3 runs one MXQ infer per kept position, so a manual
+        ``.forward()`` with the default ``logits_to_keep=0`` on a
+        last-only compiled model is dramatically slower than the
+        HF-generate case (which sets ``logits_to_keep=1``). Docstrings
+        alone don't surface this; a stderr warning does. Fires at most
+        once per instance so long training / eval loops don't spam.
+        """
+        if getattr(self, "_mxq_last_only_slow_path_warned", False):
+            return
+        logger.warning(
+            "Non-default `logits_to_keep` on a last-only MXQ build triggers a "
+            "fallback that runs one MXQ infer per kept position and is "
+            "dramatically slower than the default on long prefills. Pass "
+            "`logits_to_keep=1` for last-token workloads; HF `.generate()` "
+            "already sets this automatically, so this warning does not "
+            "indicate a bug in generation. This message fires once per "
+            "model instance."
+        )
+        self._mxq_last_only_slow_path_warned = True
+
     def _mxq_supports_all_logits(self) -> bool:
         """Return True when the compiled MXQ emits logits for every input token.
 
@@ -334,6 +357,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # ``walk_positions`` is sorted-unique so the cursor can advance
         # monotonically; ``output_positions`` preserves caller order and
         # duplicates so the final tensor matches HF fancy-indexing.
+        self._warn_last_only_slow_path_once()
         walk_positions = self._walk_positions_for_logits_to_keep(logits_to_keep, seq_len)
         output_positions = self._output_positions_for_logits_to_keep(logits_to_keep, seq_len)
         per_position_logits: dict[int, np.ndarray] = {}
@@ -397,7 +421,8 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         ``.generate()`` are safe because HF sets ``logits_to_keep=1``
         automatically; callers doing manual ``.forward()`` for perplexity
         eval / logit collection should know this cost is inherent to
-        last-only compiled models.
+        last-only compiled models. A runtime WARNING fires once per model
+        instance on the first Path 3 entry to surface the cost.
         """
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         self.npu_time = 0.0 if count_npu_time else None
@@ -490,7 +515,9 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         dramatically slower than ``logits_to_keep=1``. ``.generate()``
         avoids this because HF sets ``logits_to_keep=1`` automatically;
         manual ``.forward()`` callers doing perplexity eval / logit
-        collection incur this cost inherently on last-only builds.
+        collection incur this cost inherently on last-only builds. A
+        runtime WARNING fires once per model instance on the first Path
+        3 entry to surface the cost.
         """
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         batch_size = attention_mask.shape[0]
@@ -866,6 +893,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # position in O(1); duplicates and caller order are restored from
         # ``output_positions_by_item`` when the final tensor is assembled.
         # ------------------------------------------------------------------
+        self._warn_last_only_slow_path_once()
         pointer_by_item: dict[int, int] = {j: 0 for j in range(batch_size)}
         per_item_kept_logits: dict[int, dict[int, torch.Tensor]] = {j: {} for j in range(batch_size)}
         cursor = 0

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -1006,12 +1006,54 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 raw_output, inputs_embeds_numpy_shape = _run_batch_infer(
                     cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
                 )
-                logits_chunks = cast(
-                    torch.FloatTensor,
-                    torch.tensor(raw_output, dtype=inputs_embeds.dtype, device=inputs_embeds.device).reshape(
-                        [len(cache_ids), 1, -1]
-                    ),
-                )
+                # Two runtime layouts show up in practice for default-keep
+                # batched infer:
+                #   * per-item last row -> raw size == active * vocab, i.e.
+                #     the backend already collapsed the token axis (static
+                #     last-only MXQ, or a dynamic-axis MXQ whose batched
+                #     kernel happens to emit one row per item).
+                #   * per-token flat -> raw size == total_tokens * vocab,
+                #     i.e. a truly dynamic-axis backend that streams every
+                #     token row into the output (matches the shared
+                #     ``Path 2`` layout downstream).
+                # ``_mxq_static_vocab_size`` reads the compiled vocab axis
+                # once (cached); using it to disambiguate lets Path 1 stay
+                # correct across both layouts without a routing change.
+                raw_arr = np.asarray(raw_output)
+                active = len(cache_ids)
+                total_tokens = sum(sequence_lengths_chunks)
+                vocab = self._mxq_static_vocab_size()
+                if raw_arr.size == active * vocab:
+                    logits_chunks = cast(
+                        torch.FloatTensor,
+                        torch.tensor(
+                            raw_arr, dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                        ).reshape([active, 1, vocab]),
+                    )
+                elif raw_arr.size == total_tokens * vocab:
+                    # Per-token flat output: pick each item's last row using
+                    # cumulative offsets. Item k occupies rows
+                    # ``[offset, offset + seq_len_k)`` in the flat buffer;
+                    # its default-keep row is the final one.
+                    flat = raw_arr.reshape(total_tokens, vocab)
+                    last_rows = np.empty((active, vocab), dtype=flat.dtype)
+                    offset = 0
+                    for k, len_k in enumerate(sequence_lengths_chunks):
+                        last_rows[k] = flat[offset + len_k - 1]
+                        offset += len_k
+                    logits_chunks = cast(
+                        torch.FloatTensor,
+                        torch.tensor(
+                            last_rows, dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                        ).reshape([active, 1, vocab]),
+                    )
+                else:
+                    raise RuntimeError(
+                        f"Unexpected batched MXQ output size {raw_arr.size} for "
+                        f"active={active}, total_tokens={total_tokens}, vocab={vocab}: "
+                        f"expected {active * vocab} (per-item last row) or "
+                        f"{total_tokens * vocab} (per-token flat)."
+                    )
 
                 if debug_enabled:
                     batch_seq_sum = sum(sequence_lengths_chunks)

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -279,6 +279,48 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         self._mxq_static_vocab_cached = vocab
         return vocab
 
+    def _empty_kept_logits(
+        self,
+        batch_size: int,
+        dtype: torch.dtype,
+        device: Union[torch.device, str],
+    ) -> "torch.FloatTensor":
+        """Return the canonical ``(batch, 0, vocab)`` empty-selector logits.
+
+        All three ``_run_chunked_logits_to_keep`` execution paths (single-
+        input Path 3 fallback, batched Path 2 dynamic-axis, batched Path 3
+        last-only fallback) converge here when the caller's
+        ``logits_to_keep`` selector is empty — the compiled MXQ vocab dim
+        is preserved so the same request returns the same shape regardless
+        of which path handled it, matching HF's ``hidden_states[:, empty, :]``
+        -> LM head -> ``(batch, 0, vocab)`` contract.
+        """
+        return cast(
+            torch.FloatTensor,
+            torch.zeros(
+                (batch_size, 0, self._mxq_static_vocab_size()),
+                dtype=dtype,
+                device=device,
+            ),
+        )
+
+    def _empty_item_kept_logits(
+        self,
+        dtype: torch.dtype,
+        device: Union[torch.device, str],
+    ) -> torch.Tensor:
+        """Return a per-item ``(0, vocab)`` placeholder for an empty selector.
+
+        Symmetric with :meth:`_empty_kept_logits` but at the per-item level:
+        Path 2 and Path 3 both stack per-item kept-logits before returning
+        the batched result, and callers whose selector is empty for a
+        specific batch item use this so the downstream ``-inf`` padding
+        pass can right-fill without a shape-mismatch special case.
+        """
+        return torch.empty(
+            (0, self._mxq_static_vocab_size()), dtype=dtype, device=device
+        )
+
     @staticmethod
     def _is_last_only_selector(
         logits_to_keep: Union[int, torch.Tensor], seq_len: int
@@ -576,16 +618,12 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         if not output_positions:
             # Empty selection (empty tensor input): the KV cache has already
             # been advanced through the entire input by the trailing loop
-            # above. Return (1, 0, vocab) rather than np.concatenate-ing an
-            # empty list; the compiled vocab dim is preserved so the
-            # single-input caller's ``.squeeze(0)`` yields (0, vocab) —
-            # matching Path 2's empty branch and HF's
-            # ``hidden_states[:, empty, :]`` -> LM head -> (batch, 0, vocab)
-            # contract. Dropping to (1, 0, 0) here would make the same
-            # ``logits_to_keep=torch.tensor([])`` request return a different
-            # rank / last-dim from the other two paths.
-            vocab = self._mxq_static_vocab_size()
-            return torch.zeros((1, 0, vocab), dtype=dtype, device=device)
+            # above. Delegate to the shared helper so the compiled vocab
+            # dim is preserved and the single-input caller's ``.squeeze(0)``
+            # yields ``(0, vocab)`` — matching Path 2's empty branch and
+            # HF's ``hidden_states[:, empty, :]`` -> LM head ->
+            # ``(batch, 0, vocab)`` contract.
+            return self._empty_kept_logits(1, dtype, device)
 
         logits_ndarray = np.concatenate(
             [per_position_logits[p] for p in output_positions], axis=-2
@@ -1162,7 +1200,6 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 if past_key_values is not None:
                     past_key_values.update_seen_tokens(seen_tokens)
 
-            mxq_vocab_size = self._mxq_static_vocab_size()
             per_item_sliced: list[torch.Tensor] = []
             vocab_size = 0
             for j in range(batch_size):
@@ -1174,33 +1211,28 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                     sliced = np.stack(
                         [kept_by_item[j][p] for p in positions_j], axis=0
                     )
+                    item = torch.tensor(
+                        sliced, dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                    )
                 else:
                     # Empty selector: (0, vocab) placeholder so the padding
                     # pass below can right-fill with -inf, symmetric with
                     # the Path 3 fallback.
-                    sliced = np.empty((0, mxq_vocab_size), dtype=np.float32)
-                vocab_size = max(vocab_size, sliced.shape[-1])
-                per_item_sliced.append(
-                    torch.tensor(sliced, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
-                )
+                    item = self._empty_item_kept_logits(
+                        inputs_embeds.dtype, inputs_embeds.device
+                    )
+                vocab_size = max(vocab_size, item.shape[-1])
+                per_item_sliced.append(item)
 
             max_keep_len = max((item.shape[0] for item in per_item_sliced), default=0)
             if max_keep_len == 0:
                 # No batch item had any kept positions (e.g. empty-tensor
-                # selector). Return (batch, 0, vocab) so the compiled vocab
-                # axis is preserved — Path 3's empty-selector fallback and
-                # HF's ``hidden_states[:, empty, :]`` -> LM head both keep
-                # the vocab dim, and dropping it here would make the same
-                # ``logits_to_keep=torch.tensor([])`` request return a
-                # different last-dim depending on the batched vs single
-                # entry point.
-                return cast(
-                    torch.FloatTensor,
-                    torch.zeros(
-                        (batch_size, 0, mxq_vocab_size),
-                        dtype=inputs_embeds.dtype,
-                        device=inputs_embeds.device,
-                    ),
+                # selector). Shared helper preserves the compiled vocab
+                # axis so this branch matches Path 3's empty-selector
+                # fallback and HF's ``hidden_states[:, empty, :]`` -> LM
+                # head shape contract.
+                return self._empty_kept_logits(
+                    batch_size, inputs_embeds.dtype, inputs_embeds.device
                 )
             padded: list[torch.Tensor] = []
             for item in per_item_sliced:
@@ -1324,7 +1356,6 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             cursor += chunk
 
         per_item_final: list[torch.Tensor] = []
-        vocab_size = 0
         for j in range(batch_size):
             # per_item_kept_logits is keyed by (unique) walk positions; the
             # final tensor uses output positions so duplicate indices in the
@@ -1334,42 +1365,33 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 item_logits = torch.cat(
                     [per_item_kept_logits[j][p] for p in positions_j], dim=0
                 )
-                vocab_size = max(vocab_size, item_logits.shape[-1])
             else:
-                item_logits = torch.empty(
-                    (0, 0), dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                # Shared (0, vocab) placeholder — same last dim as the
+                # non-empty branch (MXQ vocab is compiled static) so the
+                # padding pass below can right-fill without a numel==0
+                # special case.
+                item_logits = self._empty_item_kept_logits(
+                    inputs_embeds.dtype, inputs_embeds.device
                 )
             per_item_final.append(item_logits)
 
         max_keep_len = max((item.shape[0] for item in per_item_final), default=0)
         if max_keep_len == 0:
-            # No batch item had any kept positions (e.g. empty-tensor selector).
-            # Return (batch, 0, vocab) so the compiled vocab axis is preserved,
-            # matching Path 2's batched empty branch, Path 3's single-input
-            # fallback (see :meth:`_mxq_static_vocab_size`), and HF's
-            # ``hidden_states[:, empty, :]`` -> LM head -> ``(batch, 0, vocab)``
-            # contract.
-            return cast(
-                torch.FloatTensor,
-                torch.zeros(
-                    (batch_size, 0, self._mxq_static_vocab_size()),
-                    dtype=inputs_embeds.dtype,
-                    device=inputs_embeds.device,
-                ),
+            # No batch item had any kept positions (e.g. empty-tensor
+            # selector). Shared helper preserves the compiled vocab axis so
+            # this branch matches Path 2's batched empty branch, Path 3's
+            # single-input fallback, and HF's ``hidden_states[:, empty, :]``
+            # -> LM head -> ``(batch, 0, vocab)`` contract.
+            return self._empty_kept_logits(
+                batch_size, inputs_embeds.dtype, inputs_embeds.device
             )
         padded_final: list[torch.Tensor] = []
         for item in per_item_final:
             if item.shape[0] < max_keep_len:
-                pad_rows = max_keep_len - item.shape[0]
-                pad_cols = vocab_size if item.numel() == 0 else item.shape[-1]
-                if item.numel() == 0:
-                    item = torch.empty(
-                        (0, pad_cols), dtype=inputs_embeds.dtype, device=inputs_embeds.device
-                    )
                 # -inf so downstream softmax assigns 0 probability to padded
                 # positions; using 0.0 would spread mass over real vocab rows.
                 pad = torch.full(
-                    (pad_rows, pad_cols),
+                    (max_keep_len - item.shape[0], item.shape[-1]),
                     float("-inf"),
                     dtype=item.dtype,
                     device=item.device,

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -631,7 +631,17 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         timing_phase: Literal["prefill", "decode"] = "prefill" if initial_cache_size == 0 else "decode"
 
         def _do_infer(start: int, end: int) -> np.ndarray:
-            cache_size = 0 if past_key_values is None else past_key_values.get_seq_length()
+            # When the caller did not supply a cache, use ``start`` (the number
+            # of tokens already fed to the NPU within this call) as the KV
+            # cache_size. Every path calls ``_do_infer`` with monotonically
+            # increasing, contiguous windows, so ``start`` is exactly the
+            # running "processed so far" count. Without this, Path 3's prefix
+            # walks would pass cache_size=0 for every chunk and the size-1
+            # kept-position captures would see no left context — silently
+            # corrupting keep-all / perplexity logits when use_cache is unset.
+            # Path 1 and Path 2 have the same latent issue for multi-chunk
+            # prefills; the same fix covers them.
+            cache_size = start if past_key_values is None else past_key_values.get_seq_length()
             chunk = inputs_embeds_numpy[:, :, start:end, :]
             if count_npu_time:
                 t0 = time.perf_counter()
@@ -710,8 +720,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             end_index = min(start + chunk_size, sequence_lengths[j])
             if start < sequence_lengths[j] and end_index <= sequence_lengths[j]:
                 sequence_lengths_chunks.append(end_index - start)
+                # Without a caller-supplied cache, use ``start`` as the KV
+                # cache_size — item j has been walked contiguously from 0 to
+                # ``start`` by prior chunks in this call, so ``start`` is its
+                # running "processed so far" count. Passing 0 here would tell
+                # the NPU to treat every chunk as a fresh sequence, silently
+                # dropping left-context between chunks (see the matching fix
+                # in ``llm_forward._do_infer``).
                 cache_sizes_chunks.append(
-                    past_key_values.get_seq_length(j) if past_key_values is not None else 0
+                    past_key_values.get_seq_length(j) if past_key_values is not None else start
                 )
                 cache_ids.append(j)
                 inputs_embeds_chunks.append(inputs_embeds_masked[j][start:end_index, :])

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -430,14 +430,6 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             attention_mask_bool = cast(torch.BoolTensor, attention_mask.type(torch.bool))
             inputs_embeds_masked = [inputs_embeds[i, attention_mask_bool[i, :], :] for i in range(batch_size)]
             sequence_lengths = cast(list[int], attention_mask.sum(dim=1).tolist())
-            zero_length_rows = [
-                row_index for row_index, sequence_length in enumerate(sequence_lengths) if sequence_length == 0
-            ]
-            if zero_length_rows:
-                raise ValueError(
-                    "Batched LLM inputs contain empty sequences after applying attention_mask. "
-                    f"Zero-length rows: {zero_length_rows}"
-                )
         else:
             assert inputs_embeds.shape[1] == 1
             inputs_embeds_masked = [inputs_embeds[i, :, :] for i in range(batch_size)]
@@ -509,6 +501,14 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # contract regressions stay visible.
         # ------------------------------------------------------------------
         if is_default_keep:
+            zero_length_rows = [
+                row_index for row_index, sequence_length in enumerate(sequence_lengths) if sequence_length == 0
+            ]
+            if zero_length_rows:
+                raise ValueError(
+                    "Batched LLM inputs contain empty sequences after applying attention_mask. "
+                    f"Zero-length rows: {zero_length_rows}"
+                )
             num_of_chunks = math.ceil(max_sequence_length / prefill_chunk_size)
             logits_dict: dict[int, torch.Tensor] = {}
 
@@ -725,10 +725,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 if past_key_values is not None:
                     past_key_values.update_seen_tokens(seen_tokens)
 
+            mxq_vocab_size = int(mxq_model.get_model_output_shape()[0][-1])
             per_item_sliced: list[torch.Tensor] = []
             vocab_size = 0
             for j in range(batch_size):
-                item_all = np.concatenate(all_logits_by_item[j], axis=0)
+                if all_logits_by_item[j]:
+                    item_all = np.concatenate(all_logits_by_item[j], axis=0)
+                else:
+                    # Zero-length row (attention_mask entirely zero): no chunk
+                    # contributed. Synthesize a (0, vocab) placeholder so the
+                    # padding pass below can right-fill with -inf, symmetric
+                    # with the Path 3 fallback.
+                    item_all = np.empty((0, mxq_vocab_size), dtype=np.float32)
                 positions_j = keep_positions_by_item[j]
                 sliced = item_all[positions_j, :] if positions_j else item_all[0:0, :]
                 vocab_size = max(vocab_size, sliced.shape[-1])

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -208,6 +208,36 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         self._mxq_all_logits_cached = supports
         return supports
 
+    def _mxq_static_vocab_size(self) -> int:
+        """Return the compiled MXQ vocab dimension (last output-shape axis).
+
+        Symmetric with :meth:`_mxq_supports_all_logits`: probes the backend
+        once and caches the result on the instance because the compiled
+        vocab dim is fixed for the lifetime of the model. Path 2 in
+        ``_llm_forward_batch`` needs this value to synthesize placeholder
+        rows for zero-length batch items and would otherwise call
+        ``mxq_model.get_model_output_shape()`` on every batched forward.
+
+        Unlike the boolean probe, there is no safe fallback for an unknown
+        vocab size: the same ``(AttributeError, qbruntime.QbRuntimeError)``
+        probe-failure classes recognized by :meth:`_mxq_supports_all_logits`
+        propagate through here rather than being swallowed into a sentinel
+        — callers see the underlying backend error, and nothing is cached
+        so a later successful probe can still be recorded. Any other
+        exception is a real bug and also propagates.
+        """
+        cached = getattr(self, "_mxq_static_vocab_cached", None)
+        if cached is not None:
+            return cached
+        output_shapes = self.npu_backend.mxq_model.get_model_output_shape()
+        vocab = int(output_shapes[0][-1])
+        assert vocab > 0, (
+            "MXQ vocab dim must be static (>0); got %d (mblt_model_zoo assumes the LM head vocab axis is compiled statically even when the token axis is dynamic)"
+            % vocab
+        )
+        self._mxq_static_vocab_cached = vocab
+        return vocab
+
     @staticmethod
     def _is_last_only_selector(
         logits_to_keep: Union[int, torch.Tensor], seq_len: int
@@ -859,11 +889,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 if past_key_values is not None:
                     past_key_values.update_seen_tokens(seen_tokens)
 
-            mxq_vocab_size = int(mxq_model.get_model_output_shape()[0][-1])
-            assert mxq_vocab_size > 0, (
-                "MXQ vocab dim must be static (>0); got %d (mblt_model_zoo assumes the LM head vocab axis is compiled statically even when the token axis is dynamic)"
-                % mxq_vocab_size
-            )
+            mxq_vocab_size = self._mxq_static_vocab_size()
             per_item_sliced: list[torch.Tensor] = []
             vocab_size = 0
             for j in range(batch_size):

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -376,9 +376,36 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
            logits, only advancing the KV cache) and runs a size-1 infer at
            each kept position to capture its logits.
 
-        The returned tensor still carries the leading batch axis produced
-        by ``do_infer``; single-input callers typically apply
-        ``.squeeze(0)`` afterwards, dual-input callers leave it as-is.
+        Args:
+            do_infer: Callable ``(start, end) -> np.ndarray`` that runs one
+                MXQ infer over the ``[start, end)`` slice of the caller's
+                input(s), advances the KV cache, and returns raw logits
+                shaped ``(1, end - start, vocab)`` — a leading batch axis
+                of size 1, the token axis at ``ndim - 2``, and the vocab
+                axis last. Path 2 concatenates per-chunk outputs along
+                ``axis=-2`` and slices the same axis via
+                ``ndim - 2``, so this layout is load-bearing.
+
+        Returns:
+            A ``torch.Tensor`` with a leading batch axis of size 1. The
+            trailing shape depends on which path ran:
+
+            * Path 1 (last-only fast): ``(1, 1, vocab)`` — the raw
+              last-chunk ``do_infer`` output, returned as-is.
+            * Path 2 (dynamic-axis): ``(1, kept_positions, vocab)`` where
+              ``kept_positions == len(_output_positions_for_logits_to_keep(
+              logits_to_keep, seq_len))`` (caller order and duplicates are
+              preserved, matching HF fancy-indexing).
+            * Path 3 (last-only fallback): ``(1, kept_positions, vocab)``
+              when at least one position was kept, and ``(1, 0, 0)`` when
+              the caller passed an empty ``logits_to_keep`` selector — in
+              the empty case the KV cache has still been advanced through
+              the full input by the trailing prefill loop.
+
+            Caller convention: single-input ``llm_forward`` callers apply
+            ``.squeeze(0)`` afterwards to drop the leading batch axis;
+            dual-input callers (e.g. the Qwen3-VL text decoder) preserve
+            it so downstream stacking sees a consistent ``(1, ...)`` shape.
         """
         is_default_keep = self._is_last_only_selector(logits_to_keep, seq_len)
         supports_all = False if is_default_keep else self._mxq_supports_all_logits()

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -22,6 +22,14 @@ logger = logging.getLogger(__name__)
 _MXQ_DYNAMIC_AXIS_SENTINEL = -1
 _MXQ_TOKEN_AXIS_INDEX = -2
 
+_TENSOR_SELECTOR_INT_DTYPES = (
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+)
+
 
 class _BatchChunkAssembly(NamedTuple):
     """Per-chunk batched infer inputs assembled from a shared `[start, start+chunk)` window.
@@ -325,6 +333,28 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         )
 
     @staticmethod
+    def _validate_tensor_selector_dtype(logits_to_keep: torch.Tensor) -> None:
+        """Reject non-integer tensor selectors before ``int()`` erases the dtype.
+
+        HF's ``hidden_states[:, logits_to_keep, :]`` fancy-indexing accepts
+        only integer index tensors; bool tensors trigger a separate
+        boolean-mask code path. We do not support boolean-mask indexing —
+        silently coercing ``True/False`` to ``1/0`` would misread a mask
+        as positions, and no downstream path here applies masks correctly.
+        Float dtypes are rejected because ``int(1.9) == 1`` would silently
+        pick the wrong position instead of failing like PyTorch's fancy
+        indexing does.
+        """
+        if logits_to_keep.dtype not in _TENSOR_SELECTOR_INT_DTYPES:
+            raise TypeError(
+                "logits_to_keep tensor must have an integer dtype "
+                "(int8/int16/int32/int64/uint8); got "
+                f"{logits_to_keep.dtype}. Boolean-mask indexing is not "
+                "supported — convert masks to positions via "
+                "``mask.nonzero().flatten()`` before passing them in."
+            )
+
+    @staticmethod
     def _is_last_only_selector(
         logits_to_keep: Union[int, torch.Tensor], seq_len: int
     ) -> bool:
@@ -347,6 +377,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         if isinstance(logits_to_keep, int) and logits_to_keep == 1:
             return True
         if isinstance(logits_to_keep, torch.Tensor) and logits_to_keep.numel() == 1:
+            MobilintModelMixin._validate_tensor_selector_dtype(logits_to_keep)
             idx = int(logits_to_keep.flatten()[0].item())
             return idx == seq_len - 1 or idx == -1
         return False
@@ -362,12 +393,12 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         """
         wrapped: list[int] = []
         for raw_index in indices:
-            idx = int(raw_index)
+            idx = raw_index
             if idx < 0:
                 idx = seq_len + idx
             if not 0 <= idx < seq_len:
                 raise IndexError(
-                    f"logits_to_keep index {int(raw_index)} out of range for seq_len={seq_len}"
+                    f"logits_to_keep index {raw_index} out of range for seq_len={seq_len}"
                 )
             wrapped.append(idx)
         return wrapped
@@ -403,6 +434,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         the selector once, to avoid a per-call device-to-host copy.
         """
         if isinstance(logits_to_keep, torch.Tensor):
+            cls._validate_tensor_selector_dtype(logits_to_keep)
             raw = logits_to_keep.detach().to("cpu").flatten().tolist()
             return cls._output_positions_from_cpu_indices(raw, seq_len)
         n = int(logits_to_keep)
@@ -905,6 +937,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             # Without this, a large GPU-resident selector would pay a
             # device->host copy on every batch item.
             if isinstance(logits_to_keep, torch.Tensor):
+                self._validate_tensor_selector_dtype(logits_to_keep)
                 cpu_indices = logits_to_keep.detach().to("cpu").flatten().tolist()
 
                 def _positions_for(seq_len_j: int) -> list[int]:

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -345,6 +345,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         :meth:`_llm_forward_batch`, whose padded rows are filled with
         ``-inf`` so downstream softmax leaves padded positions at zero
         probability.
+
+        Performance: on last-only MXQ (:meth:`_mxq_supports_all_logits`
+        returns False), ``logits_to_keep=0`` triggers the Path 3 fallback,
+        which runs one size-1 infer per input token and is dramatically
+        slower than ``logits_to_keep=1`` on long prefills. Callers using
+        ``.generate()`` are safe because HF sets ``logits_to_keep=1``
+        automatically; callers doing manual ``.forward()`` for perplexity
+        eval / logit collection should know this cost is inherent to
+        last-only compiled models.
         """
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         self.npu_time = 0.0 if count_npu_time else None
@@ -430,6 +439,14 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         softmax assigns exactly zero probability to padded slots; callers
         that don't also track a padding mask (e.g. generation) would
         otherwise see real vocab mass leak onto padded positions.
+
+        Performance: on last-only MXQ (:meth:`_mxq_supports_all_logits`
+        returns False), ``logits_to_keep=0`` walks the batch cursor one
+        token at a time through kept positions, so long prefills are
+        dramatically slower than ``logits_to_keep=1``. ``.generate()``
+        avoids this because HF sets ``logits_to_keep=1`` automatically;
+        manual ``.forward()`` callers doing perplexity eval / logit
+        collection incur this cost inherently on last-only builds.
         """
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         batch_size = attention_mask.shape[0]

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -2,7 +2,7 @@ import logging
 import math
 import os
 import time
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Optional, Union, cast
 
 import numpy as np
 import qbruntime
@@ -20,6 +20,23 @@ logger = logging.getLogger(__name__)
 
 _MXQ_DYNAMIC_AXIS_SENTINEL = -1
 _MXQ_TOKEN_AXIS_INDEX = -2
+
+
+class _BatchChunkAssembly(NamedTuple):
+    """Per-chunk batched infer inputs assembled from a shared `[start, start+chunk)` window.
+
+    ``prefill_masks`` is only populated when Path 1 (last-only fast path)
+    needs the "is this the item's final chunk" flag to decide whether to
+    capture its logits; Path 2 and Path 3 pass ``include_prefill_masks=False``
+    to :meth:`MobilintModelMixin._assemble_batch_chunk` and receive ``None``.
+    """
+
+    sequence_lengths_chunks: list[int]
+    cache_sizes_chunks: list[int]
+    cache_ids: list[int]
+    inputs_embeds_chunks: list[torch.Tensor]
+    seen_tokens: dict[int, int]
+    prefill_masks: Optional[list[bool]]
 
 
 class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
@@ -605,6 +622,60 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             device=inputs_embeds.device,
         )
 
+    @staticmethod
+    def _assemble_batch_chunk(
+        batch_size: int,
+        sequence_lengths: list[int],
+        inputs_embeds_masked: list[torch.Tensor],
+        start: int,
+        chunk_size: int,
+        past_key_values: Optional[MobilintCache],
+        *,
+        include_prefill_masks: bool = False,
+    ) -> _BatchChunkAssembly:
+        """Assemble one batched infer's inputs by scanning each batch item's `[start, start+chunk_size)` window.
+
+        Shared by all three paths of :meth:`_llm_forward_batch`: Path 1 (default
+        fast path) also needs the ``prefill_masks`` bit that flags whether an
+        item still has tokens after ``end_index`` — that's how it decides
+        whether the current infer holds the item's final logits or is just a
+        KV-advancing prefill. Paths 2 and 3 don't consult it, so they pass
+        ``include_prefill_masks=False`` and ignore the ``None`` field.
+
+        ``chunk_size`` is a per-call argument (not a fixed attribute) because
+        Path 3 sizes each chunk dynamically based on the smallest next-needed
+        walk position across still-active items, while Paths 1 and 2 pass the
+        caller's ``prefill_chunk_size`` unchanged.
+        """
+        sequence_lengths_chunks: list[int] = []
+        cache_sizes_chunks: list[int] = []
+        cache_ids: list[int] = []
+        inputs_embeds_chunks: list[torch.Tensor] = []
+        seen_tokens: dict[int, int] = {}
+        prefill_masks: Optional[list[bool]] = [] if include_prefill_masks else None
+
+        for j in range(batch_size):
+            end_index = min(start + chunk_size, sequence_lengths[j])
+            if start < sequence_lengths[j] and end_index <= sequence_lengths[j]:
+                sequence_lengths_chunks.append(end_index - start)
+                cache_sizes_chunks.append(
+                    past_key_values.get_seq_length(j) if past_key_values is not None else 0
+                )
+                cache_ids.append(j)
+                inputs_embeds_chunks.append(inputs_embeds_masked[j][start:end_index, :])
+                seen_tokens[j] = end_index - start
+                if prefill_masks is not None:
+                    prefill_masks.append(end_index < inputs_embeds_masked[j].shape[0])
+
+        return _BatchChunkAssembly(
+            sequence_lengths_chunks=sequence_lengths_chunks,
+            cache_sizes_chunks=cache_sizes_chunks,
+            cache_ids=cache_ids,
+            inputs_embeds_chunks=inputs_embeds_chunks,
+            seen_tokens=seen_tokens,
+            prefill_masks=prefill_masks,
+        )
+
     def _llm_forward_batch(
         self,
         inputs_embeds: torch.Tensor,
@@ -751,24 +822,23 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             for i in range(num_of_chunks):
                 start_index = i * prefill_chunk_size
 
-                sequence_lengths_chunks: list[int] = []
-                cache_sizes_chunks: list[int] = []
-                cache_ids: list[int] = []
-                prefill_masks: list[bool] = []
-                inputs_embeds_chunks: list[torch.Tensor] = []
-                seen_tokens: dict[int, int] = {}
-
-                for j in range(batch_size):
-                    end_index = min(start_index + prefill_chunk_size, sequence_lengths[j])
-                    if start_index < sequence_lengths[j] and end_index <= sequence_lengths[j]:
-                        sequence_lengths_chunks.append(end_index - start_index)
-                        cache_sizes_chunks.append(
-                            past_key_values.get_seq_length(j) if past_key_values is not None else 0
-                        )
-                        cache_ids.append(j)
-                        prefill_masks.append(end_index < inputs_embeds_masked[j].shape[0])
-                        inputs_embeds_chunks.append(inputs_embeds_masked[j][start_index:end_index, :])
-                        seen_tokens[j] = end_index - start_index
+                (
+                    sequence_lengths_chunks,
+                    cache_sizes_chunks,
+                    cache_ids,
+                    inputs_embeds_chunks,
+                    seen_tokens,
+                    prefill_masks,
+                ) = self._assemble_batch_chunk(
+                    batch_size,
+                    sequence_lengths,
+                    inputs_embeds_masked,
+                    start_index,
+                    prefill_chunk_size,
+                    past_key_values,
+                    include_prefill_masks=True,
+                )
+                assert prefill_masks is not None
 
                 if len(inputs_embeds_chunks) == 0:
                     continue
@@ -909,22 +979,21 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             for i in range(num_of_chunks):
                 start_index = i * prefill_chunk_size
 
-                sequence_lengths_chunks = []
-                cache_sizes_chunks = []
-                cache_ids = []
-                inputs_embeds_chunks = []
-                seen_tokens = {}
-
-                for j in range(batch_size):
-                    end_index = min(start_index + prefill_chunk_size, sequence_lengths[j])
-                    if start_index < sequence_lengths[j] and end_index <= sequence_lengths[j]:
-                        sequence_lengths_chunks.append(end_index - start_index)
-                        cache_sizes_chunks.append(
-                            past_key_values.get_seq_length(j) if past_key_values is not None else 0
-                        )
-                        cache_ids.append(j)
-                        inputs_embeds_chunks.append(inputs_embeds_masked[j][start_index:end_index, :])
-                        seen_tokens[j] = end_index - start_index
+                (
+                    sequence_lengths_chunks,
+                    cache_sizes_chunks,
+                    cache_ids,
+                    inputs_embeds_chunks,
+                    seen_tokens,
+                    _,
+                ) = self._assemble_batch_chunk(
+                    batch_size,
+                    sequence_lengths,
+                    inputs_embeds_masked,
+                    start_index,
+                    prefill_chunk_size,
+                    past_key_values,
+                )
 
                 if len(inputs_embeds_chunks) == 0:
                     continue
@@ -1043,26 +1112,25 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             else:
                 chunk = min(prefill_chunk_size, min_next_needed - cursor)
 
-            sequence_lengths_chunks = []
-            cache_sizes_chunks = []
-            cache_ids = []
-            inputs_embeds_chunks = []
-            seen_tokens = {}
-
             # Every item still within its sequence gets an infer call at this
             # cursor so its KV cache advances monotonically through all positions;
             # this holds even when ptr == len(walk_positions_by_item[j]) — the
             # size-1 kept-logit capture is gated later by positions_j[ptr] == cursor.
-            for j in range(batch_size):
-                end_j = min(cursor + chunk, sequence_lengths[j])
-                if cursor < sequence_lengths[j] and end_j <= sequence_lengths[j]:
-                    sequence_lengths_chunks.append(end_j - cursor)
-                    cache_sizes_chunks.append(
-                        past_key_values.get_seq_length(j) if past_key_values is not None else 0
-                    )
-                    cache_ids.append(j)
-                    inputs_embeds_chunks.append(inputs_embeds_masked[j][cursor:end_j, :])
-                    seen_tokens[j] = end_j - cursor
+            (
+                sequence_lengths_chunks,
+                cache_sizes_chunks,
+                cache_ids,
+                inputs_embeds_chunks,
+                seen_tokens,
+                _,
+            ) = self._assemble_batch_chunk(
+                batch_size,
+                sequence_lengths,
+                inputs_embeds_masked,
+                cursor,
+                chunk,
+                past_key_values,
+            )
 
             if not inputs_embeds_chunks:
                 cursor += chunk

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -829,6 +829,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                     past_key_values.update_seen_tokens(seen_tokens)
 
             mxq_vocab_size = int(mxq_model.get_model_output_shape()[0][-1])
+            assert mxq_vocab_size > 0, (
+                "MXQ vocab dim must be static (>0); got %d (mblt_model_zoo assumes the LM head vocab axis is compiled statically even when the token axis is dynamic)"
+                % mxq_vocab_size
+            )
             per_item_sliced: list[torch.Tensor] = []
             vocab_size = 0
             for j in range(batch_size):

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -260,10 +260,12 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             return cached
         output_shapes = self.npu_backend.mxq_model.get_model_output_shape()
         vocab = int(output_shapes[0][-1])
-        assert vocab > 0, (
-            "MXQ vocab dim must be static (>0); got %d (mblt_model_zoo assumes the LM head vocab axis is compiled statically even when the token axis is dynamic)"
-            % vocab
-        )
+        if vocab <= 0:
+            raise RuntimeError(
+                f"MXQ vocab dim must be static (>0); got {vocab} "
+                "(mblt_model_zoo assumes the LM head vocab axis is compiled "
+                "statically even when the token axis is dynamic)"
+            )
         self._mxq_static_vocab_cached = vocab
         return vocab
 

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -470,11 +470,14 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
               ``kept_positions == len(_output_positions_for_logits_to_keep(
               logits_to_keep, seq_len))`` (caller order and duplicates are
               preserved, matching HF fancy-indexing).
-            * Path 3 (last-only fallback): ``(1, kept_positions, vocab)``
-              when at least one position was kept, and ``(1, 0, 0)`` when
-              the caller passed an empty ``logits_to_keep`` selector — in
-              the empty case the KV cache has still been advanced through
-              the full input by the trailing prefill loop.
+            * Path 3 (last-only fallback): ``(1, kept_positions, vocab)``.
+              When the caller passes an empty ``logits_to_keep`` selector
+              ``kept_positions`` is 0 and the vocab axis comes from
+              :meth:`_mxq_static_vocab_size`, so the shape/rank stays
+              parity with Path 2's empty-selector output and HF's
+              ``hidden_states[:, empty, :]`` semantics. The KV cache has
+              still been advanced through the full input by the trailing
+              prefill loop.
 
             Caller convention: single-input ``llm_forward`` callers apply
             ``.squeeze(0)`` afterwards to drop the leading batch axis;
@@ -573,11 +576,16 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         if not output_positions:
             # Empty selection (empty tensor input): the KV cache has already
             # been advanced through the entire input by the trailing loop
-            # above. Return a (1, 0, 0) placeholder rather than calling
-            # np.concatenate on an empty list. The leading 1 matches the
-            # batch axis that do_infer would have produced, so single-input
-            # callers can still ``.squeeze(0)`` down to (0, 0).
-            return torch.zeros((1, 0, 0), dtype=dtype, device=device)
+            # above. Return (1, 0, vocab) rather than np.concatenate-ing an
+            # empty list; the compiled vocab dim is preserved so the
+            # single-input caller's ``.squeeze(0)`` yields (0, vocab) —
+            # matching Path 2's empty branch and HF's
+            # ``hidden_states[:, empty, :]`` -> LM head -> (batch, 0, vocab)
+            # contract. Dropping to (1, 0, 0) here would make the same
+            # ``logits_to_keep=torch.tensor([])`` request return a different
+            # rank / last-dim from the other two paths.
+            vocab = self._mxq_static_vocab_size()
+            return torch.zeros((1, 0, vocab), dtype=dtype, device=device)
 
         logits_ndarray = np.concatenate(
             [per_position_logits[p] for p in output_positions], axis=-2

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -2,7 +2,7 @@ import logging
 import math
 import os
 import time
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast
 
 import numpy as np
 import qbruntime
@@ -214,6 +214,100 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
 
         return output
 
+    def _run_chunked_logits_to_keep(
+        self,
+        *,
+        do_infer: Callable[[int, int], np.ndarray],
+        seq_len: int,
+        prefill_chunk_size: int,
+        logits_to_keep: Union[int, torch.Tensor],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Shared 3-path dispatch for HF-style ``logits_to_keep`` over a chunked MXQ.
+
+        Callers provide a ``do_infer(start, end)`` closure that runs one
+        MXQ infer over the ``[start, end)`` slice of their own input(s)
+        (advancing the KV cache) and returns the raw logits ndarray. This
+        helper handles the three execution paths uniformly:
+
+        1. ``logits_to_keep == 1``: fast path; the caller's chunk size is
+           used as-is and only the last chunk's logits are returned.
+        2. MXQ has a dynamic token axis (see
+           :meth:`_mxq_supports_all_logits`): keep the caller's chunk size
+           and concatenate per-chunk outputs, then slice to the requested
+           positions along the token axis (``ndim - 2``).
+        3. Otherwise (last-only MXQ + non-default request): a fallback that
+           prefills the non-kept prefix with normal chunks (throwing away
+           logits, only advancing the KV cache) and runs a size-1 infer at
+           each kept position to capture its logits.
+
+        The returned tensor still carries the leading batch axis produced
+        by ``do_infer``; single-input callers typically apply
+        ``.squeeze(0)`` afterwards, dual-input callers leave it as-is.
+        """
+        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
+        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
+
+        # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
+        # additionally collects every chunk's output so the concatenation
+        # covers the full input.
+        if is_default_keep or supports_all:
+            num_of_chunks = math.ceil(seq_len / prefill_chunk_size)
+            assert num_of_chunks > 0, "num_of_chunks is not positive! num_of_chunks: %d" % num_of_chunks
+
+            per_chunk_logits: list[np.ndarray] = []
+            logits_ndarray: Optional[np.ndarray] = None
+            for i in range(num_of_chunks):
+                start_index = i * prefill_chunk_size
+                end_index = min(start_index + prefill_chunk_size, seq_len)
+                logits_ndarray = do_infer(start_index, end_index)
+                if supports_all:
+                    per_chunk_logits.append(logits_ndarray)
+
+            if supports_all:
+                logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
+                positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+                token_axis = logits_ndarray.ndim - 2
+                logits_ndarray = np.take(logits_ndarray, positions_to_keep, axis=token_axis)
+
+            assert logits_ndarray is not None
+            return torch.tensor(logits_ndarray, dtype=dtype, device=device)
+
+        # Path 3: fallback. Interleave normal chunks (for positions the
+        # caller does not care about) with size-1 infer calls (one per kept
+        # position). The KV cache advances monotonically through every
+        # position of the input, so subsequent decode steps see the same
+        # cache state as the other two paths would leave behind.
+        positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+        per_position_logits: dict[int, np.ndarray] = {}
+        cursor = 0
+        for p in positions_to_keep:
+            while cursor < p:
+                end_index = min(cursor + prefill_chunk_size, p)
+                do_infer(cursor, end_index)
+                cursor = end_index
+            per_position_logits[p] = do_infer(cursor, cursor + 1)
+            cursor += 1
+        while cursor < seq_len:
+            end_index = min(cursor + prefill_chunk_size, seq_len)
+            do_infer(cursor, end_index)
+            cursor = end_index
+
+        if not positions_to_keep:
+            # Empty selection (empty tensor or all indices out-of-range): the
+            # KV cache has already been advanced through the entire input by
+            # the trailing loop above. Return a (1, 0, 0) placeholder rather
+            # than calling np.concatenate on an empty list. The leading 1
+            # matches the batch axis that do_infer would have produced, so
+            # single-input callers can still ``.squeeze(0)`` down to (0, 0).
+            return torch.zeros((1, 0, 0), dtype=dtype, device=device)
+
+        logits_ndarray = np.concatenate(
+            [per_position_logits[p] for p in positions_to_keep], axis=-2
+        )
+        return torch.tensor(logits_ndarray, dtype=dtype, device=device)
+
     def llm_forward(
         self,
         inputs_embeds: torch.Tensor,
@@ -231,19 +325,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         position; ``>1`` returns the last N positions; a ``torch.Tensor``
         selects specific positions.
 
-        Three execution paths cover the interaction between the request and
-        the compiled MXQ:
-
-        1. ``logits_to_keep == 1``: unchanged fast path; the caller's
-           ``prefill_chunk_size`` is used as-is.
-        2. MXQ has a dynamic token axis (see
-           :meth:`_mxq_supports_all_logits`): keep the caller's chunk size
-           and concatenate per-chunk outputs, then slice to the requested
-           positions.
-        3. Otherwise (last-only MXQ + non-default request): a fallback that
-           prefills the non-kept prefix with normal chunks (throwing away
-           logits, only advancing the KV cache) and runs a size-1 infer at
-           each kept position to capture its logits.
+        The three execution paths (fast path, dynamic-axis, fallback) are
+        implemented once in :meth:`_run_chunked_logits_to_keep`; this
+        wrapper just builds a single-input ``do_infer`` closure that
+        advances the KV cache and forwards to the shared helper.
         """
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         self.npu_time = 0.0 if count_npu_time else None
@@ -268,9 +353,6 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         initial_cache_size = 0 if past_key_values is None else past_key_values.get_seq_length()
         timing_phase: Literal["prefill", "decode"] = "prefill" if initial_cache_size == 0 else "decode"
 
-        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
-        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
-
         def _do_infer(start: int, end: int) -> np.ndarray:
             cache_size = 0 if past_key_values is None else past_key_values.get_seq_length()
             chunk = inputs_embeds_numpy[:, :, start:end, :]
@@ -288,68 +370,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 past_key_values.update_cache_position(cache_position[start:end])
             return result[0]
 
-        # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
-        # additionally collects every chunk's output so the concatenation
-        # covers the full input.
-        if is_default_keep or supports_all:
-            num_of_chunks = math.ceil(seq_len / resolved_prefill_chunk_size)
-            assert num_of_chunks > 0, "num_of_chunks is not positive! num_of_chunks: %d" % num_of_chunks
-
-            per_chunk_logits: list[np.ndarray] = []
-            logits_ndarray: Optional[np.ndarray] = None
-            for i in range(num_of_chunks):
-                start_index = i * resolved_prefill_chunk_size
-                end_index = min(start_index + resolved_prefill_chunk_size, seq_len)
-                logits_ndarray = _do_infer(start_index, end_index)
-                if supports_all:
-                    per_chunk_logits.append(logits_ndarray)
-
-            if supports_all:
-                logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
-                positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
-                token_axis = logits_ndarray.ndim - 2
-                logits_ndarray = np.take(logits_ndarray, positions_to_keep, axis=token_axis)
-
-            assert logits_ndarray is not None
-            return torch.tensor(
-                logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device
-            ).squeeze(0)
-
-        # Path 3: fallback. Interleave normal chunks (for positions the
-        # caller does not care about) with size-1 infer calls (one per kept
-        # position). The KV cache advances monotonically through every
-        # position of the input, so subsequent decode steps see the same
-        # cache state as the other two paths would leave behind.
-        positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
-        per_position_logits: dict[int, np.ndarray] = {}
-        cursor = 0
-        for p in positions_to_keep:
-            while cursor < p:
-                end_index = min(cursor + resolved_prefill_chunk_size, p)
-                _do_infer(cursor, end_index)
-                cursor = end_index
-            per_position_logits[p] = _do_infer(cursor, cursor + 1)
-            cursor += 1
-        while cursor < seq_len:
-            end_index = min(cursor + resolved_prefill_chunk_size, seq_len)
-            _do_infer(cursor, end_index)
-            cursor = end_index
-
-        if not positions_to_keep:
-            # Empty selection (empty tensor or all indices out-of-range): the
-            # KV cache has already been advanced through the entire input by
-            # the trailing loop above. Return a (0, 0) placeholder rather
-            # than calling np.concatenate on an empty list.
-            return torch.zeros(
-                (0, 0), dtype=inputs_embeds.dtype, device=inputs_embeds.device
-            )
-
-        logits_ndarray = np.concatenate(
-            [per_position_logits[p] for p in positions_to_keep], axis=-2
+        logits = self._run_chunked_logits_to_keep(
+            do_infer=_do_infer,
+            seq_len=seq_len,
+            prefill_chunk_size=resolved_prefill_chunk_size,
+            logits_to_keep=logits_to_keep,
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
         )
-        return torch.tensor(
-            logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device
-        ).squeeze(0)
+        return logits.squeeze(0)
 
     def resolve_batched_attention_mask(
         self,

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -168,7 +168,11 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 first_shape = tuple(output_shapes[0])
                 if len(first_shape) >= 2 and int(first_shape[-2]) == -1:
                     supports = True
-        except Exception:  # noqa: BLE001 - defensively fall back to slow path
+        except (AttributeError, RuntimeError):
+            # AttributeError: backend or ``get_model_output_shape`` missing.
+            # RuntimeError: backend refused the probe (``qbruntime.QbRuntimeError``
+            # is a ``RuntimeError`` subclass). Any other exception is a real bug
+            # and should propagate.
             supports = False
         self._mxq_all_logits_cached = supports
         return supports

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -185,6 +185,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         value equal to ``_MXQ_DYNAMIC_AXIS_SENTINEL`` marks it as dynamic.
         The result is cached on the instance because the shape is fixed
         for the lifetime of the loaded model.
+
+        Cache population is lazy. Both call sites in
+        ``_run_chunked_logits_to_keep`` and ``_llm_forward_batch`` guard the
+        probe with ``False if is_default_keep else self._mxq_supports_all_logits()``,
+        so a model whose traffic is entirely last-only (Path 1) never calls
+        this method and ``_mxq_all_logits_cached`` stays unset. The first
+        non-default ``logits_to_keep`` request then pays a single
+        ``get_model_output_shape`` backend call before the cache is filled;
+        every subsequent call is a plain attribute read. This is
+        intentional: eager probing at ``__init__`` time would burn a
+        backend call on the common default-generation path where the
+        dynamic-axis answer is never consulted.
         """
         cached = getattr(self, "_mxq_all_logits_cached", None)
         if cached is not None:

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -328,7 +328,11 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         The three execution paths (fast path, dynamic-axis, fallback) are
         implemented once in :meth:`_run_chunked_logits_to_keep`; this
         wrapper just builds a single-input ``do_infer`` closure that
-        advances the KV cache and forwards to the shared helper.
+        advances the KV cache and forwards to the shared helper. When an
+        ``attention_mask`` is provided we dispatch to
+        :meth:`_llm_forward_batch`, whose padded rows are filled with
+        ``-inf`` so downstream softmax leaves padded positions at zero
+        probability.
         """
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         self.npu_time = 0.0 if count_npu_time else None
@@ -406,6 +410,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         count_npu_time: bool = False,
         logits_to_keep: Union[int, torch.Tensor] = 1,
     ):
+        """Batched sibling of :meth:`llm_forward` with the same 3-path dispatch.
+
+        Paths 2 and 3 produce a variable number of kept positions per
+        batch item and stack them into ``(batch, max_keep_len, vocab)``.
+        Padded rows are filled with ``-inf`` (not 0.0) so downstream
+        softmax assigns exactly zero probability to padded slots; callers
+        that don't also track a padding mask (e.g. generation) would
+        otherwise see real vocab mass leak onto padded positions.
+        """
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         batch_size = attention_mask.shape[0]
 
@@ -723,8 +736,11 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             padded: list[torch.Tensor] = []
             for item in per_item_sliced:
                 if item.shape[0] < max_keep_len:
-                    pad = torch.zeros(
+                    # -inf so downstream softmax assigns 0 probability to padded
+                    # positions; using 0.0 would spread mass over real vocab rows.
+                    pad = torch.full(
                         (max_keep_len - item.shape[0], vocab_size),
+                        float("-inf"),
                         dtype=item.dtype,
                         device=item.device,
                     )
@@ -832,11 +848,16 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 pad_rows = max_keep_len - item.shape[0]
                 pad_cols = vocab_size if item.numel() == 0 else item.shape[-1]
                 if item.numel() == 0:
-                    item = torch.zeros(
+                    item = torch.empty(
                         (0, pad_cols), dtype=inputs_embeds.dtype, device=inputs_embeds.device
                     )
-                pad = torch.zeros(
-                    (pad_rows, pad_cols), dtype=item.dtype, device=item.device
+                # -inf so downstream softmax assigns 0 probability to padded
+                # positions; using 0.0 would spread mass over real vocab rows.
+                pad = torch.full(
+                    (pad_rows, pad_cols),
+                    float("-inf"),
+                    dtype=item.dtype,
+                    device=item.device,
                 )
                 item = torch.cat([item, pad], dim=0)
             padded_final.append(item)

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -209,6 +209,26 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         return supports
 
     @staticmethod
+    def _is_last_only_selector(
+        logits_to_keep: Union[int, torch.Tensor], seq_len: int
+    ) -> bool:
+        """Return True when ``logits_to_keep`` semantically selects only the last position.
+
+        Matches ``logits_to_keep == 1`` (the int shortcut) and its tensor
+        equivalents: a single-element tensor holding ``seq_len - 1`` or
+        ``-1``. HF callers that build the selector programmatically as
+        ``torch.tensor([seq_len - 1])`` are asking for the same last-token
+        logit as ``logits_to_keep=1`` and should hit Path 1 identically
+        rather than probing the dynamic axis and taking Path 2/3.
+        """
+        if isinstance(logits_to_keep, int) and logits_to_keep == 1:
+            return True
+        if isinstance(logits_to_keep, torch.Tensor) and logits_to_keep.numel() == 1:
+            idx = int(logits_to_keep.flatten()[0].item())
+            return idx == seq_len - 1 or idx == -1
+        return False
+
+    @staticmethod
     def _wrap_and_validate_indices(indices: list[int], seq_len: int) -> list[int]:
         """Apply HF-style negative-wrap and range-check to a list of position indices.
 
@@ -317,7 +337,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         by ``do_infer``; single-input callers typically apply
         ``.squeeze(0)`` afterwards, dual-input callers leave it as-is.
         """
-        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
+        is_default_keep = self._is_last_only_selector(logits_to_keep, seq_len)
         supports_all = False if is_default_keep else self._mxq_supports_all_logits()
 
         # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
@@ -548,7 +568,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             "prefill_chunk_size should be a positive number! prefill_chunk_size: %d" % prefill_chunk_size
         )
 
-        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
+        # int==1 always hits Path 1 (the existing per-item cursor code handles
+        # mixed lengths correctly and this is the HF-generate default). For a
+        # scalar tensor selector we additionally require every item to share the
+        # same length, because a single value can only uniformly represent
+        # "last position" when there is only one length in the batch.
+        if isinstance(logits_to_keep, int) and logits_to_keep == 1:
+            is_default_keep = True
+        else:
+            lens_equal = all(sl == sequence_lengths[0] for sl in sequence_lengths)
+            is_default_keep = lens_equal and self._is_last_only_selector(
+                logits_to_keep, sequence_lengths[0]
+            )
         supports_all = False if is_default_keep else self._mxq_supports_all_logits()
 
         # Path 2 uses the output positions directly to assemble the final

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -482,29 +482,51 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         supports_all = False if is_default_keep else self._mxq_supports_all_logits()
 
         # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
-        # additionally collects every chunk's output so the concatenation
-        # covers the full input.
+        # extracts kept-position rows on the fly and drops each chunk right
+        # after, so peak memory stays at (kept_positions * vocab) instead of
+        # spiking to (num_of_chunks * chunk_len * vocab) at concat time.
+        # logits_to_keep=1 dominates in practice; keep-all only shows up in
+        # perplexity eval — kept_positions << seq_len for the common case.
         if is_default_keep or supports_all:
             num_of_chunks = math.ceil(seq_len / prefill_chunk_size)
             assert num_of_chunks > 0, "num_of_chunks is not positive! num_of_chunks: %d" % num_of_chunks
 
-            per_chunk_logits: list[np.ndarray] = []
+            if supports_all:
+                output_positions = self._output_positions_for_logits_to_keep(logits_to_keep, seq_len)
+                walk_positions = sorted(set(output_positions))
+                kept_by_position: dict[int, np.ndarray] = {}
+                walk_ptr = 0
+
             logits_ndarray: Optional[np.ndarray] = None
             for i in range(num_of_chunks):
                 start_index = i * prefill_chunk_size
                 end_index = min(start_index + prefill_chunk_size, seq_len)
                 logits_ndarray = do_infer(start_index, end_index)
                 if supports_all:
-                    per_chunk_logits.append(logits_ndarray)
+                    token_axis = logits_ndarray.ndim - 2
+                    while walk_ptr < len(walk_positions) and walk_positions[walk_ptr] < end_index:
+                        p = walk_positions[walk_ptr]
+                        # np.take returns a fresh allocation, so the chunk
+                        # itself can be freed as soon as this iteration ends.
+                        kept_by_position[p] = np.take(
+                            logits_ndarray, [p - start_index], axis=token_axis
+                        )
+                        walk_ptr += 1
 
             if supports_all:
-                logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
-                # HF fancy-indexing preserves caller order and duplicates;
-                # ``np.take`` matches that when we pass the output positions
-                # directly without dedup/sort.
-                output_positions = self._output_positions_for_logits_to_keep(logits_to_keep, seq_len)
-                token_axis = logits_ndarray.ndim - 2
-                logits_ndarray = np.take(logits_ndarray, output_positions, axis=token_axis)
+                if output_positions:
+                    # HF fancy-indexing preserves caller order and duplicates —
+                    # concatenating in output_positions order mirrors that.
+                    logits_ndarray = np.concatenate(
+                        [kept_by_position[p] for p in output_positions],
+                        axis=-2,
+                    )
+                else:
+                    # Empty selector: (1, 0, vocab) matches pre-refactor Path 2.
+                    # The KV cache has already been advanced by the loop above.
+                    assert logits_ndarray is not None
+                    token_axis = logits_ndarray.ndim - 2
+                    logits_ndarray = np.take(logits_ndarray, [], axis=token_axis)
 
             assert logits_ndarray is not None
             return torch.tensor(logits_ndarray, dtype=dtype, device=device)
@@ -1030,13 +1052,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # ------------------------------------------------------------------
         # Path 2: dynamic-output MXQ. The compiled model already produces
         # per-position logits, so we keep the caller's chunk size and split
-        # each chunk's flat output by per-item offsets. Per-item logits are
-        # concatenated, sliced by that item's kept positions, right-padded
-        # to the longest kept sequence, and stacked.
+        # each chunk's flat output by per-item offsets. We stash only the
+        # rows at each item's kept walk positions (keyed by position) and
+        # drop the chunk immediately — peak memory stays at
+        # (kept_positions * vocab) per item instead of spiking to
+        # (batch * num_of_chunks * chunk_len * vocab) at concat time.
+        # Final assembly reindexes by ``output_positions_by_item`` so HF
+        # caller order and duplicates survive.
         # ------------------------------------------------------------------
         if supports_all:
             num_of_chunks = math.ceil(max_sequence_length / prefill_chunk_size)
-            all_logits_by_item: dict[int, list[np.ndarray]] = {j: [] for j in range(batch_size)}
+            kept_by_item: dict[int, dict[int, np.ndarray]] = {j: {} for j in range(batch_size)}
+            walk_ptr_by_item: dict[int, int] = {j: 0 for j in range(batch_size)}
 
             for i in range(num_of_chunks):
                 start_index = i * prefill_chunk_size
@@ -1069,7 +1096,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 offset = 0
                 for k, cache_id in enumerate(cache_ids):
                     len_k = sequence_lengths_chunks[k]
-                    all_logits_by_item[cache_id].append(flat_output[offset : offset + len_k, :].copy())
+                    walk_j = walk_positions_by_item[cache_id]
+                    ptr = walk_ptr_by_item[cache_id]
+                    chunk_end_global = start_index + len_k
+                    while ptr < len(walk_j) and walk_j[ptr] < chunk_end_global:
+                        p = walk_j[ptr]
+                        # .copy() so the whole chunk buffer can be dropped
+                        # once this iteration ends — the point of Option C.
+                        kept_by_item[cache_id][p] = flat_output[
+                            offset + (p - start_index), :
+                        ].copy()
+                        ptr += 1
+                    walk_ptr_by_item[cache_id] = ptr
                     offset += len_k
 
                 if debug_enabled:
@@ -1090,16 +1128,19 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             per_item_sliced: list[torch.Tensor] = []
             vocab_size = 0
             for j in range(batch_size):
-                if all_logits_by_item[j]:
-                    item_all = np.concatenate(all_logits_by_item[j], axis=0)
-                else:
-                    # Zero-length row (attention_mask entirely zero): no chunk
-                    # contributed. Synthesize a (0, vocab) placeholder so the
-                    # padding pass below can right-fill with -inf, symmetric
-                    # with the Path 3 fallback.
-                    item_all = np.empty((0, mxq_vocab_size), dtype=np.float32)
                 positions_j = output_positions_by_item[j]
-                sliced = item_all[positions_j, :] if positions_j else item_all[0:0, :]
+                if positions_j:
+                    # np.stack of the per-position 1D rows reconstructs the
+                    # (kept, vocab) tensor in HF caller order (duplicates
+                    # preserved since positions_j is not deduped).
+                    sliced = np.stack(
+                        [kept_by_item[j][p] for p in positions_j], axis=0
+                    )
+                else:
+                    # Empty selector: (0, vocab) placeholder so the padding
+                    # pass below can right-fill with -inf, symmetric with
+                    # the Path 3 fallback.
+                    sliced = np.empty((0, mxq_vocab_size), dtype=np.float32)
                 vocab_size = max(vocab_size, sliced.shape[-1])
                 per_item_sliced.append(
                     torch.tensor(sliced, dtype=inputs_embeds.dtype, device=inputs_embeds.device)

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -757,27 +757,37 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
 
         # ------------------------------------------------------------------
         # Path 3: fallback for last-only MXQ with a non-default request.
-        # We advance a shared cursor across the batch; the chunk size uses
-        # the caller's ``prefill_chunk_size`` until we reach the earliest
-        # kept position across items, then drops to 1 so each kept
-        # position is captured with its own infer call. Because items
-        # share the same iteration structure we key on the shared cursor
-        # and only record logits for items whose kept-set contains it.
+        # We advance a shared cursor across the batch and pick the chunk
+        # size from the smallest next-needed kept position across only
+        # those items that are still active AND still have pending kept
+        # positions. Items whose kept-set is exhausted (or empty) no
+        # longer force a size-1 walk across the rest of the batch — a
+        # single late kept position in one item used to drag every other
+        # item into per-step infer calls. keep_positions_by_item lists
+        # are sorted+deduped by ``_normalize_logits_to_keep``, so a
+        # per-item pointer tracks the next needed position in O(1).
         # ------------------------------------------------------------------
-        keep_sets: dict[int, set[int]] = {j: set(keep_positions_by_item[j]) for j in range(batch_size)}
-        min_keep_start = max_sequence_length
-        for j in range(batch_size):
-            positions_j = keep_positions_by_item[j]
-            if positions_j:
-                min_keep_start = min(min_keep_start, positions_j[0])
-
+        pointer_by_item: dict[int, int] = {j: 0 for j in range(batch_size)}
         per_item_kept_logits: dict[int, dict[int, torch.Tensor]] = {j: {} for j in range(batch_size)}
         cursor = 0
         while cursor < max_sequence_length:
-            if cursor < min_keep_start:
-                chunk = min(prefill_chunk_size, min_keep_start - cursor)
-            else:
+            min_next_needed: Optional[int] = None
+            for j in range(batch_size):
+                if cursor >= sequence_lengths[j]:
+                    continue
+                ptr = pointer_by_item[j]
+                positions_j = keep_positions_by_item[j]
+                if ptr < len(positions_j):
+                    nn = positions_j[ptr]
+                    if min_next_needed is None or nn < min_next_needed:
+                        min_next_needed = nn
+
+            if min_next_needed is None:
+                chunk = prefill_chunk_size
+            elif min_next_needed == cursor:
                 chunk = 1
+            else:
+                chunk = min(prefill_chunk_size, min_next_needed - cursor)
 
             sequence_lengths_chunks = []
             cache_sizes_chunks = []
@@ -822,8 +832,11 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
 
             if chunk == 1:
                 for k, cache_id in enumerate(cache_ids):
-                    if cursor in keep_sets[cache_id]:
+                    ptr = pointer_by_item[cache_id]
+                    positions_j = keep_positions_by_item[cache_id]
+                    if ptr < len(positions_j) and positions_j[ptr] == cursor:
                         per_item_kept_logits[cache_id][cursor] = logits_chunks[k, :, :].clone()
+                        pointer_by_item[cache_id] = ptr + 1
 
             if past_key_values is not None:
                 past_key_values.update_seen_tokens(seen_tokens)

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -145,6 +145,62 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         timing[f"{phase}_time"] = float(timing.get(f"{phase}_time", 0.0)) + float(elapsed)
         timing[f"{phase}_calls"] = int(timing.get(f"{phase}_calls", 0)) + 1
 
+    def _mxq_supports_all_logits(self) -> bool:
+        """Return True when the compiled MXQ emits logits for every input token.
+
+        Some MXQ builds compile the LM head with a dynamic token axis, so a
+        single ``mxq_model.infer`` call returns per-position logits instead
+        of only the last-token logit. We probe this by inspecting the first
+        entry of :py:meth:`qbruntime.Model.get_model_output_shape`: token
+        axis is the second-to-last dimension (matching both
+        ``(batch, seq_len, vocab)`` and ``(batch, 1, seq_len, vocab)``
+        layouts we see in practice), and a value of ``-1`` marks it as
+        dynamic. The result is cached on the instance because the shape is
+        fixed for the lifetime of the loaded model.
+        """
+        cached = getattr(self, "_mxq_all_logits_cached", None)
+        if cached is not None:
+            return cached
+        supports = False
+        try:
+            output_shapes = self.npu_backend.mxq_model.get_model_output_shape()
+            if output_shapes:
+                first_shape = tuple(output_shapes[0])
+                if len(first_shape) >= 2 and int(first_shape[-2]) == -1:
+                    supports = True
+        except Exception:  # noqa: BLE001 - defensively fall back to slow path
+            supports = False
+        self._mxq_all_logits_cached = supports
+        return supports
+
+    @staticmethod
+    def _normalize_logits_to_keep(logits_to_keep: Union[int, torch.Tensor], seq_len: int) -> list[int]:
+        """Translate HF-style ``logits_to_keep`` into an ordered position list.
+
+        * ``int == 0``: keep every position.
+        * ``int > 0``: keep the last N positions (clamped to ``seq_len``).
+        * ``torch.Tensor``: treat as position indices (negatives wrap,
+          out-of-range values are dropped, duplicates collapsed).
+
+        The returned list is sorted ascending so callers can walk the
+        sequence left-to-right when they need to interleave prefill and
+        per-position infer calls.
+        """
+        if isinstance(logits_to_keep, torch.Tensor):
+            indices = logits_to_keep.detach().to("cpu").flatten().tolist()
+            normalized: list[int] = []
+            for raw_index in indices:
+                idx = int(raw_index)
+                if idx < 0:
+                    idx = seq_len + idx
+                if 0 <= idx < seq_len:
+                    normalized.append(idx)
+            return sorted(set(normalized))
+        n = int(logits_to_keep)
+        if n <= 0 or n >= seq_len:
+            return list(range(seq_len))
+        return list(range(seq_len - n, seq_len))
+
     def mxq_forward(
         self,
         input: torch.Tensor,
@@ -166,7 +222,29 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         prefill_chunk_size: Optional[int] = None,
         count_npu_time: bool = False,
         attention_mask: Optional[torch.Tensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 1,
     ):
+        """Chunked MXQ prefill / decode with HF-style ``logits_to_keep``.
+
+        ``logits_to_keep`` follows the ``transformers`` semantics: ``1``
+        (default) returns only the last-token logits; ``0`` returns every
+        position; ``>1`` returns the last N positions; a ``torch.Tensor``
+        selects specific positions.
+
+        Three execution paths cover the interaction between the request and
+        the compiled MXQ:
+
+        1. ``logits_to_keep == 1``: unchanged fast path; the caller's
+           ``prefill_chunk_size`` is used as-is.
+        2. MXQ has a dynamic token axis (see
+           :meth:`_mxq_supports_all_logits`): keep the caller's chunk size
+           and concatenate per-chunk outputs, then slice to the requested
+           positions.
+        3. Otherwise (last-only MXQ + non-default request): a fallback that
+           prefills the non-kept prefix with normal chunks (throwing away
+           logits, only advancing the KV cache) and runs a size-1 infer at
+           each kept position to capture its logits.
+        """
         resolved_prefill_chunk_size = self.resolve_prefill_chunk_size(prefill_chunk_size)
         self.npu_time = 0.0 if count_npu_time else None
 
@@ -178,42 +256,91 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 past_key_values,
                 resolved_prefill_chunk_size,
                 count_npu_time=count_npu_time,
+                logits_to_keep=logits_to_keep,
             )
 
         inputs_embeds_numpy = inputs_embeds.type(torch.float32).cpu().numpy()
         if inputs_embeds_numpy.ndim == 3:
             inputs_embeds_numpy = np.expand_dims(inputs_embeds_numpy, 1)  # (batch, 1, seqlen, hidden_size)
 
-        num_of_chunks = math.ceil(inputs_embeds_numpy.shape[2] / resolved_prefill_chunk_size)
-        assert num_of_chunks > 0, "num_of_chunks is not positive! num_of_chunks: %d" % num_of_chunks
-
+        seq_len = inputs_embeds_numpy.shape[2]
         mxq_model = self.npu_backend.mxq_model
         initial_cache_size = 0 if past_key_values is None else past_key_values.get_seq_length()
         timing_phase: Literal["prefill", "decode"] = "prefill" if initial_cache_size == 0 else "decode"
 
-        for i in range(num_of_chunks):
-            start_index = i * resolved_prefill_chunk_size
-            end_index = min(start_index + resolved_prefill_chunk_size, inputs_embeds_numpy.shape[2])
-            cache_size = 0 if past_key_values is None else past_key_values.get_seq_length()
+        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
+        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
 
+        def _do_infer(start: int, end: int) -> np.ndarray:
+            cache_size = 0 if past_key_values is None else past_key_values.get_seq_length()
+            chunk = inputs_embeds_numpy[:, :, start:end, :]
             if count_npu_time:
                 t0 = time.perf_counter()
-                result = mxq_model.infer([inputs_embeds_numpy[:, :, start_index:end_index, :]], None, cache_size)
+                result = mxq_model.infer([chunk], None, cache_size)
                 elapsed = time.perf_counter() - t0
+                assert self.npu_time is not None
                 self.npu_time += elapsed
                 self._record_npu_timing(timing_phase, elapsed)
             else:
-                result = mxq_model.infer([inputs_embeds_numpy[:, :, start_index:end_index, :]], None, cache_size)
-
+                result = mxq_model.infer([chunk], None, cache_size)
             assert result is not None, "mxq infer result is None!"
-            logits_ndarray = result[0]
-
             if past_key_values is not None:
-                past_key_values.update_cache_position(cache_position[start_index:end_index])
+                past_key_values.update_cache_position(cache_position[start:end])
+            return result[0]
 
-        logits = torch.tensor(logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device).squeeze(0)
+        # Path 1 & 2: chunked pass with caller's prefill_chunk_size. Path 2
+        # additionally collects every chunk's output so the concatenation
+        # covers the full input.
+        if is_default_keep or supports_all:
+            num_of_chunks = math.ceil(seq_len / resolved_prefill_chunk_size)
+            assert num_of_chunks > 0, "num_of_chunks is not positive! num_of_chunks: %d" % num_of_chunks
 
-        return logits
+            per_chunk_logits: list[np.ndarray] = []
+            logits_ndarray: Optional[np.ndarray] = None
+            for i in range(num_of_chunks):
+                start_index = i * resolved_prefill_chunk_size
+                end_index = min(start_index + resolved_prefill_chunk_size, seq_len)
+                logits_ndarray = _do_infer(start_index, end_index)
+                if supports_all:
+                    per_chunk_logits.append(logits_ndarray)
+
+            if supports_all:
+                logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
+                positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+                token_axis = logits_ndarray.ndim - 2
+                logits_ndarray = np.take(logits_ndarray, positions_to_keep, axis=token_axis)
+
+            assert logits_ndarray is not None
+            return torch.tensor(
+                logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device
+            ).squeeze(0)
+
+        # Path 3: fallback. Interleave normal chunks (for positions the
+        # caller does not care about) with size-1 infer calls (one per kept
+        # position). The KV cache advances monotonically through every
+        # position of the input, so subsequent decode steps see the same
+        # cache state as the other two paths would leave behind.
+        positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+        per_position_logits: dict[int, np.ndarray] = {}
+        cursor = 0
+        for p in positions_to_keep:
+            while cursor < p:
+                end_index = min(cursor + resolved_prefill_chunk_size, p)
+                _do_infer(cursor, end_index)
+                cursor = end_index
+            per_position_logits[p] = _do_infer(cursor, cursor + 1)
+            cursor += 1
+        while cursor < seq_len:
+            end_index = min(cursor + resolved_prefill_chunk_size, seq_len)
+            _do_infer(cursor, end_index)
+            cursor = end_index
+
+        logits_ndarray = np.concatenate(
+            [per_position_logits[p] for p in positions_to_keep], axis=-2
+        )
+        return torch.tensor(
+            logits_ndarray, dtype=inputs_embeds.dtype, device=inputs_embeds.device
+        ).squeeze(0)
 
     def resolve_batched_attention_mask(
         self,
@@ -239,6 +366,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         past_key_values: Optional[MobilintCache],
         prefill_chunk_size: int = 0,
         count_npu_time: bool = False,
+        logits_to_keep: Union[int, torch.Tensor] = 1,
     ):
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         batch_size = attention_mask.shape[0]
@@ -276,179 +404,408 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         assert prefill_chunk_size > 0, (
             "prefill_chunk_size should be a positive number! prefill_chunk_size: %d" % prefill_chunk_size
         )
-        num_of_chunks = math.ceil(max_sequence_length / prefill_chunk_size)
 
-        logits_dict: dict[int, torch.Tensor] = {}
+        is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
+        supports_all = False if is_default_keep else self._mxq_supports_all_logits()
 
-        for i in range(num_of_chunks):
-            start_index = i * prefill_chunk_size
-
-            sequence_lengths_chunks: list[int] = []
-            cache_sizes_chunks: list[int] = []
-            cache_ids: list[int] = []
-            prefill_masks: list[bool] = []
-            inputs_embeds_chunks: list[torch.Tensor] = []
-            seen_tokens: dict[int, int] = {}
-
+        keep_positions_by_item: dict[int, list[int]] = {}
+        if not is_default_keep:
             for j in range(batch_size):
-                end_index = min(start_index + prefill_chunk_size, sequence_lengths[j])
-                if start_index < sequence_lengths[j] and end_index <= sequence_lengths[j]:
-                    sequence_lengths_chunks.append(end_index - start_index)
-                    cache_sizes_chunks.append(past_key_values.get_seq_length(j) if past_key_values is not None else 0)
-                    cache_ids.append(j)
-                    prefill_masks.append(end_index < inputs_embeds_masked[j].shape[0])
-                    inputs_embeds_chunks.append(inputs_embeds_masked[j][start_index:end_index, :])
-                    seen_tokens[j] = end_index - start_index
+                keep_positions_by_item[j] = self._normalize_logits_to_keep(logits_to_keep, sequence_lengths[j])
 
-            if len(inputs_embeds_chunks) == 0:
-                continue
-
-            inputs_embeds_concat = torch.concat(inputs_embeds_chunks, dim=0).unsqueeze(0)
-            inputs_embeds_numpy: np.ndarray = inputs_embeds_concat.type(torch.float32).cpu().numpy()
-
-            if inputs_embeds_numpy.ndim == 3:
-                inputs_embeds_numpy = np.expand_dims(inputs_embeds_numpy, 1)
-
-            batch_params = [
+        def _run_batch_infer(
+            cache_ids_l: list[int],
+            sequence_lengths_chunks_l: list[int],
+            cache_sizes_chunks_l: list[int],
+            inputs_embeds_chunks_l: list[torch.Tensor],
+        ) -> np.ndarray:
+            inputs_embeds_concat_l = torch.concat(inputs_embeds_chunks_l, dim=0).unsqueeze(0)
+            inputs_embeds_numpy_l: np.ndarray = inputs_embeds_concat_l.type(torch.float32).cpu().numpy()
+            if inputs_embeds_numpy_l.ndim == 3:
+                inputs_embeds_numpy_l = np.expand_dims(inputs_embeds_numpy_l, 1)
+            batch_params_l = [
                 qbruntime.BatchParam(
-                    sequence_length=sequence_lengths_chunks[k],
-                    cache_size=cache_sizes_chunks[k],
-                    cache_id=cache_ids[k],
+                    sequence_length=sequence_lengths_chunks_l[k],
+                    cache_size=cache_sizes_chunks_l[k],
+                    cache_id=cache_ids_l[k],
                 )
-                for k in range(len(cache_ids))
+                for k in range(len(cache_ids_l))
             ]
-
-            if debug_enabled:
-                batch_seq_sum = sum(param.sequence_length for param in batch_params)
-                logger.debug(
-                    (
-                        "[BATCH-LLM][CHUNK %d/%d] start=%d active=%d ids=%s seq_chunks=%s "
-                        "cache_sizes=%s prefill=%s input_shape=%s batch_seq_sum=%d"
-                    ),
-                    i + 1,
-                    num_of_chunks,
-                    start_index,
-                    len(cache_ids),
-                    cache_ids,
-                    sequence_lengths_chunks,
-                    cache_sizes_chunks,
-                    prefill_masks,
-                    tuple(inputs_embeds_numpy.shape),
-                    batch_seq_sum,
-                )
-
-                logger.debug(
-                    "[BATCH-LLM][CHUNK %d/%d][BATCH_PARAMS] %s",
-                    i + 1,
-                    num_of_chunks,
-                    [
-                        {
-                            "sequence_length": sequence_lengths_chunks[k],
-                            "cache_size": cache_sizes_chunks[k],
-                            "cache_id": cache_ids[k],
-                        }
-                        for k in range(len(cache_ids))
-                    ],
-                )
-
-                first_input_chunk = inputs_embeds_chunks[0]
-                input_batch_same = all(
-                    chunk.shape == first_input_chunk.shape and torch.equal(chunk, first_input_chunk)
-                    for chunk in inputs_embeds_chunks[1:]
-                )
-                logger.debug(
-                    "[BATCH-LLM][CHUNK %d/%d] input_batch_same=%s",
-                    i + 1,
-                    num_of_chunks,
-                    input_batch_same,
-                )
-
             if count_npu_time:
                 t0 = time.perf_counter()
-                result = mxq_model.infer([inputs_embeds_numpy], None, 0, batch_params)
+                result_l = mxq_model.infer([inputs_embeds_numpy_l], None, 0, batch_params_l)
                 assert self.npu_time is not None
                 elapsed = time.perf_counter() - t0
                 self.npu_time += elapsed
                 phase: Literal["prefill", "decode"] = (
                     "prefill"
-                    if max_sequence_length > 1 or any(cache_size == 0 for cache_size in cache_sizes_chunks)
+                    if max_sequence_length > 1 or any(cache_size == 0 for cache_size in cache_sizes_chunks_l)
                     else "decode"
                 )
                 self._record_npu_timing(phase, elapsed)
             else:
-                result = mxq_model.infer([inputs_embeds_numpy], None, 0, batch_params)
-            assert result is not None, "mxq infer result is None!"
+                result_l = mxq_model.infer([inputs_embeds_numpy_l], None, 0, batch_params_l)
+            assert result_l is not None, "mxq infer result is None!"
+            return result_l[0]
 
+        # ------------------------------------------------------------------
+        # Path 1: default fast path (logits_to_keep == 1). Preserved
+        # verbatim including the existing debug instrumentation so cache
+        # contract regressions stay visible.
+        # ------------------------------------------------------------------
+        if is_default_keep:
+            num_of_chunks = math.ceil(max_sequence_length / prefill_chunk_size)
+            logits_dict: dict[int, torch.Tensor] = {}
+
+            for i in range(num_of_chunks):
+                start_index = i * prefill_chunk_size
+
+                sequence_lengths_chunks: list[int] = []
+                cache_sizes_chunks: list[int] = []
+                cache_ids: list[int] = []
+                prefill_masks: list[bool] = []
+                inputs_embeds_chunks: list[torch.Tensor] = []
+                seen_tokens: dict[int, int] = {}
+
+                for j in range(batch_size):
+                    end_index = min(start_index + prefill_chunk_size, sequence_lengths[j])
+                    if start_index < sequence_lengths[j] and end_index <= sequence_lengths[j]:
+                        sequence_lengths_chunks.append(end_index - start_index)
+                        cache_sizes_chunks.append(
+                            past_key_values.get_seq_length(j) if past_key_values is not None else 0
+                        )
+                        cache_ids.append(j)
+                        prefill_masks.append(end_index < inputs_embeds_masked[j].shape[0])
+                        inputs_embeds_chunks.append(inputs_embeds_masked[j][start_index:end_index, :])
+                        seen_tokens[j] = end_index - start_index
+
+                if len(inputs_embeds_chunks) == 0:
+                    continue
+
+                if debug_enabled:
+                    inputs_embeds_concat_dbg = torch.concat(inputs_embeds_chunks, dim=0).unsqueeze(0)
+                    inputs_embeds_numpy_dbg = inputs_embeds_concat_dbg.type(torch.float32).cpu().numpy()
+                    if inputs_embeds_numpy_dbg.ndim == 3:
+                        inputs_embeds_numpy_dbg = np.expand_dims(inputs_embeds_numpy_dbg, 1)
+                    batch_seq_sum = sum(sequence_lengths_chunks)
+                    logger.debug(
+                        (
+                            "[BATCH-LLM][CHUNK %d/%d] start=%d active=%d ids=%s seq_chunks=%s "
+                            "cache_sizes=%s prefill=%s input_shape=%s batch_seq_sum=%d"
+                        ),
+                        i + 1,
+                        num_of_chunks,
+                        start_index,
+                        len(cache_ids),
+                        cache_ids,
+                        sequence_lengths_chunks,
+                        cache_sizes_chunks,
+                        prefill_masks,
+                        tuple(inputs_embeds_numpy_dbg.shape),
+                        batch_seq_sum,
+                    )
+                    logger.debug(
+                        "[BATCH-LLM][CHUNK %d/%d][BATCH_PARAMS] %s",
+                        i + 1,
+                        num_of_chunks,
+                        [
+                            {
+                                "sequence_length": sequence_lengths_chunks[k],
+                                "cache_size": cache_sizes_chunks[k],
+                                "cache_id": cache_ids[k],
+                            }
+                            for k in range(len(cache_ids))
+                        ],
+                    )
+                    first_input_chunk = inputs_embeds_chunks[0]
+                    input_batch_same = all(
+                        chunk.shape == first_input_chunk.shape and torch.equal(chunk, first_input_chunk)
+                        for chunk in inputs_embeds_chunks[1:]
+                    )
+                    logger.debug(
+                        "[BATCH-LLM][CHUNK %d/%d] input_batch_same=%s",
+                        i + 1,
+                        num_of_chunks,
+                        input_batch_same,
+                    )
+
+                raw_output = _run_batch_infer(
+                    cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
+                )
+                logits_chunks = cast(
+                    torch.FloatTensor,
+                    torch.tensor(raw_output, dtype=inputs_embeds.dtype, device=inputs_embeds.device).reshape(
+                        [len(cache_ids), 1, -1]
+                    ),
+                )
+
+                if debug_enabled:
+                    first_logits = logits_chunks[0]
+                    result_batch_same = all(torch.equal(chunk, first_logits) for chunk in logits_chunks[1:])
+                    next_tokens = logits_chunks[:, -1, :].argmax(dim=-1).tolist()
+                    logger.debug(
+                        "[BATCH-LLM][CHUNK %d/%d] result_batch_same=%s next_tokens=%s",
+                        i + 1,
+                        num_of_chunks,
+                        result_batch_same,
+                        next_tokens,
+                    )
+                    if not result_batch_same and len(cache_ids) > 1:
+                        logits_vectors = logits_chunks[:, -1, :]
+                        cosine_similarity = torch.nn.functional.cosine_similarity(
+                            logits_vectors.unsqueeze(1),
+                            logits_vectors.unsqueeze(0),
+                            dim=-1,
+                        )
+                        max_abs_diff = torch.abs(
+                            logits_vectors.unsqueeze(1) - logits_vectors.unsqueeze(0)
+                        ).amax(dim=-1)
+                        cosine_rows = [
+                            " ".join(
+                                f"{float(cosine_similarity[row, col]):7.3f}"
+                                for col in range(cosine_similarity.shape[1])
+                            )
+                            for row in range(cosine_similarity.shape[0])
+                        ]
+                        max_abs_diff_rows = [
+                            " ".join(
+                                f"{float(max_abs_diff[row, col]):7.3f}" for col in range(max_abs_diff.shape[1])
+                            )
+                            for row in range(max_abs_diff.shape[0])
+                        ]
+                        logger.debug(
+                            "[BATCH-LLM][CHUNK %d/%d][COSINE_SIM]\ncache_ids=%s\n%s\n[MAX_ABS_DIFF]\n%s",
+                            i + 1,
+                            num_of_chunks,
+                            cache_ids,
+                            "\n".join(cosine_rows),
+                            "\n".join(max_abs_diff_rows),
+                        )
+                    logger.debug(
+                        "[BATCH-LLM][CHUNK %d/%d] infer_output_shape=%s",
+                        i + 1,
+                        num_of_chunks,
+                        tuple(logits_chunks.shape),
+                    )
+
+                for j, prefill_mask in enumerate(prefill_masks):
+                    if prefill_mask is False:
+                        cache_id = cache_ids[j]
+                        logits_dict[cache_id] = logits_chunks[j, :, :].clone()
+
+                if past_key_values is not None:
+                    past_key_values.update_seen_tokens(seen_tokens)
+
+            if debug_enabled:
+                missing_ids = [cache_id for cache_id in range(batch_size) if cache_id not in logits_dict]
+                logger.debug(
+                    "[BATCH-LLM][END] logits_dict_keys=%s missing_ids=%s",
+                    sorted(list(logits_dict.keys())),
+                    missing_ids,
+                )
+
+            logits_list = [logits_dict[cache_id] for cache_id in range(batch_size)]
+            stacked = cast(torch.FloatTensor, torch.stack(logits_list, dim=0))
+            if debug_enabled:
+                logger.debug("[BATCH-LLM][END] output_shape=%s", tuple(stacked.shape))
+            return stacked
+
+        # ------------------------------------------------------------------
+        # Path 2: dynamic-output MXQ. The compiled model already produces
+        # per-position logits, so we keep the caller's chunk size and split
+        # each chunk's flat output by per-item offsets. Per-item logits are
+        # concatenated, sliced by that item's kept positions, right-padded
+        # to the longest kept sequence, and stacked.
+        # ------------------------------------------------------------------
+        if supports_all:
+            num_of_chunks = math.ceil(max_sequence_length / prefill_chunk_size)
+            all_logits_by_item: dict[int, list[np.ndarray]] = {j: [] for j in range(batch_size)}
+
+            for i in range(num_of_chunks):
+                start_index = i * prefill_chunk_size
+
+                sequence_lengths_chunks = []
+                cache_sizes_chunks = []
+                cache_ids = []
+                inputs_embeds_chunks = []
+                seen_tokens = {}
+
+                for j in range(batch_size):
+                    end_index = min(start_index + prefill_chunk_size, sequence_lengths[j])
+                    if start_index < sequence_lengths[j] and end_index <= sequence_lengths[j]:
+                        sequence_lengths_chunks.append(end_index - start_index)
+                        cache_sizes_chunks.append(
+                            past_key_values.get_seq_length(j) if past_key_values is not None else 0
+                        )
+                        cache_ids.append(j)
+                        inputs_embeds_chunks.append(inputs_embeds_masked[j][start_index:end_index, :])
+                        seen_tokens[j] = end_index - start_index
+
+                if len(inputs_embeds_chunks) == 0:
+                    continue
+
+                raw_output = _run_batch_infer(
+                    cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
+                )
+
+                total_tokens = sum(sequence_lengths_chunks)
+                flat_output = np.asarray(raw_output).reshape(total_tokens, -1)
+                offset = 0
+                for k, cache_id in enumerate(cache_ids):
+                    len_k = sequence_lengths_chunks[k]
+                    all_logits_by_item[cache_id].append(flat_output[offset : offset + len_k, :].copy())
+                    offset += len_k
+
+                if debug_enabled:
+                    logger.debug(
+                        "[BATCH-LLM][DYNAMIC CHUNK %d/%d] start=%d ids=%s seq_chunks=%s flat_output_shape=%s",
+                        i + 1,
+                        num_of_chunks,
+                        start_index,
+                        cache_ids,
+                        sequence_lengths_chunks,
+                        tuple(flat_output.shape),
+                    )
+
+                if past_key_values is not None:
+                    past_key_values.update_seen_tokens(seen_tokens)
+
+            per_item_sliced: list[torch.Tensor] = []
+            vocab_size = 0
+            for j in range(batch_size):
+                item_all = np.concatenate(all_logits_by_item[j], axis=0)
+                positions_j = keep_positions_by_item[j]
+                sliced = item_all[positions_j, :] if positions_j else item_all[0:0, :]
+                vocab_size = max(vocab_size, sliced.shape[-1])
+                per_item_sliced.append(
+                    torch.tensor(sliced, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
+                )
+
+            max_keep_len = max((item.shape[0] for item in per_item_sliced), default=0)
+            padded: list[torch.Tensor] = []
+            for item in per_item_sliced:
+                if item.shape[0] < max_keep_len:
+                    pad = torch.zeros(
+                        (max_keep_len - item.shape[0], vocab_size),
+                        dtype=item.dtype,
+                        device=item.device,
+                    )
+                    item = torch.cat([item, pad], dim=0)
+                padded.append(item)
+            stacked = cast(torch.FloatTensor, torch.stack(padded, dim=0))
+            if debug_enabled:
+                logger.debug("[BATCH-LLM][END] output_shape=%s", tuple(stacked.shape))
+            return stacked
+
+        # ------------------------------------------------------------------
+        # Path 3: fallback for last-only MXQ with a non-default request.
+        # We advance a shared cursor across the batch; the chunk size uses
+        # the caller's ``prefill_chunk_size`` until we reach the earliest
+        # kept position across items, then drops to 1 so each kept
+        # position is captured with its own infer call. Because items
+        # share the same iteration structure we key on the shared cursor
+        # and only record logits for items whose kept-set contains it.
+        # ------------------------------------------------------------------
+        keep_sets: dict[int, set[int]] = {j: set(keep_positions_by_item[j]) for j in range(batch_size)}
+        min_keep_start = max_sequence_length
+        for j in range(batch_size):
+            positions_j = keep_positions_by_item[j]
+            if positions_j:
+                min_keep_start = min(min_keep_start, positions_j[0])
+
+        per_item_kept_logits: dict[int, dict[int, torch.Tensor]] = {j: {} for j in range(batch_size)}
+        cursor = 0
+        while cursor < max_sequence_length:
+            if cursor < min_keep_start:
+                chunk = min(prefill_chunk_size, min_keep_start - cursor)
+            else:
+                chunk = 1
+
+            sequence_lengths_chunks = []
+            cache_sizes_chunks = []
+            cache_ids = []
+            inputs_embeds_chunks = []
+            seen_tokens = {}
+
+            for j in range(batch_size):
+                end_j = min(cursor + chunk, sequence_lengths[j])
+                if cursor < sequence_lengths[j] and end_j <= sequence_lengths[j]:
+                    sequence_lengths_chunks.append(end_j - cursor)
+                    cache_sizes_chunks.append(
+                        past_key_values.get_seq_length(j) if past_key_values is not None else 0
+                    )
+                    cache_ids.append(j)
+                    inputs_embeds_chunks.append(inputs_embeds_masked[j][cursor:end_j, :])
+                    seen_tokens[j] = end_j - cursor
+
+            if not inputs_embeds_chunks:
+                cursor += chunk
+                continue
+
+            raw_output = _run_batch_infer(
+                cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
+            )
             logits_chunks = cast(
                 torch.FloatTensor,
-                torch.tensor(result[0], dtype=inputs_embeds.dtype, device=inputs_embeds.device).reshape(
+                torch.tensor(raw_output, dtype=inputs_embeds.dtype, device=inputs_embeds.device).reshape(
                     [len(cache_ids), 1, -1]
                 ),
             )
 
             if debug_enabled:
-                first_logits = logits_chunks[0]
-                result_batch_same = all(torch.equal(chunk, first_logits) for chunk in logits_chunks[1:])
-                next_tokens = logits_chunks[:, -1, :].argmax(dim=-1).tolist()
                 logger.debug(
-                    "[BATCH-LLM][CHUNK %d/%d] result_batch_same=%s next_tokens=%s",
-                    i + 1,
-                    num_of_chunks,
-                    result_batch_same,
-                    next_tokens,
-                )
-                if not result_batch_same and len(cache_ids) > 1:
-                    logits_vectors = logits_chunks[:, -1, :]
-                    cosine_similarity = torch.nn.functional.cosine_similarity(
-                        logits_vectors.unsqueeze(1),
-                        logits_vectors.unsqueeze(0),
-                        dim=-1,
-                    )
-                    max_abs_diff = torch.abs(logits_vectors.unsqueeze(1) - logits_vectors.unsqueeze(0)).amax(dim=-1)
-                    cosine_rows = [
-                        " ".join(
-                            f"{float(cosine_similarity[row, col]):7.3f}" for col in range(cosine_similarity.shape[1])
-                        )
-                        for row in range(cosine_similarity.shape[0])
-                    ]
-                    max_abs_diff_rows = [
-                        " ".join(f"{float(max_abs_diff[row, col]):7.3f}" for col in range(max_abs_diff.shape[1]))
-                        for row in range(max_abs_diff.shape[0])
-                    ]
-                    logger.debug(
-                        "[BATCH-LLM][CHUNK %d/%d][COSINE_SIM]\ncache_ids=%s\n%s\n[MAX_ABS_DIFF]\n%s",
-                        i + 1,
-                        num_of_chunks,
-                        cache_ids,
-                        "\n".join(cosine_rows),
-                        "\n".join(max_abs_diff_rows),
-                    )
-
-                logger.debug(
-                    "[BATCH-LLM][CHUNK %d/%d] infer_output_shape=%s",
-                    i + 1,
-                    num_of_chunks,
-                    tuple(logits_chunks.shape),
+                    "[BATCH-LLM][FALLBACK] cursor=%d chunk=%d ids=%s seq_chunks=%s cache_sizes=%s",
+                    cursor,
+                    chunk,
+                    cache_ids,
+                    sequence_lengths_chunks,
+                    cache_sizes_chunks,
                 )
 
-            for j, prefill_mask in enumerate(prefill_masks):
-                if prefill_mask is False:
-                    cache_id = cache_ids[j]
-                    logits_dict[cache_id] = logits_chunks[j, :, :].clone()
+            if chunk == 1:
+                for k, cache_id in enumerate(cache_ids):
+                    if cursor in keep_sets[cache_id]:
+                        per_item_kept_logits[cache_id][cursor] = logits_chunks[k, :, :].clone()
 
             if past_key_values is not None:
                 past_key_values.update_seen_tokens(seen_tokens)
 
-        if debug_enabled:
-            missing_ids = [cache_id for cache_id in range(batch_size) if cache_id not in logits_dict]
-            logger.debug(
-                "[BATCH-LLM][END] logits_dict_keys=%s missing_ids=%s",
-                sorted(list(logits_dict.keys())),
-                missing_ids,
-            )
+            cursor += chunk
 
-        logits_list = [logits_dict[cache_id] for cache_id in range(batch_size)]
-        return cast(torch.FloatTensor, torch.stack(logits_list, dim=0))
+        per_item_final: list[torch.Tensor] = []
+        vocab_size = 0
+        for j in range(batch_size):
+            positions_j = keep_positions_by_item[j]
+            if positions_j:
+                item_logits = torch.cat(
+                    [per_item_kept_logits[j][p] for p in positions_j], dim=0
+                )
+                vocab_size = max(vocab_size, item_logits.shape[-1])
+            else:
+                item_logits = torch.empty(
+                    (0, 0), dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                )
+            per_item_final.append(item_logits)
+
+        max_keep_len = max((item.shape[0] for item in per_item_final), default=0)
+        padded_final: list[torch.Tensor] = []
+        for item in per_item_final:
+            if item.shape[0] < max_keep_len:
+                pad_rows = max_keep_len - item.shape[0]
+                pad_cols = vocab_size if item.numel() == 0 else item.shape[-1]
+                if item.numel() == 0:
+                    item = torch.zeros(
+                        (0, pad_cols), dtype=inputs_embeds.dtype, device=inputs_embeds.device
+                    )
+                pad = torch.zeros(
+                    (pad_rows, pad_cols), dtype=item.dtype, device=item.device
+                )
+                item = torch.cat([item, pad], dim=0)
+            padded_final.append(item)
+        stacked = cast(torch.FloatTensor, torch.stack(padded_final, dim=0))
+        if debug_enabled:
+            logger.debug("[BATCH-LLM][END] output_shape=%s", tuple(stacked.shape))
+        return stacked
 
     @staticmethod
     def _validate_batch_cache(past_key_values: Optional[MobilintCache], batch_size: int) -> None:

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -338,17 +338,16 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         ``.detach().to("cpu").flatten().tolist()`` because the downstream
         wrap/validate and path-3 cursor arithmetic operate on a Python
         ``list[int]``. For typical selectors (a handful to a few dozen
-        positions) this transfer is negligible. In workloads that repeatedly
-        call this helper with a very large GPU-resident selector tensor —
-        e.g. perplexity evaluation with thousands of kept positions — the
-        per-call device-to-host copy can become a hot spot; in that case
-        callers should either move the selector to CPU once up front or,
-        when the selection is contiguous, pass an int form (``0`` for
-        keep-all or ``N`` for the last ``N``) which skips the copy entirely.
+        positions) this transfer is negligible. When the same tensor
+        selector must be resolved against multiple ``seq_len`` values —
+        e.g. a batched forward with mixed lengths, or perplexity
+        evaluation reusing one large selector across the batch — call
+        :meth:`_output_positions_from_cpu_indices` after materializing
+        the selector once, to avoid a per-call device-to-host copy.
         """
         if isinstance(logits_to_keep, torch.Tensor):
             raw = logits_to_keep.detach().to("cpu").flatten().tolist()
-            return cls._wrap_and_validate_indices(raw, seq_len)
+            return cls._output_positions_from_cpu_indices(raw, seq_len)
         n = int(logits_to_keep)
         if n < 0:
             raise ValueError(
@@ -358,6 +357,25 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         if n == 0 or n >= seq_len:
             return list(range(seq_len))
         return list(range(seq_len - n, seq_len))
+
+    @classmethod
+    def _output_positions_from_cpu_indices(
+        cls,
+        cpu_indices: list[int],
+        seq_len: int,
+    ) -> list[int]:
+        """Tensor-selector fast path once the CPU materialization is hoisted.
+
+        Given an already-CPU list of raw indices (typically produced by
+        ``logits_to_keep.detach().to("cpu").flatten().tolist()`` once
+        outside a per-item loop), apply the same wrap-and-validate step
+        as :meth:`_output_positions_for_logits_to_keep` — HF-style
+        negative wrap plus range check — and return the resulting output
+        positions. The batch loop in :meth:`_llm_forward_batch` uses this
+        entry point so a large GPU-resident selector is copied to host
+        exactly once per forward, instead of once per batch item.
+        """
+        return cls._wrap_and_validate_indices(cpu_indices, seq_len)
 
     @classmethod
     def _walk_positions_for_logits_to_keep(
@@ -752,12 +770,12 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # scalar tensor selector we additionally require every item to share the
         # same length, because a single value can only uniformly represent
         # "last position" when there is only one length in the batch.
+        lens_equal = all(sl == sequence_lengths[0] for sl in sequence_lengths)
         if isinstance(logits_to_keep, int) and logits_to_keep == 1:
             is_default_keep = True
         else:
             # int==1 is handled by the fast pre-check above, so the call
             # below only meaningfully evaluates torch.Tensor selectors.
-            lens_equal = all(sl == sequence_lengths[0] for sl in sequence_lengths)
             is_default_keep = lens_equal and self._is_last_only_selector(
                 logits_to_keep, sequence_lengths[0]
             )
@@ -769,11 +787,35 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         output_positions_by_item: dict[int, list[int]] = {}
         walk_positions_by_item: dict[int, list[int]] = {}
         if not is_default_keep:
-            for j in range(batch_size):
-                output_positions_by_item[j] = self._output_positions_for_logits_to_keep(
-                    logits_to_keep, sequence_lengths[j]
-                )
-                walk_positions_by_item[j] = sorted(set(output_positions_by_item[j]))
+            # Hoist the tensor->CPU copy: the raw selector indices are
+            # identical across the batch, only the per-item seq_len differs.
+            # Without this, a large GPU-resident selector would pay a
+            # device->host copy on every batch item.
+            if isinstance(logits_to_keep, torch.Tensor):
+                cpu_indices = logits_to_keep.detach().to("cpu").flatten().tolist()
+
+                def _positions_for(seq_len_j: int) -> list[int]:
+                    return self._output_positions_from_cpu_indices(cpu_indices, seq_len_j)
+            else:
+                def _positions_for(seq_len_j: int) -> list[int]:
+                    return self._output_positions_for_logits_to_keep(logits_to_keep, seq_len_j)
+
+            if lens_equal:
+                # Uniform-length batches (common in perplexity eval) can share
+                # a single result across every item: the position lists depend
+                # only on seq_len and the selector, both fixed across the batch.
+                # Downstream code only reads these lists (indexing / iteration /
+                # len), so sharing the same object is safe.
+                shared_out = _positions_for(sequence_lengths[0])
+                shared_walk = sorted(set(shared_out))
+                for j in range(batch_size):
+                    output_positions_by_item[j] = shared_out
+                    walk_positions_by_item[j] = shared_walk
+            else:
+                for j in range(batch_size):
+                    positions_j = _positions_for(sequence_lengths[j])
+                    output_positions_by_item[j] = positions_j
+                    walk_positions_by_item[j] = sorted(set(positions_j))
 
         def _run_batch_infer(
             cache_ids_l: list[int],

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -822,6 +822,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             sequence_lengths_chunks_l: list[int],
             cache_sizes_chunks_l: list[int],
             inputs_embeds_chunks_l: list[torch.Tensor],
+            phase_override: Optional[Literal["prefill", "decode"]] = None,
         ) -> tuple[np.ndarray, tuple[int, ...]]:
             inputs_embeds_concat_l = torch.concat(inputs_embeds_chunks_l, dim=0).unsqueeze(0)
             inputs_embeds_numpy_l: np.ndarray = inputs_embeds_concat_l.type(torch.float32).cpu().numpy()
@@ -841,7 +842,14 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 assert self.npu_time is not None
                 elapsed = time.perf_counter() - t0
                 self.npu_time += elapsed
-                phase: Literal["prefill", "decode"] = (
+                # Path 3 fallback advances a shared cursor across the batch, so its
+                # chunk=1 capture calls run at cursor > 0 with all cache_sizes > 0 —
+                # but the auto-heuristic below latches on max_sequence_length (the
+                # batch-wide max, not the current chunk size) and would misclassify
+                # every one of those captures as 'prefill'. Path 3 passes an
+                # explicit phase_override to keep decode_time accurate; Path 1 and
+                # Path 2 leave it None and get the auto-heuristic.
+                phase: Literal["prefill", "decode"] = phase_override or (
                     "prefill"
                     if max_sequence_length > 1 or any(cache_size == 0 for cache_size in cache_sizes_chunks_l)
                     else "decode"
@@ -1178,8 +1186,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 cursor += chunk
                 continue
 
+            # chunk == 1 iterations only fire when a kept position lands at cursor
+            # (see the ``elif min_next_needed == cursor`` branch above), so they
+            # are always the size-1 logit-capture calls at cursor > 0 with the KV
+            # cache already populated — i.e. decode-shaped work. Force the phase
+            # rather than let the auto-heuristic classify these as 'prefill'
+            # because max_sequence_length > 1.
             raw_output, _ = _run_batch_infer(
-                cache_ids, sequence_lengths_chunks, cache_sizes_chunks, inputs_embeds_chunks
+                cache_ids,
+                sequence_lengths_chunks,
+                cache_sizes_chunks,
+                inputs_embeds_chunks,
+                phase_override="decode" if chunk == 1 else None,
             )
             logits_chunks = cast(
                 torch.FloatTensor,

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -18,6 +18,10 @@ from .configuration_utils import MobilintConfigMixin, MobilintEncoderDecoderConf
 logger = logging.getLogger(__name__)
 
 
+_MXQ_DYNAMIC_AXIS_SENTINEL = -1
+_MXQ_TOKEN_AXIS_INDEX = -2
+
+
 class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
     npu_backend_prefix: Literal["", "encoder_", "decoder_", "base_", "draft_", "fc_"] = ""
     _DEFAULT_PREFILL_CHUNK_SIZE = 128
@@ -151,12 +155,13 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         Some MXQ builds compile the LM head with a dynamic token axis, so a
         single ``mxq_model.infer`` call returns per-position logits instead
         of only the last-token logit. We probe this by inspecting the first
-        entry of :py:meth:`qbruntime.Model.get_model_output_shape`: token
-        axis is the second-to-last dimension (matching both
-        ``(batch, seq_len, vocab)`` and ``(batch, 1, seq_len, vocab)``
-        layouts we see in practice), and a value of ``-1`` marks it as
-        dynamic. The result is cached on the instance because the shape is
-        fixed for the lifetime of the loaded model.
+        entry of :py:meth:`qbruntime.Model.get_model_output_shape`: the
+        token axis lives at ``_MXQ_TOKEN_AXIS_INDEX`` (the second-to-last
+        dimension, matching both ``(batch, seq_len, vocab)`` and
+        ``(batch, 1, seq_len, vocab)`` layouts we see in practice), and a
+        value equal to ``_MXQ_DYNAMIC_AXIS_SENTINEL`` marks it as dynamic.
+        The result is cached on the instance because the shape is fixed
+        for the lifetime of the loaded model.
         """
         cached = getattr(self, "_mxq_all_logits_cached", None)
         if cached is not None:
@@ -166,7 +171,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             output_shapes = self.npu_backend.mxq_model.get_model_output_shape()
             if output_shapes:
                 first_shape = tuple(output_shapes[0])
-                if len(first_shape) >= 2 and int(first_shape[-2]) == -1:
+                if (
+                    len(first_shape) >= abs(_MXQ_TOKEN_AXIS_INDEX)
+                    and int(first_shape[_MXQ_TOKEN_AXIS_INDEX]) == _MXQ_DYNAMIC_AXIS_SENTINEL
+                ):
                     supports = True
         except (AttributeError, RuntimeError):
             # AttributeError: backend or ``get_model_output_shape`` missing.

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -316,6 +316,18 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         rejected with :class:`ValueError`: silently mapping them to
         keep-all is a footgun (the caller probably meant ``torch.tensor``
         negative-wrap indexing), and HF itself does not accept them.
+
+        Performance: tensor inputs are always materialized to CPU via
+        ``.detach().to("cpu").flatten().tolist()`` because the downstream
+        wrap/validate and path-3 cursor arithmetic operate on a Python
+        ``list[int]``. For typical selectors (a handful to a few dozen
+        positions) this transfer is negligible. In workloads that repeatedly
+        call this helper with a very large GPU-resident selector tensor —
+        e.g. perplexity evaluation with thousands of kept positions — the
+        per-call device-to-host copy can become a hot spot; in that case
+        callers should either move the selector to CPU once up front or,
+        when the selection is contiguous, pass an int form (``0`` for
+        keep-all or ``N`` for the last ``N``) which skips the copy entirely.
         """
         if isinstance(logits_to_keep, torch.Tensor):
             raw = logits_to_keep.detach().to("cpu").flatten().tolist()

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -186,32 +186,68 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         return supports
 
     @staticmethod
-    def _normalize_logits_to_keep(logits_to_keep: Union[int, torch.Tensor], seq_len: int) -> list[int]:
-        """Translate HF-style ``logits_to_keep`` into an ordered position list.
+    def _wrap_and_validate_indices(indices: list[int], seq_len: int) -> list[int]:
+        """Apply HF-style negative-wrap and range-check to a list of position indices.
 
-        * ``int == 0``: keep every position.
-        * ``int > 0``: keep the last N positions (clamped to ``seq_len``).
-        * ``torch.Tensor``: treat as position indices (negatives wrap,
-          out-of-range values are dropped, duplicates collapsed).
+        HF's ``hidden_states[:, tensor, :]`` fancy-indexing wraps negatives
+        (``-1 -> seq_len-1``) and raises on out-of-range values. We mirror
+        that: silently dropping out-of-range indices is a footgun because
+        the caller cannot tell whether their intent was satisfied.
+        """
+        wrapped: list[int] = []
+        for raw_index in indices:
+            idx = int(raw_index)
+            if idx < 0:
+                idx = seq_len + idx
+            if not 0 <= idx < seq_len:
+                raise IndexError(
+                    f"logits_to_keep index {int(raw_index)} out of range for seq_len={seq_len}"
+                )
+            wrapped.append(idx)
+        return wrapped
 
-        The returned list is sorted ascending so callers can walk the
-        sequence left-to-right when they need to interleave prefill and
-        per-position infer calls.
+    @classmethod
+    def _output_positions_for_logits_to_keep(
+        cls,
+        logits_to_keep: Union[int, torch.Tensor],
+        seq_len: int,
+    ) -> list[int]:
+        """Position indices to place in the final logits output, in HF order.
+
+        Mirrors HF's ``hidden_states[:, logits_to_keep, :]`` semantics for
+        tensor inputs: caller-supplied order is preserved and duplicates
+        are kept (a repeated index picks the same position twice).
+
+        Integer semantics: ``0`` (or any non-positive int) keeps every
+        position; ``n > 0`` keeps the last ``n`` positions (clamped to
+        ``seq_len``). Negative ints fall back to keep-all for backward
+        compatibility with the initial implementation in commit d92a353;
+        callers that need per-position selection should pass a tensor.
         """
         if isinstance(logits_to_keep, torch.Tensor):
-            indices = logits_to_keep.detach().to("cpu").flatten().tolist()
-            normalized: list[int] = []
-            for raw_index in indices:
-                idx = int(raw_index)
-                if idx < 0:
-                    idx = seq_len + idx
-                if 0 <= idx < seq_len:
-                    normalized.append(idx)
-            return sorted(set(normalized))
+            raw = logits_to_keep.detach().to("cpu").flatten().tolist()
+            return cls._wrap_and_validate_indices(raw, seq_len)
         n = int(logits_to_keep)
         if n <= 0 or n >= seq_len:
             return list(range(seq_len))
         return list(range(seq_len - n, seq_len))
+
+    @classmethod
+    def _walk_positions_for_logits_to_keep(
+        cls,
+        logits_to_keep: Union[int, torch.Tensor],
+        seq_len: int,
+    ) -> list[int]:
+        """Unique kept positions in ascending order, for KV-cursor walks.
+
+        The Path 3 fallback interleaves prefill and size-1 infer calls
+        while advancing a monotonic cursor through the sequence, so it
+        needs a sorted, deduped set of positions even when the caller's
+        tensor contains duplicates or arrives out of order. Assembly of
+        the final output tensor uses :meth:`_output_positions_for_logits_to_keep`
+        instead so duplicates and caller order survive.
+        """
+        return sorted(set(cls._output_positions_for_logits_to_keep(logits_to_keep, seq_len)))
 
     def mxq_forward(
         self,
@@ -279,9 +315,12 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
 
             if supports_all:
                 logits_ndarray = np.concatenate(per_chunk_logits, axis=-2)
-                positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+                # HF fancy-indexing preserves caller order and duplicates;
+                # ``np.take`` matches that when we pass the output positions
+                # directly without dedup/sort.
+                output_positions = self._output_positions_for_logits_to_keep(logits_to_keep, seq_len)
                 token_axis = logits_ndarray.ndim - 2
-                logits_ndarray = np.take(logits_ndarray, positions_to_keep, axis=token_axis)
+                logits_ndarray = np.take(logits_ndarray, output_positions, axis=token_axis)
 
             assert logits_ndarray is not None
             return torch.tensor(logits_ndarray, dtype=dtype, device=device)
@@ -291,10 +330,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # position). The KV cache advances monotonically through every
         # position of the input, so subsequent decode steps see the same
         # cache state as the other two paths would leave behind.
-        positions_to_keep = self._normalize_logits_to_keep(logits_to_keep, seq_len)
+        #
+        # ``walk_positions`` is sorted-unique so the cursor can advance
+        # monotonically; ``output_positions`` preserves caller order and
+        # duplicates so the final tensor matches HF fancy-indexing.
+        walk_positions = self._walk_positions_for_logits_to_keep(logits_to_keep, seq_len)
+        output_positions = self._output_positions_for_logits_to_keep(logits_to_keep, seq_len)
         per_position_logits: dict[int, np.ndarray] = {}
         cursor = 0
-        for p in positions_to_keep:
+        for p in walk_positions:
             while cursor < p:
                 end_index = min(cursor + prefill_chunk_size, p)
                 do_infer(cursor, end_index)
@@ -306,17 +350,17 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             do_infer(cursor, end_index)
             cursor = end_index
 
-        if not positions_to_keep:
-            # Empty selection (empty tensor or all indices out-of-range): the
-            # KV cache has already been advanced through the entire input by
-            # the trailing loop above. Return a (1, 0, 0) placeholder rather
-            # than calling np.concatenate on an empty list. The leading 1
-            # matches the batch axis that do_infer would have produced, so
-            # single-input callers can still ``.squeeze(0)`` down to (0, 0).
+        if not output_positions:
+            # Empty selection (empty tensor input): the KV cache has already
+            # been advanced through the entire input by the trailing loop
+            # above. Return a (1, 0, 0) placeholder rather than calling
+            # np.concatenate on an empty list. The leading 1 matches the
+            # batch axis that do_infer would have produced, so single-input
+            # callers can still ``.squeeze(0)`` down to (0, 0).
             return torch.zeros((1, 0, 0), dtype=dtype, device=device)
 
         logits_ndarray = np.concatenate(
-            [per_position_logits[p] for p in positions_to_keep], axis=-2
+            [per_position_logits[p] for p in output_positions], axis=-2
         )
         return torch.tensor(logits_ndarray, dtype=dtype, device=device)
 
@@ -480,10 +524,17 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         is_default_keep = isinstance(logits_to_keep, int) and logits_to_keep == 1
         supports_all = False if is_default_keep else self._mxq_supports_all_logits()
 
-        keep_positions_by_item: dict[int, list[int]] = {}
+        # Path 2 uses the output positions directly to assemble the final
+        # per-item tensor (HF order, duplicates preserved). Path 3 also
+        # needs a sorted-unique variant to drive the shared cursor.
+        output_positions_by_item: dict[int, list[int]] = {}
+        walk_positions_by_item: dict[int, list[int]] = {}
         if not is_default_keep:
             for j in range(batch_size):
-                keep_positions_by_item[j] = self._normalize_logits_to_keep(logits_to_keep, sequence_lengths[j])
+                output_positions_by_item[j] = self._output_positions_for_logits_to_keep(
+                    logits_to_keep, sequence_lengths[j]
+                )
+                walk_positions_by_item[j] = sorted(set(output_positions_by_item[j]))
 
         def _run_batch_infer(
             cache_ids_l: list[int],
@@ -762,7 +813,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                     # padding pass below can right-fill with -inf, symmetric
                     # with the Path 3 fallback.
                     item_all = np.empty((0, mxq_vocab_size), dtype=np.float32)
-                positions_j = keep_positions_by_item[j]
+                positions_j = output_positions_by_item[j]
                 sliced = item_all[positions_j, :] if positions_j else item_all[0:0, :]
                 vocab_size = max(vocab_size, sliced.shape[-1])
                 per_item_sliced.append(
@@ -796,9 +847,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         # positions. Items whose kept-set is exhausted (or empty) no
         # longer force a size-1 walk across the rest of the batch — a
         # single late kept position in one item used to drag every other
-        # item into per-step infer calls. keep_positions_by_item lists
-        # are sorted+deduped by ``_normalize_logits_to_keep``, so a
-        # per-item pointer tracks the next needed position in O(1).
+        # item into per-step infer calls. ``walk_positions_by_item`` is
+        # sorted-unique so a per-item pointer tracks the next needed
+        # position in O(1); duplicates and caller order are restored from
+        # ``output_positions_by_item`` when the final tensor is assembled.
         # ------------------------------------------------------------------
         pointer_by_item: dict[int, int] = {j: 0 for j in range(batch_size)}
         per_item_kept_logits: dict[int, dict[int, torch.Tensor]] = {j: {} for j in range(batch_size)}
@@ -809,7 +861,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 if cursor >= sequence_lengths[j]:
                     continue
                 ptr = pointer_by_item[j]
-                positions_j = keep_positions_by_item[j]
+                positions_j = walk_positions_by_item[j]
                 if ptr < len(positions_j):
                     nn = positions_j[ptr]
                     if min_next_needed is None or nn < min_next_needed:
@@ -866,7 +918,7 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             if chunk == 1:
                 for k, cache_id in enumerate(cache_ids):
                     ptr = pointer_by_item[cache_id]
-                    positions_j = keep_positions_by_item[cache_id]
+                    positions_j = walk_positions_by_item[cache_id]
                     if ptr < len(positions_j) and positions_j[ptr] == cursor:
                         per_item_kept_logits[cache_id][cursor] = logits_chunks[k, :, :].clone()
                         pointer_by_item[cache_id] = ptr + 1
@@ -879,7 +931,10 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         per_item_final: list[torch.Tensor] = []
         vocab_size = 0
         for j in range(batch_size):
-            positions_j = keep_positions_by_item[j]
+            # per_item_kept_logits is keyed by (unique) walk positions; the
+            # final tensor uses output positions so duplicate indices in the
+            # caller's tensor pick the same walk-position tensor twice.
+            positions_j = output_positions_by_item[j]
             if positions_j:
                 item_logits = torch.cat(
                     [per_item_kept_logits[j][p] for p in positions_j], dim=0

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -335,6 +335,15 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
             _do_infer(cursor, end_index)
             cursor = end_index
 
+        if not positions_to_keep:
+            # Empty selection (empty tensor or all indices out-of-range): the
+            # KV cache has already been advanced through the entire input by
+            # the trailing loop above. Return a (0, 0) placeholder rather
+            # than calling np.concatenate on an empty list.
+            return torch.zeros(
+                (0, 0), dtype=inputs_embeds.dtype, device=inputs_embeds.device
+            )
+
         logits_ndarray = np.concatenate(
             [per_position_logits[p] for p in positions_to_keep], axis=-2
         )

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -261,17 +261,23 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
         tensor inputs: caller-supplied order is preserved and duplicates
         are kept (a repeated index picks the same position twice).
 
-        Integer semantics: ``0`` (or any non-positive int) keeps every
-        position; ``n > 0`` keeps the last ``n`` positions (clamped to
-        ``seq_len``). Negative ints fall back to keep-all for backward
-        compatibility with the initial implementation in commit d92a353;
-        callers that need per-position selection should pass a tensor.
+        Integer semantics: ``0`` keeps every position (HF keep-all);
+        ``n > 0`` keeps the last ``n`` positions (clamped to ``seq_len``,
+        so ``n >= seq_len`` also keeps every position). Negative ints are
+        rejected with :class:`ValueError`: silently mapping them to
+        keep-all is a footgun (the caller probably meant ``torch.tensor``
+        negative-wrap indexing), and HF itself does not accept them.
         """
         if isinstance(logits_to_keep, torch.Tensor):
             raw = logits_to_keep.detach().to("cpu").flatten().tolist()
             return cls._wrap_and_validate_indices(raw, seq_len)
         n = int(logits_to_keep)
-        if n <= 0 or n >= seq_len:
+        if n < 0:
+            raise ValueError(
+                "logits_to_keep must be a non-negative int (0 keeps all positions, "
+                "n>0 keeps last n) or a torch.Tensor of positions; got %d" % n
+            )
+        if n == 0 or n >= seq_len:
             return list(range(seq_len))
         return list(range(seq_len - n, seq_len))
 

--- a/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/modeling_utils.py
@@ -1008,31 +1008,51 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                 )
                 # Two runtime layouts show up in practice for default-keep
                 # batched infer:
-                #   * per-item last row -> raw size == active * vocab, i.e.
-                #     the backend already collapsed the token axis (static
+                #   * per-item last row -> N rows == active, i.e. the
+                #     backend already collapsed the token axis (static
                 #     last-only MXQ, or a dynamic-axis MXQ whose batched
                 #     kernel happens to emit one row per item).
-                #   * per-token flat -> raw size == total_tokens * vocab,
-                #     i.e. a truly dynamic-axis backend that streams every
-                #     token row into the output (matches the shared
-                #     ``Path 2`` layout downstream).
-                # ``_mxq_static_vocab_size`` reads the compiled vocab axis
-                # once (cached); using it to disambiguate lets Path 1 stay
-                # correct across both layouts without a routing change.
+                #   * per-token flat -> N rows == total_tokens, i.e. a
+                #     truly dynamic-axis backend that streams every token
+                #     row into the output (matches the shared ``Path 2``
+                #     layout downstream).
+                # Path 1 must not require ``mxq_model.get_model_output_shape()``:
+                # some backends can infer last-token logits without
+                # exposing that probe, and ``_mxq_supports_all_logits`` is
+                # intentionally short-circuited here to avoid it. Derive
+                # vocab from the raw ndarray's trailing axis instead — LM
+                # head outputs always carry vocab as the last dim — and
+                # fall back to ``config.vocab_size`` for the rare 1D
+                # buffer case. Layout is then chosen by comparing the row
+                # count to ``active`` vs ``total_tokens``.
                 raw_arr = np.asarray(raw_output)
                 active = len(cache_ids)
                 total_tokens = sum(sequence_lengths_chunks)
-                vocab = self._mxq_static_vocab_size()
-                if raw_arr.size == active * vocab:
+                if raw_arr.ndim >= 2 and raw_arr.shape[-1] > 0:
+                    vocab = int(raw_arr.shape[-1])
+                else:
+                    vocab = int(getattr(self.config, "vocab_size", 0))
+                    if vocab <= 0 or raw_arr.size % vocab != 0:
+                        raise RuntimeError(
+                            f"Cannot derive vocab dim from flat batched MXQ "
+                            f"output of size {raw_arr.size}: raw ndarray is "
+                            f"rank {raw_arr.ndim} and config.vocab_size={vocab} "
+                            f"does not divide the buffer."
+                        )
+                n_rows = raw_arr.size // vocab
+                if n_rows == active:
+                    # Layout A (per-item last row) — includes the
+                    # active == total_tokens decode case where both
+                    # layouts coincide.
                     logits_chunks = cast(
                         torch.FloatTensor,
                         torch.tensor(
                             raw_arr, dtype=inputs_embeds.dtype, device=inputs_embeds.device
                         ).reshape([active, 1, vocab]),
                     )
-                elif raw_arr.size == total_tokens * vocab:
-                    # Per-token flat output: pick each item's last row using
-                    # cumulative offsets. Item k occupies rows
+                elif n_rows == total_tokens:
+                    # Layout B (per-token flat): pick each item's last
+                    # row using cumulative offsets. Item k occupies rows
                     # ``[offset, offset + seq_len_k)`` in the flat buffer;
                     # its default-keep row is the final one.
                     flat = raw_arr.reshape(total_tokens, vocab)
@@ -1049,10 +1069,11 @@ class MobilintModelMixin(PretrainedOnlyMixin, PreTrainedModel):
                     )
                 else:
                     raise RuntimeError(
-                        f"Unexpected batched MXQ output size {raw_arr.size} for "
-                        f"active={active}, total_tokens={total_tokens}, vocab={vocab}: "
-                        f"expected {active * vocab} (per-item last row) or "
-                        f"{total_tokens * vocab} (per-token flat)."
+                        f"Unexpected batched MXQ output row count {n_rows} "
+                        f"(vocab={vocab}, raw size={raw_arr.size}) for "
+                        f"active={active}, total_tokens={total_tokens}: "
+                        f"expected {active} (per-item last row) or "
+                        f"{total_tokens} (per-token flat)."
                     )
 
                 if debug_enabled:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ onnxruntime-gpu = [
     "onnx; sys_platform != 'darwin'",
     "onnxruntime-gpu; sys_platform != 'darwin'",
 ]
+qwen-asr = [
+    "qwen-asr",
+]
 
 # Tools setting -----------------------------------------
 [tool.setuptools]
@@ -114,7 +117,6 @@ dev = [
     "torchvision",
     "soundfile",
     "rich",
-    "qwen-asr",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
     "full_matrix: additional transformer model/core matrix cases enabled by --full-matrix.",
+    "upstream_contract: pins invariants of upstream HF transformers classes that our wrappers depend on; deselect with '-m \"not upstream_contract\"' in fast CI.",
 ]
 
 [tool.ruff]

--- a/tests/transformers/TEST.md
+++ b/tests/transformers/TEST.md
@@ -8,36 +8,24 @@ paths:
 
 You can validate Mobilint's Transformers integration with [`pytest`](https://docs.pytest.org/en/stable/). The snippets below assume your virtual environment is already activated.
 
+## Choose the Smallest Command
+
+Pick the smallest command that covers your change. `pytest tests/transformers` runs every category and takes several minutes, so reserve it for shared code. `--full-matrix` is even heavier and is only appropriate as a release or merge gate.
+
+| Change scope | Recommended command |
+| --- | --- |
+| Single model file edit | [Run a Single Test File](#run-a-single-test-file) |
+| Single model case validation | [Run a Single Model Case](#run-a-single-model-case) with `-k` |
+| Category-wide edit (e.g., all `text_generation` models) | [Run a Subdirectory of Tests](#run-a-subdirectory-of-tests) |
+| Shared utility edit (`generation_utils.py`, base pipelines, cross-model helpers) | [Run All Categories (Quick Mode)](#run-all-categories-quick-mode) |
+| Release / merge gate | [Run the Full Matrix](#run-the-full-matrix) |
+
 ## Install Development Dependencies
 
 Install the runtime extras plus the developer tooling (pytest, datasets, torchvision, audio libs, etc.) required by the test suite:
 
 ```bash
 pip install -e ".[transformers]" --group dev
-```
-
-## Run Quick Tests
-
-Execute the quick default suite. Unless you explicitly override model or core options, pytest keeps only the first model in each `MODEL_PATHS` list and runs single-core cases only:
-
-```bash
-pytest tests/transformers
-```
-
-## Run the Full Matrix
-
-Restore the full architecture matrix, including every model path declared in a test module plus the default core sweeps:
-
-```bash
-pytest tests/transformers --full-matrix
-```
-
-## Run a Subdirectory of Tests
-
-Limit execution to a test category, e.g., only causal language-model tests:
-
-```bash
-pytest tests/transformers/text_generation
 ```
 
 ## Run a Single Test File
@@ -60,6 +48,30 @@ Or you can just write the part of the model name.
 
 ```bash
 pytest tests/transformers/text_generation/non_batch/test_qwen2.py -k "0.5B"
+```
+
+## Run a Subdirectory of Tests
+
+Limit execution to a test category, e.g., only causal language-model tests:
+
+```bash
+pytest tests/transformers/text_generation
+```
+
+## Run All Categories (Quick Mode)
+
+Execute every category in quick mode. Unless you explicitly override model or core options, pytest keeps only the first model in each `MODEL_PATHS` list and runs single-core cases only. This still walks the full directory, so prefer a narrower scope from the table above when possible:
+
+```bash
+pytest tests/transformers
+```
+
+## Run the Full Matrix
+
+Restore the full architecture matrix, including every model path declared in a test module plus the default core sweeps. Reserve this for pre-merge or release validation, not per-change iteration:
+
+```bash
+pytest tests/transformers --full-matrix
 ```
 
 ## Sweep Core Modes

--- a/tests/transformers/_fake_mxq.py
+++ b/tests/transformers/_fake_mxq.py
@@ -1,0 +1,133 @@
+"""Shared fake MXQ backends for the LLM-core ``llm_forward`` tests.
+
+These stubs stand in for a real MXQ compiled model so tests can exercise the
+shared ``MobilintModelMixin.llm_forward`` code paths (fast/last-only, dynamic
+axis all-logits, and last-only fallback) without booting an NPU.
+
+The Qwen3-VL / Qwen2-VL text decoders have their own dual-input variants of
+these fakes (with a different ``infer`` signature); those live next to the
+respective VL tests and are intentionally not unified here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mblt_model_zoo.hf_transformers.utils.modeling_utils import MobilintModelMixin
+
+
+class FakeInputBufferInfo:
+    def __init__(self, max_width: int, max_cache_size: int = 128):
+        self.max_width = max_width
+        self.max_cache_size = max_cache_size
+
+
+class StaticLastOnlyMxq:
+    """MXQ stub that emits only the last-token logits per infer call.
+
+    ``infer`` accepts both the single-item shape (``[chunk], None, cache_size``)
+    and the batched shape (``[chunk], None, 0, batch_params``). Every call is
+    recorded so tests can assert chunk boundaries.
+    """
+
+    def __init__(self, vocab_size: int = 5, max_width: int = 4):
+        self.vocab_size = vocab_size
+        self.max_width = max_width
+        self.calls: list[dict] = []
+        self._batched_counter = 0
+
+    def get_input_buffer_info(self):
+        return [FakeInputBufferInfo(max_width=self.max_width)]
+
+    def get_model_output_shape(self):
+        # Static token axis (second-to-last); "1" signals last-token-only output.
+        return [(1, 1, self.vocab_size)]
+
+    def infer(self, inputs, _extra, cache_size, batch_params=None):
+        chunk = np.asarray(inputs[0])
+        if batch_params is None:
+            self.calls.append({"shape": tuple(chunk.shape), "cache_size": int(cache_size)})
+            return [np.full((1, 1, self.vocab_size), fill_value=float(cache_size), dtype=np.float32)]
+
+        self._batched_counter += 1
+        active_batch = len(batch_params)
+        payload = np.stack(
+            [
+                np.full((self.vocab_size,), fill_value=float(p.cache_id * 100 + self._batched_counter), dtype=np.float32)
+                for p in batch_params
+            ],
+            axis=0,
+        )
+        self.calls.append(
+            {
+                "shape": tuple(chunk.shape),
+                "batch": [(p.cache_id, p.sequence_length, p.cache_size) for p in batch_params],
+            }
+        )
+        assert payload.shape == (active_batch, self.vocab_size)
+        return [payload]
+
+
+class DynamicAxisMxq:
+    """MXQ stub that emits per-position logits."""
+
+    def __init__(self, vocab_size: int = 5, max_width: int = 4):
+        self.vocab_size = vocab_size
+        self.max_width = max_width
+        self.calls: list[dict] = []
+        self._batched_counter = 0
+
+    def get_input_buffer_info(self):
+        return [FakeInputBufferInfo(max_width=self.max_width)]
+
+    def get_model_output_shape(self):
+        # Dynamic token axis; the shared helper interprets this as all-logits.
+        return [(1, -1, self.vocab_size)]
+
+    def infer(self, inputs, _extra, cache_size, batch_params=None):
+        chunk = np.asarray(inputs[0])
+        if batch_params is None:
+            # Single-item: chunk is (1, 1, chunk_len, hidden). Emit
+            # (1, chunk_len, vocab) so the token axis is second-to-last.
+            chunk_len = int(chunk.shape[2])
+            offset = int(cache_size) * self.vocab_size
+            values = np.arange(chunk_len * self.vocab_size, dtype=np.float32) + offset
+            self.calls.append(
+                {"shape": tuple(chunk.shape), "cache_size": int(cache_size), "chunk_len": chunk_len}
+            )
+            return [values.reshape(1, chunk_len, self.vocab_size)]
+
+        self._batched_counter += 1
+        total_tokens = sum(int(p.sequence_length) for p in batch_params)
+        flat = np.arange(total_tokens * self.vocab_size, dtype=np.float32).reshape(
+            total_tokens, self.vocab_size
+        )
+        # Encode per-item id into the payload so batched tests can spot mixups.
+        offset = 0
+        for p in batch_params:
+            flat[offset : offset + int(p.sequence_length), :] += p.cache_id * 1000.0
+            offset += int(p.sequence_length)
+        self.calls.append(
+            {
+                "shape": tuple(chunk.shape),
+                "batch": [(p.cache_id, p.sequence_length, p.cache_size) for p in batch_params],
+            }
+        )
+        return [flat]
+
+
+class FakeBackend:
+    def __init__(self, mxq_model):
+        self.mxq_model = mxq_model
+
+
+def make_model(mxq, *, max_batch_size: int = 1) -> MobilintModelMixin:
+    """Construct a bare ``MobilintModelMixin`` without triggering NPU init."""
+    model = MobilintModelMixin.__new__(MobilintModelMixin)
+    model.npu_backend = FakeBackend(mxq)
+    config_kwargs = {"npu_prefill_chunk_size": None}
+    if max_batch_size > 1:
+        config_kwargs["max_batch_size"] = max_batch_size
+    model.config = type("Config", (), config_kwargs)()
+    model.npu_time = None
+    return model

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -428,6 +428,134 @@ def test_qwen3_asr_beam_forward_out_of_range_selector_raises() -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Beam-path chunk-boundary contract
+#
+# When the suffix crosses a prefill-chunk boundary (``suffix_length >
+# resolved_prefill_chunk_size``), the beam loop must accumulate every chunk's
+# logits — not just the final chunk's — before the ``logits_to_keep`` selector
+# runs. Without that, keep-all silently returns ``(batch, final_chunk_len,
+# vocab)`` instead of ``(batch, input_ids.shape[1], vocab)`` and any tensor
+# selector referencing a position outside the final chunk either raises
+# ``IndexError`` or picks the wrong row. The shape-only tests above miss this
+# because ``_DummyQwen3ASRBeamTextModel.resolve_prefill_chunk_size`` defaults
+# to 16, well above the window sizes they use.
+# ---------------------------------------------------------------------------
+
+
+def test_qwen3_asr_beam_forward_multi_chunk_keeps_full_window() -> None:
+    """Default keep-all across a chunk boundary must return the full window.
+
+    With ``prefill_chunk_size=2`` and a 4-token window the suffix decodes over
+    two chunks; the position-aware stub tags each row with its absolute cache
+    position so the returned tensor reveals whether every chunk survived.
+    """
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(4, dtype=torch.long),
+        prefill_chunk_size=2,
+    )
+
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (1, 4, 8)
+    for position in range(4):
+        assert torch.equal(logits[0, position], torch.full((8,), float(position)))
+
+
+def test_qwen3_asr_beam_forward_multi_chunk_selector_picks_early_position() -> None:
+    """A tensor selector referencing a position inside the *first* chunk must
+    still resolve to that position's logits after a multi-chunk suffix decode.
+    Buggy code (final-chunk-only) either raises out-of-range or returns the
+    wrong row when the selector reaches into an earlier chunk."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+    selector = torch.tensor([0, 3])
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(4, dtype=torch.long),
+        prefill_chunk_size=2,
+        logits_to_keep=selector,
+    )
+
+    assert logits.shape == (1, 2, 8)
+    assert torch.equal(logits[0, 0], torch.full((8,), 0.0))
+    assert torch.equal(logits[0, 1], torch.full((8,), 3.0))
+
+
+def test_qwen3_asr_beam_forward_multi_chunk_empty_selector() -> None:
+    """Empty-selector shape contract survives multi-chunk suffix decode."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(4, dtype=torch.long),
+        prefill_chunk_size=2,
+        logits_to_keep=torch.tensor([], dtype=torch.long),
+    )
+
+    # Empty selector still requires the KV cache to advance through every
+    # chunk — a fix that early-outs on empty selector would leave later
+    # decode steps with an incomplete cache.
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (1, 0, 8)
+
+
+def test_qwen3_asr_beam_forward_uneven_final_chunk_keeps_full_window() -> None:
+    """Odd suffix (last chunk shorter than the rest) must still yield the
+    full window. Guards against a fix that concatenates but assumes chunks
+    are all the same size."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(3, dtype=torch.long),
+        prefill_chunk_size=2,
+    )
+
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (1, 3, 8)
+    for position in range(3):
+        assert torch.equal(logits[0, position], torch.full((8,), float(position)))
+
+
 def test_qwen3_asr_forward_routes_logits_to_keep_to_beam_path() -> None:
     """Verify ``forward`` plumbs ``logits_to_keep`` into the beam path — the
     review-flagged bug was that the wrapper silently dropped the selector

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -36,6 +36,28 @@ class _InputsEmbedAwareMxqModel:
         return [torch.full((suffix_length, 8), row_value, dtype=torch.float32).numpy()]
 
 
+class _PositionAwareMxqModel:
+    """MXQ stub that tags each returned row with its absolute cache position.
+
+    Lets a test tell which sequence position ended up in the final tensor
+    without having to reason about beam-cache internals: the logits value
+    at row ``i`` is ``cache_size + i`` (broadcast across the vocab axis),
+    so a selector's picked positions are directly readable from the output.
+    """
+
+    def __init__(self) -> None:
+        self.infer_calls = 0
+
+    def infer(self, inputs: list[object], output_buffer: object, cache_size: int) -> list[object]:
+        del output_buffer
+        row_embeds = inputs[0]
+        self.infer_calls += 1
+        suffix_length = int(row_embeds.shape[2])
+        vocab = 8
+        positions = torch.arange(cache_size, cache_size + suffix_length, dtype=torch.float32)
+        return [positions.unsqueeze(-1).expand(suffix_length, vocab).contiguous().numpy()]
+
+
 class _DummyCache:
     """Tiny cache stub exposing the sequence length API used by ``forward``."""
 
@@ -72,9 +94,10 @@ class _DummyQwen3ASRTextModel(MobilintQwen3ASRTextModel):
         prefill_chunk_size: int | None = None,
         count_npu_time: bool = False,
         attention_mask: torch.Tensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
     ) -> torch.Tensor:
         """Return deterministic logits while exposing forward-time cache state."""
-        del cache_position, prefill_chunk_size, count_npu_time, attention_mask
+        del cache_position, prefill_chunk_size, count_npu_time, attention_mask, logits_to_keep
         self.forward_past_key_values = past_key_values
         return torch.zeros(
             inputs_embeds.shape[0],
@@ -245,6 +268,190 @@ def test_qwen3_asr_duplicate_logits_reuse_single_source_beams() -> None:
     assert mxq_model.infer_calls == 1
     assert logits.shape == (2, 1, 8)
     assert torch.equal(logits[0], logits[1])
+
+
+# ---------------------------------------------------------------------------
+# Beam-path logits_to_keep contract
+#
+# The non-beam path (`llm_forward`) honors HF-style `logits_to_keep`, but the
+# beam-cache-backed path (`_beam_llm_forward`) was silently returning the
+# full input window regardless of the selector. These tests pin the same
+# `(batch, kept, vocab)` shape contract that `TestLogitsShapeMatrix` enforces
+# for the non-beam paths, and they verify that a tensor selector actually
+# picks the requested absolute positions (via the position-aware stub) so a
+# broken index-select would fail loudly instead of returning the right shape
+# with wrong contents.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("logits_to_keep", "expected_kept"),
+    [
+        pytest.param(0, 3, id="int_0_keep_all"),
+        pytest.param(1, 1, id="int_1_last_only"),
+        pytest.param(2, 2, id="int_2_last_n"),
+        pytest.param(torch.tensor([0, 2]), 2, id="tensor_pick_positions"),
+        pytest.param(torch.tensor([-1]), 1, id="tensor_negative_last"),
+        pytest.param(torch.tensor([1, 1]), 2, id="tensor_duplicate_positions"),
+        pytest.param(torch.tensor([], dtype=torch.long), 0, id="tensor_empty"),
+    ],
+)
+def test_qwen3_asr_beam_forward_honors_logits_to_keep_shape(
+    logits_to_keep: object,
+    expected_kept: int,
+) -> None:
+    """Beam path returns ``(batch, kept, vocab)`` matching HF selector semantics."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 5, 6]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[7.0, 7.0], [8.0, 8.0], [9.0, 9.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(3, dtype=torch.long),
+        logits_to_keep=logits_to_keep,
+    )
+
+    assert logits.shape == (2, expected_kept, 8)
+
+
+def test_qwen3_asr_beam_forward_default_matches_pre_selector_behavior() -> None:
+    """Default (``logits_to_keep=0``) preserves the ``(batch, input_ids.shape[1], vocab)``
+    contract the beam path had before selector plumbing landed."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4], [4]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0]],
+            [[7.0, 7.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.tensor([0], dtype=torch.long),
+    )
+
+    assert logits.shape == (2, 1, 8)
+
+
+def test_qwen3_asr_beam_forward_tensor_selector_picks_correct_positions() -> None:
+    """A tensor selector must pick the requested absolute positions, not just
+    a shape-compatible slice. Uses the position-aware stub so each row of the
+    returned logits is tagged with its sequence index (``cache_size + i``)."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+    selector = torch.tensor([0, 3, 1])
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(4, dtype=torch.long),
+        logits_to_keep=selector,
+    )
+
+    assert logits.shape == (1, 3, 8)
+    # Row values are the absolute cache position (0..3) broadcast across vocab.
+    assert torch.equal(logits[0, 0], torch.full((8,), 0.0))
+    assert torch.equal(logits[0, 1], torch.full((8,), 3.0))
+    assert torch.equal(logits[0, 2], torch.full((8,), 1.0))
+
+
+def test_qwen3_asr_beam_forward_empty_selector_preserves_vocab_axis() -> None:
+    """``torch.tensor([])`` returns ``(batch, 0, vocab)`` — the vocab axis
+    survives so downstream stacking / lm_head passes see a consistent rank
+    regardless of which path (beam vs. non-beam) produced the logits."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5], [4, 5]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0]],
+            [[7.0, 7.0], [8.0, 8.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(2, dtype=torch.long),
+        logits_to_keep=torch.tensor([], dtype=torch.long),
+    )
+
+    assert logits.shape == (2, 0, 8)
+    assert logits.dtype == inputs_embeds.dtype
+
+
+def test_qwen3_asr_beam_forward_out_of_range_selector_raises() -> None:
+    """Out-of-range tensor indices must fail loudly, matching the non-beam
+    contract (HF fancy-indexing raises IndexError on the same input)."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0]]],
+        dtype=torch.float32,
+    )
+
+    with pytest.raises(IndexError):
+        model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=torch.arange(2, dtype=torch.long),
+            logits_to_keep=torch.tensor([99]),
+        )
+
+
+def test_qwen3_asr_forward_routes_logits_to_keep_to_beam_path() -> None:
+    """Verify ``forward`` plumbs ``logits_to_keep`` into the beam path — the
+    review-flagged bug was that the wrapper silently dropped the selector
+    when routing to ``_beam_llm_forward``."""
+    mxq_model = _InputsEmbedAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 5, 6]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[7.0, 7.0], [8.0, 8.0], [9.0, 9.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    outputs = model(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        logits_to_keep=1,
+    )
+
+    assert outputs.last_hidden_state.shape == (2, 1, 8)
 
 
 def test_qwen3_asr_thinker_forward_supports_return_dict_false() -> None:

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -26,6 +26,13 @@ class _InputsEmbedAwareMxqModel:
     def __init__(self) -> None:
         self.infer_calls = 0
 
+    def get_model_output_shape(self) -> list[tuple[int, ...]]:
+        # Dynamic token axis: matches the ``per-token logits`` shape this
+        # stub returns from ``infer``, so ``_mxq_supports_all_logits`` picks
+        # the ``supports_all`` branch of ``_beam_llm_forward`` and the
+        # caller's ``prefill_chunk_size`` is preserved.
+        return [(1, -1, 8)]
+
     def infer(self, inputs: list[object], output_buffer: object, cache_size: int) -> list[object]:
         """Return logits whose value identifies the forwarded embedding row."""
         del output_buffer, cache_size
@@ -48,6 +55,10 @@ class _PositionAwareMxqModel:
     def __init__(self) -> None:
         self.infer_calls = 0
 
+    def get_model_output_shape(self) -> list[tuple[int, ...]]:
+        # Dynamic token axis; see ``_InputsEmbedAwareMxqModel``.
+        return [(1, -1, 8)]
+
     def infer(self, inputs: list[object], output_buffer: object, cache_size: int) -> list[object]:
         del output_buffer
         row_embeds = inputs[0]
@@ -56,6 +67,37 @@ class _PositionAwareMxqModel:
         vocab = 8
         positions = torch.arange(cache_size, cache_size + suffix_length, dtype=torch.float32)
         return [positions.unsqueeze(-1).expand(suffix_length, vocab).contiguous().numpy()]
+
+
+class _LastOnlyMxqModel:
+    """MXQ stub compiled with a static token axis of 1 (last-token-only output).
+
+    ``get_model_output_shape`` reports ``(1, 1, vocab)`` — no
+    ``_MXQ_DYNAMIC_AXIS_SENTINEL`` in the token axis — so
+    ``_mxq_supports_all_logits`` returns ``False`` and the beam path routes
+    a non-default ``logits_to_keep`` request through the ``last_only_slow``
+    branch. ``infer`` emits a single row per call regardless of chunk width,
+    matching how a real last-only build behaves; the row value carries the
+    absolute cache position of the last input token in the chunk so tests
+    can assert which position ended up in the final tensor.
+    """
+
+    def __init__(self) -> None:
+        self.infer_calls = 0
+        self.vocab_size = 8
+
+    def get_model_output_shape(self) -> list[tuple[int, ...]]:
+        return [(1, 1, self.vocab_size)]
+
+    def infer(self, inputs: list[object], output_buffer: object, cache_size: int) -> list[object]:
+        del output_buffer
+        row_embeds = inputs[0]
+        self.infer_calls += 1
+        chunk_len = int(row_embeds.shape[2])
+        last_position = int(cache_size) + chunk_len - 1
+        return [
+            torch.full((1, self.vocab_size), float(last_position), dtype=torch.float32).numpy()
+        ]
 
 
 class _DummyCache:
@@ -805,3 +847,181 @@ def test_beam_forward_prefix_reuse_heterogeneous_beams_align() -> None:
     # tags each row with its absolute cache position.
     assert torch.equal(logits[0, 0], torch.full((8,), 2.0))
     assert torch.equal(logits[1, 0], torch.full((8,), 2.0))
+
+
+# ---------------------------------------------------------------------------
+# Beam-path last-only MXQ contract
+#
+# A last-only MXQ build compiles the LM head with a static token axis of 1,
+# so every ``mxq_model.infer`` call returns one row regardless of chunk
+# width. Before the ``_mxq_supports_all_logits`` dispatch landed in the beam
+# path, a multi-chunk suffix on such a backend produced ``num_chunks`` rows
+# instead of ``suffix_length`` rows: ``logits_to_keep=0`` returned a
+# truncated tensor and tensor / last-N selectors either raised
+# ``IndexError`` or picked from the wrong shortened axis. These tests pin
+# the fix in place:
+#
+# * ``logits_to_keep=1`` hits the last-token fast path and preserves the
+#   caller's ``prefill_chunk_size`` — only ``ceil(suffix_length /
+#   prefill_chunk_size)`` infer calls, and the returned row is the last
+#   window position on both static and dynamic backends.
+# * ``logits_to_keep=0`` (and any non-default selector) hits the size-1
+#   fallback so each infer emits one row per suffix position, matching
+#   the shape contract the outer alignment / selector logic already
+#   expects. Slow-path warning fires once per model instance.
+# ---------------------------------------------------------------------------
+
+
+def test_beam_forward_last_only_backend_logits_to_keep_1_uses_fast_path() -> None:
+    """``logits_to_keep=1`` on a last-only MXQ preserves the caller's
+    ``prefill_chunk_size`` (no size-1 override) and returns the last-token
+    logit. Pre-fix code either raised ``IndexError`` on the outer
+    ``index_select`` or picked from the wrong shortened axis when the
+    suffix crossed a chunk boundary."""
+    mxq_model = _LastOnlyMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(4, dtype=torch.long),
+        prefill_chunk_size=2,
+        logits_to_keep=1,
+    )
+
+    # Fast path: 2 chunks of the caller's ``prefill_chunk_size=2``.
+    assert mxq_model.infer_calls == 2
+    assert logits.shape == (1, 1, 8)
+    # Last window position is index 3 (``cache_size + chunk_len - 1`` for
+    # the final chunk).
+    assert torch.equal(logits[0, 0], torch.full((8,), 3.0))
+
+
+def test_beam_forward_last_only_backend_keep_all_uses_size_1_fallback() -> None:
+    """``logits_to_keep=0`` on a last-only MXQ forces ``effective_chunk_size
+    = 1`` so each infer captures one row per suffix position. The returned
+    tensor must span the full input window with each row tagged by its
+    absolute position — pre-fix code returned ``(1, num_chunks, vocab)``
+    with silently truncated content."""
+    mxq_model = _LastOnlyMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+
+    with pytest.warns(UserWarning, match="last-only MXQ"):
+        logits = model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=torch.arange(4, dtype=torch.long),
+            prefill_chunk_size=2,
+            logits_to_keep=0,
+        )
+
+    # Size-1 override: one infer per suffix position.
+    assert mxq_model.infer_calls == 4
+    assert logits.shape == (1, 4, 8)
+    for position in range(4):
+        assert torch.equal(logits[0, position], torch.full((8,), float(position)))
+
+
+def test_beam_forward_last_only_backend_tensor_selector_picks_absolute_positions() -> None:
+    """A tensor selector on a last-only MXQ still resolves to the absolute
+    positions requested — the size-1 fallback gives the outer selector
+    ``(1, suffix_length, vocab)`` rows to index against."""
+    mxq_model = _LastOnlyMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+    selector = torch.tensor([0, 3, 1])
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(4, dtype=torch.long),
+        prefill_chunk_size=2,
+        logits_to_keep=selector,
+    )
+
+    assert mxq_model.infer_calls == 4
+    assert logits.shape == (1, 3, 8)
+    assert torch.equal(logits[0, 0], torch.full((8,), 0.0))
+    assert torch.equal(logits[0, 1], torch.full((8,), 3.0))
+    assert torch.equal(logits[0, 2], torch.full((8,), 1.0))
+
+
+def test_beam_forward_last_only_backend_last_only_selector_does_not_warn() -> None:
+    """The slow-path warning is scoped to the ``last_only_slow`` branch: a
+    ``logits_to_keep=1`` request (fast path) must not emit it."""
+    mxq_model = _LastOnlyMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=1)
+    input_ids = torch.tensor([[4, 5, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]],
+        dtype=torch.float32,
+    )
+
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=torch.arange(4, dtype=torch.long),
+            prefill_chunk_size=2,
+            logits_to_keep=1,
+        )
+
+
+def test_beam_forward_last_only_backend_warns_only_once_per_instance() -> None:
+    """The slow-path warning fires at most once per model instance, matching
+    ``_warn_last_only_slow_path_once``'s contract."""
+    mxq_model = _LastOnlyMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    input_ids = torch.tensor([[4, 5]], dtype=torch.long)
+    inputs_embeds = torch.tensor([[[1.0, 1.0], [2.0, 2.0]]], dtype=torch.float32)
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        # First call fires the warning.
+        model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=MobilintBeamCache(mxq_model, batch_size=1),
+            cache_position=torch.arange(2, dtype=torch.long),
+            prefill_chunk_size=2,
+            logits_to_keep=0,
+        )
+        # Second call — same instance — must not re-emit it.
+        model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=MobilintBeamCache(mxq_model, batch_size=1),
+            cache_position=torch.arange(2, dtype=torch.long),
+            prefill_chunk_size=2,
+            logits_to_keep=0,
+        )
+
+    last_only_warnings = [w for w in caught if "last-only MXQ" in str(w.message)]
+    assert len(last_only_warnings) == 1

--- a/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
+++ b/tests/transformers/automatic_speech_recognition/test_qwen3_asr_cache_contract.py
@@ -603,3 +603,205 @@ def test_qwen3_asr_thinker_forward_uses_config_return_dict_default() -> None:
 
     assert isinstance(outputs, tuple)
     assert torch.equal(outputs[0], model.get_input_embeddings()(input_ids))
+
+
+# ---------------------------------------------------------------------------
+# Beam-path selector contract under active-cache prefix reuse
+#
+# When two beams share an audio source (identical ``inputs_embeds`` rows) but
+# their ``input_ids`` share only a proper prefix, the first beam commits an
+# active cache the second beam partially reuses. Concretely: beam 0 forwards
+# ``[A, B, X]`` (active cache becomes ``[A, B, X]``), and beam 1's target
+# ``[A, B, Y]`` yields ``prefix_length=2 > previous_length=0``, so beam 1's
+# ``local_start_index=2`` and only 1 suffix row is decoded. The resulting
+# ``row_logits`` for beam 1 spans window positions ``[2, 3)`` only; window
+# positions ``[0, 2)`` were not decoded this call. The selector must either
+# limit itself to the decoded suffix or raise ``IndexError`` — silently
+# returning a shortened tensor or picking the wrong absolute row is what
+# these tests guard against.
+# ---------------------------------------------------------------------------
+
+
+def test_beam_forward_prefix_reuse_keep_all_raises() -> None:
+    """``logits_to_keep=0`` (keep-all) must fail when the beam-cache prefix
+    covers part of the input window — the pre-fix code silently returned a
+    ``(batch, suffix_length, vocab)`` tensor shorter than the window."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 5, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    with pytest.raises(IndexError, match="beam cache offset"):
+        model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=torch.arange(3, dtype=torch.long),
+            logits_to_keep=0,
+        )
+
+
+def test_beam_forward_prefix_reuse_last_one_ok() -> None:
+    """``logits_to_keep=1`` (HF ``.generate()`` default) always succeeds
+    because the last window position is inside every beam's decoded suffix.
+    The position-aware stub tags each row with its absolute cache position,
+    so the returned value equals the last input window position."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 5, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(3, dtype=torch.long),
+        logits_to_keep=1,
+    )
+
+    assert logits.shape == (2, 1, 8)
+    assert torch.equal(logits[0, 0], torch.full((8,), 2.0))
+    assert torch.equal(logits[1, 0], torch.full((8,), 2.0))
+
+
+def test_beam_forward_prefix_reuse_last_n_within_suffix_ok() -> None:
+    """``logits_to_keep=n`` where ``n`` equals the aligned suffix length
+    returns ``(batch, n, vocab)`` with row values matching the tail window
+    positions. Setup: shared prefix of length 1 → ``beam_offset=1``, so the
+    aligned suffix has 2 rows and ``n=2`` is fully inside it."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(3, dtype=torch.long),
+        logits_to_keep=2,
+    )
+
+    assert logits.shape == (2, 2, 8)
+    for beam in range(2):
+        assert torch.equal(logits[beam, 0], torch.full((8,), 1.0))
+        assert torch.equal(logits[beam, 1], torch.full((8,), 2.0))
+
+
+def test_beam_forward_prefix_reuse_tensor_selector_in_suffix_ok() -> None:
+    """A tensor selector referencing only positions inside every beam's
+    decoded suffix (``>= beam_offset``) returns the absolute-position rows,
+    not the ``[0]`` of the trimmed tensor. Duplicate positions are preserved."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 6, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+    selector = torch.tensor([2, 1, 2])
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(3, dtype=torch.long),
+        logits_to_keep=selector,
+    )
+
+    assert logits.shape == (2, 3, 8)
+    for beam in range(2):
+        assert torch.equal(logits[beam, 0], torch.full((8,), 2.0))
+        assert torch.equal(logits[beam, 1], torch.full((8,), 1.0))
+        assert torch.equal(logits[beam, 2], torch.full((8,), 2.0))
+
+
+def test_beam_forward_prefix_reuse_tensor_selector_below_offset_raises() -> None:
+    """A tensor selector referencing a position covered only by the active
+    beam cache (``< beam_offset``) raises ``IndexError`` — the pre-fix code
+    silently returned the wrong absolute row via ``index_select`` on the
+    trimmed tensor."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    input_ids = torch.tensor([[4, 5, 6], [4, 5, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    with pytest.raises(IndexError, match="beam cache offset"):
+        model._beam_llm_forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=torch.arange(3, dtype=torch.long),
+            logits_to_keep=torch.tensor([0]),
+        )
+
+
+def test_beam_forward_prefix_reuse_heterogeneous_beams_align() -> None:
+    """Two beams with different ``local_start_index`` must align to the
+    largest offset so ``torch.cat`` succeeds; pre-fix code left the two
+    ``row_logits`` at mismatched ``shape[1]`` and either raised a cryptic
+    size error or (with a lucky shape) picked wrong rows. Under
+    ``logits_to_keep=1`` the aligned last-position rows carry each beam's
+    absolute last-window position."""
+    mxq_model = _PositionAwareMxqModel()
+    model = _DummyQwen3ASRBeamTextModel(mxq_model)
+    cache = MobilintBeamCache(mxq_model, batch_size=2)
+    # Beam 0 has no shared prefix (it forwards first, so its own history
+    # is empty and prefix_length=0 → local_start_index=0). Beam 1 shares
+    # a 2-token prefix with beam 0's committed active tokens →
+    # local_start_index=2. Alignment must front-trim beam 0 to shape (1,1,vocab).
+    input_ids = torch.tensor([[4, 5, 6], [4, 5, 7]], dtype=torch.long)
+    inputs_embeds = torch.tensor(
+        [
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+        ],
+        dtype=torch.float32,
+    )
+
+    logits = model._beam_llm_forward(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        past_key_values=cache,
+        cache_position=torch.arange(3, dtype=torch.long),
+        logits_to_keep=1,
+    )
+
+    # Aligned suffix length = window_length - max(local_start_index) = 3 - 2 = 1.
+    assert logits.shape == (2, 1, 8)
+    # Last window position is index 2 for both beams; position-aware stub
+    # tags each row with its absolute cache position.
+    assert torch.equal(logits[0, 0], torch.full((8,), 2.0))
+    assert torch.equal(logits[1, 0], torch.full((8,), 2.0))

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
@@ -115,6 +115,30 @@ class TestQwen2VLForwardLogitsToKeep:
         assert output.loss is not None
         assert output.loss.dim() == 0
 
+    def test_forward_strips_loss_only_kwargs_before_model_call(self) -> None:
+        """Loss-only kwargs must not leak into ``self.model``.
+
+        Upstream ``Qwen2VLModel.forward`` forwards its ``**kwargs`` to
+        ``self.language_model``, and ``MobilintQwen2VLTextModel.forward``
+        declares no ``**kwargs`` sink — so ``num_items_in_batch`` /
+        ``shift_labels`` reaching that call would raise ``TypeError``.
+        """
+        wrapper = _make_wrapper(kept_len=4, vocab_size=5)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        labels = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(
+            input_ids=input_ids,
+            labels=labels,
+            num_items_in_batch=2,
+            shift_labels=torch.tensor([[1, 2, 3, -100]], dtype=torch.long),
+        )
+
+        assert "num_items_in_batch" not in wrapper.model.received
+        assert "shift_labels" not in wrapper.model.received
+        # Loss still computes normally with the stripped loss-only kwargs.
+        assert output.loss is not None
+
     def test_forward_rejects_duplicate_positional_and_keyword_arg(self) -> None:
         wrapper = _make_wrapper(kept_len=1)
         input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from mblt_model_zoo.hf_transformers.models.qwen2_vl.modeling_qwen2_vl import (
@@ -110,3 +111,10 @@ class TestQwen2VLForwardLogitsToKeep:
 
         assert output.loss is not None
         assert output.loss.dim() == 0
+
+    def test_forward_rejects_duplicate_positional_and_keyword_arg(self) -> None:
+        wrapper = _make_wrapper(kept_len=1)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
+            wrapper.forward(input_ids, input_ids=input_ids)

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
@@ -1,0 +1,112 @@
+"""Regression tests for the Qwen2-VL ``forward`` wrapper's ``logits_to_keep`` routing.
+
+The Qwen2-VL text decoder now honors ``logits_to_keep`` inside its own
+``llm_forward``. That only works if
+``MobilintQwen2VLForConditionalGeneration.forward`` pops ``logits_to_keep``
+from kwargs and threads it into ``self.model`` — otherwise upstream extracts
+the same named argument and performs its own final slice on the decoder
+output, silently bypassing the Mobilint decoder's position selection.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from mblt_model_zoo.hf_transformers.models.qwen2_vl.modeling_qwen2_vl import (
+    MobilintQwen2VLForConditionalGeneration,
+)
+
+
+class _RecordingModel:
+    """Stand-in for ``self.model`` used to observe forwarded kwargs."""
+
+    def __init__(self, vocab_size: int, kept_len: int) -> None:
+        self.vocab_size = vocab_size
+        self.kept_len = kept_len
+        self.received: dict = {}
+
+    def __call__(self, **kwargs):
+        self.received = kwargs
+        last_hidden_state = torch.arange(
+            self.kept_len * self.vocab_size, dtype=torch.float32
+        ).reshape(1, self.kept_len, self.vocab_size)
+        return SimpleNamespace(
+            last_hidden_state=last_hidden_state,
+            past_key_values=None,
+            hidden_states=None,
+            attentions=None,
+            rope_deltas=None,
+        )
+
+
+def _make_wrapper(kept_len: int = 3, vocab_size: int = 5):
+    wrapper = MobilintQwen2VLForConditionalGeneration.__new__(
+        MobilintQwen2VLForConditionalGeneration
+    )
+    torch.nn.Module.__init__(wrapper)
+    wrapper.config = SimpleNamespace(text_config=SimpleNamespace(vocab_size=vocab_size))
+    wrapper.model = _RecordingModel(vocab_size=vocab_size, kept_len=kept_len)
+    wrapper.lm_head = torch.nn.Identity()
+    return wrapper
+
+
+class TestQwen2VLForwardLogitsToKeep:
+    def test_forward_pops_logits_to_keep_and_threads_to_model(self) -> None:
+        wrapper = _make_wrapper(kept_len=2)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(input_ids=input_ids, logits_to_keep=torch.tensor([1, 3]))
+
+        assert output.logits.shape == (1, 2, wrapper.config.text_config.vocab_size)
+        assert "logits_to_keep" in wrapper.model.received
+        forwarded = wrapper.model.received["logits_to_keep"]
+        assert torch.is_tensor(forwarded)
+        assert forwarded.tolist() == [1, 3]
+
+    def test_forward_removes_labels_and_logits_to_keep_before_forwarding(self) -> None:
+        wrapper = _make_wrapper(kept_len=4, vocab_size=5)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        labels = torch.zeros_like(input_ids)
+
+        wrapper.forward(
+            input_ids=input_ids,
+            labels=labels,
+            logits_to_keep=1,
+        )
+
+        # ``labels`` is consumed for the loss computation and must not leak to
+        # the model call, and ``logits_to_keep`` must be popped so upstream's
+        # own re-slicing cannot bypass the Mobilint decoder.
+        assert "labels" not in wrapper.model.received
+        # ``logits_to_keep`` is passed once, as an explicit keyword.
+        assert wrapper.model.received["logits_to_keep"] == 1
+
+    def test_forward_defaults_to_keep_all_when_kwarg_absent(self) -> None:
+        wrapper = _make_wrapper(kept_len=4)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        wrapper.forward(input_ids=input_ids)
+
+        # The wrapper's default is ``0`` (keep every position).
+        assert wrapper.model.received.get("logits_to_keep") == 0
+
+    def test_forward_maps_positional_args_to_upstream_signature(self) -> None:
+        wrapper = _make_wrapper(kept_len=1)
+        input_ids = torch.tensor([[7, 8, 9]], dtype=torch.long)
+
+        wrapper.forward(input_ids)
+
+        assert "input_ids" in wrapper.model.received
+        assert torch.equal(wrapper.model.received["input_ids"], input_ids)
+
+    def test_forward_computes_loss_when_labels_are_provided(self) -> None:
+        wrapper = _make_wrapper(kept_len=4, vocab_size=5)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        labels = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(input_ids=input_ids, labels=labels)
+
+        assert output.loss is not None
+        assert output.loss.dim() == 0

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
@@ -47,7 +47,10 @@ def _make_wrapper(kept_len: int = 3, vocab_size: int = 5):
         MobilintQwen2VLForConditionalGeneration
     )
     torch.nn.Module.__init__(wrapper)
-    wrapper.config = SimpleNamespace(text_config=SimpleNamespace(vocab_size=vocab_size))
+    wrapper.config = SimpleNamespace(
+        text_config=SimpleNamespace(vocab_size=vocab_size),
+        return_dict=True,
+    )
     wrapper.model = _RecordingModel(vocab_size=vocab_size, kept_len=kept_len)
     wrapper.lm_head = torch.nn.Identity()
     return wrapper
@@ -118,6 +121,25 @@ class TestQwen2VLForwardLogitsToKeep:
 
         with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
             wrapper.forward(input_ids, input_ids=input_ids)
+
+    def test_forward_return_dict_false_returns_tuple(self) -> None:
+        """``return_dict=False`` must not leak into ``self.model`` and must yield a tuple.
+
+        Without ``@can_return_tuple``, ``return_dict`` would flow through to
+        ``self.model`` and the upstream ``Qwen2VLModel`` contract would return a
+        tuple whose ``.last_hidden_state`` dereference crashes the wrapper.
+        """
+        wrapper = _make_wrapper(kept_len=2, vocab_size=5)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(input_ids=input_ids, return_dict=False)
+
+        assert isinstance(output, tuple)
+        # ``return_dict`` must be stripped before ``self.model`` is called.
+        assert "return_dict" not in wrapper.model.received
+        # Logits are the first non-None field of Qwen2VLCausalLMOutputWithPast
+        # (loss is None because no labels).
+        assert output[0].shape == (1, 2, 5)
 
     def test_forward_rejects_too_many_positional_args(self) -> None:
         """Extra positional args beyond upstream's signature must raise TypeError.

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_logits_to_keep.py
@@ -118,3 +118,28 @@ class TestQwen2VLForwardLogitsToKeep:
 
         with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
             wrapper.forward(input_ids, input_ids=input_ids)
+
+    def test_forward_rejects_too_many_positional_args(self) -> None:
+        """Extra positional args beyond upstream's signature must raise TypeError.
+
+        ``zip`` silently drops extras, so without an explicit length check a caller
+        passing too many positional args would have those extras discarded rather
+        than surfaced. Mirror CPython's own message so the failure reads naturally.
+        """
+        from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+            upstream_positional_params,
+        )
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+            Qwen2VLForConditionalGeneration,
+        )
+
+        wrapper = _make_wrapper(kept_len=1)
+        param_count = len(upstream_positional_params(Qwen2VLForConditionalGeneration.forward))
+        extra_args = tuple(object() for _ in range(param_count + 1))
+
+        with pytest.raises(
+            TypeError,
+            match=rf"forward\(\) takes at most {param_count} positional arguments "
+            rf"but {param_count + 1} were given",
+        ):
+            wrapper.forward(*extra_args)

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_upstream_contract.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_upstream_contract.py
@@ -1,0 +1,147 @@
+"""Upstream contract: ``Qwen2VLModel.forward`` must not slice its own output.
+
+``MobilintQwen2VLForConditionalGeneration.forward`` pops ``logits_to_keep``
+from kwargs, threads it into ``self.model`` (which forwards it via ``**kwargs``
+to the Mobilint text decoder), and then SKIPS the upstream
+``hidden_states[:, slice_indices, :]`` step because the Mobilint decoder
+already returns logits selected to the requested positions.
+
+That contract holds only as long as upstream ``Qwen2VLModel.forward`` itself
+does not do its own position selection. If a future HF transformers release
+moves the slice from ``Qwen2VLForConditionalGeneration.forward`` into
+``Qwen2VLModel.forward``, our wrapper would silently return pre-sliced values
+(KV would still be correct — only the logits would be wrong), and the existing
+``_RecordingModel``-based tests could not detect the drift.
+
+These tests pin that contract via source inspection plus a functional check
+that ``logits_to_keep`` flows through unmodified to ``self.language_model``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLModel
+
+pytestmark = pytest.mark.upstream_contract
+
+
+def _forward_source() -> str:
+    return inspect.getsource(Qwen2VLModel.forward)
+
+
+class TestQwen2VLModelForwardSourceContract:
+    """Fail loudly if the upstream source acquires its own logits slicing."""
+
+    def test_no_slice_indices_local(self) -> None:
+        # ``slice_indices = slice(-logits_to_keep, None) ...`` is the exact
+        # pattern used in ``Qwen2VLForConditionalGeneration.forward``. It must
+        # not migrate into ``Qwen2VLModel.forward``.
+        assert "slice_indices" not in _forward_source()
+
+    def test_no_hidden_states_bracket_slice(self) -> None:
+        source = _forward_source()
+        # Explicit ``hidden_states[:, ..., :]`` / ``last_hidden_state[:, ..., :]``
+        # position selection would bypass the Mobilint decoder.
+        assert not re.search(r"hidden_states\s*\[\s*:\s*,", source)
+        assert not re.search(r"last_hidden_state\s*\[\s*:\s*,", source)
+
+    def test_no_gather_along_seq_dim(self) -> None:
+        # A ``.gather(1, indices)`` on the decoder output would be another way
+        # to implement position selection at the model level.
+        assert not re.search(r"\.gather\(\s*1\s*,", _forward_source())
+
+    def test_logits_to_keep_not_a_named_parameter(self) -> None:
+        # If upstream promotes ``logits_to_keep`` to a named parameter on
+        # ``Qwen2VLModel.forward``, it stops flowing through ``**kwargs`` to
+        # ``self.language_model`` and is very likely paired with local slicing.
+        params = inspect.signature(Qwen2VLModel.forward).parameters
+        assert "logits_to_keep" not in params
+
+    def test_kwargs_are_forwarded_to_language_model(self) -> None:
+        # Our wrapper depends on ``**kwargs`` reaching ``self.language_model``.
+        source = _forward_source()
+        # Match ``self.language_model(...)`` and ensure ``**kwargs`` appears in
+        # the same call.
+        match = re.search(r"self\.language_model\((?P<args>.*?)\)", source, re.DOTALL)
+        assert match is not None, "expected a self.language_model(...) call in upstream forward"
+        assert "**kwargs" in match.group("args")
+
+
+# ---------------------------------------------------------------------------
+# Functional check: logits_to_keep reaches self.language_model unmodified.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingLanguageModel:
+    """Stand-in that captures the kwargs forwarded by ``Qwen2VLModel.forward``."""
+
+    def __init__(self, vocab_size: int = 5, hidden_size: int = 4) -> None:
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.received: dict = {}
+
+    def __call__(self, **kwargs):
+        self.received = kwargs
+        inputs_embeds = kwargs.get("inputs_embeds")
+        assert inputs_embeds is not None, "test setup must pass inputs_embeds"
+        seq_len = inputs_embeds.shape[1]
+        return SimpleNamespace(
+            last_hidden_state=torch.zeros(1, seq_len, self.hidden_size),
+            past_key_values=None,
+            hidden_states=None,
+            attentions=None,
+        )
+
+
+def _make_bare_qwen2_vl_model() -> Qwen2VLModel:
+    model = Qwen2VLModel.__new__(Qwen2VLModel)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(
+        output_attentions=False,
+        output_hidden_states=False,
+        use_return_dict=True,
+    )
+    model.language_model = _RecordingLanguageModel()
+    model.rope_deltas = torch.zeros(1, dtype=torch.long)
+    return model
+
+
+class TestQwen2VLModelForwardKwargsPassthrough:
+    def test_logits_to_keep_reaches_language_model_unmodified(self) -> None:
+        model = _make_bare_qwen2_vl_model()
+        seq_len = 6
+        inputs_embeds = torch.zeros(1, seq_len, model.language_model.hidden_size)
+        # Provide ``position_ids`` explicitly so upstream skips the rope-index
+        # computation branch (which requires ``get_rope_index`` internals).
+        position_ids = torch.zeros(3, 1, seq_len, dtype=torch.long)
+        sentinel = torch.tensor([1, 3, 5])
+
+        model.forward(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            logits_to_keep=sentinel,
+        )
+
+        assert "logits_to_keep" in model.language_model.received
+        forwarded = model.language_model.received["logits_to_keep"]
+        assert torch.is_tensor(forwarded)
+        assert torch.equal(forwarded, sentinel)
+
+    def test_int_logits_to_keep_reaches_language_model_unmodified(self) -> None:
+        model = _make_bare_qwen2_vl_model()
+        seq_len = 4
+        inputs_embeds = torch.zeros(1, seq_len, model.language_model.hidden_size)
+        position_ids = torch.zeros(3, 1, seq_len, dtype=torch.long)
+
+        model.forward(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            logits_to_keep=2,
+        )
+
+        assert model.language_model.received.get("logits_to_keep") == 2

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_upstream_contract.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_upstream_contract.py
@@ -19,13 +19,18 @@ that ``logits_to_keep`` flows through unmodified to ``self.language_model``.
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import re
 from types import SimpleNamespace
 
 import pytest
 import torch
-from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLModel
+from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+    Qwen2VLCausalLMOutputWithPast,
+    Qwen2VLModel,
+    Qwen2VLModelOutputWithPast,
+)
 
 pytestmark = pytest.mark.upstream_contract
 
@@ -145,3 +150,72 @@ class TestQwen2VLModelForwardKwargsPassthrough:
         )
 
         assert model.language_model.received.get("logits_to_keep") == 2
+
+
+# ---------------------------------------------------------------------------
+# Safety net for dynamic output/loss adaptation.
+#
+# The Mobilint wrapper builds its returned ``Qwen2VLCausalLMOutputWithPast``
+# via ``mirror_output_fields`` and its loss kwargs via
+# ``build_loss_kwargs_dynamic``. Those helpers pick up new upstream additions
+# automatically, but they can only mirror fields present on the source model
+# output and can only supply loss kwargs whose value source lives in
+# ``LOSS_KWARG_SUPPLY_NAMES``. The two checks below catch the drift cases the
+# dynamic path cannot cover on its own.
+# ---------------------------------------------------------------------------
+
+
+class TestQwen2VLCausalLMOutputFieldCoverage:
+    """Every CausalLM field must be reachable via override or model-output mirror."""
+
+    def test_uncovered_causal_lm_fields_have_defaults(self) -> None:
+        overrides = {"loss", "logits"}
+        model_output_fields = {field.name for field in dataclasses.fields(Qwen2VLModelOutputWithPast)}
+        uncovered = [
+            field
+            for field in dataclasses.fields(Qwen2VLCausalLMOutputWithPast)
+            if field.name not in overrides and field.name not in model_output_fields
+        ]
+        missing_default = [
+            field.name
+            for field in uncovered
+            if field.default is dataclasses.MISSING and field.default_factory is dataclasses.MISSING
+        ]
+        assert not missing_default, (
+            "Qwen2VLCausalLMOutputWithPast added a required field that "
+            "mirror_output_fields cannot fill: "
+            f"{missing_default}. The Mobilint wrapper must supply this field "
+            "as an explicit override, or upstream must add it to "
+            "Qwen2VLModelOutputWithPast so the mirror picks it up."
+        )
+
+
+class TestQwen2VLLossFunctionKwargsSupply:
+    """Every required loss parameter must be in the supply pool."""
+
+    def test_required_loss_params_are_in_supply_pool(self) -> None:
+        from transformers.loss.loss_utils import ForCausalLMLoss
+
+        from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+            LOSS_KWARG_SUPPLY_NAMES,
+        )
+
+        signature = inspect.signature(ForCausalLMLoss)
+        required_named = [
+            name
+            for name, parameter in signature.parameters.items()
+            if parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+            and parameter.default is inspect.Parameter.empty
+        ]
+        missing = [name for name in required_named if name not in LOSS_KWARG_SUPPLY_NAMES]
+        assert not missing, (
+            "ForCausalLMLoss requires parameters that build_loss_kwargs_dynamic "
+            f"does not know how to supply: {missing}. Extend "
+            "LOSS_KWARG_SUPPLY_NAMES and the ``supply`` dict in "
+            "build_loss_kwargs_dynamic together to cover them."
+        )

--- a/tests/transformers/image_text_to_text/test_qwen2_vl_upstream_contract.py
+++ b/tests/transformers/image_text_to_text/test_qwen2_vl_upstream_contract.py
@@ -110,6 +110,7 @@ def _make_bare_qwen2_vl_model() -> Qwen2VLModel:
         output_attentions=False,
         output_hidden_states=False,
         use_return_dict=True,
+        return_dict=True,
     )
     model.language_model = _RecordingLanguageModel()
     model.rope_deltas = torch.zeros(1, dtype=torch.long)

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_cache_contract.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_cache_contract.py
@@ -51,9 +51,11 @@ class _DummyQwen3VLTextModel(MobilintQwen3VLTextModel):
         cache_position: torch.Tensor,
         prefill_chunk_size: int | None = None,
         count_npu_time: bool = False,
+        logits_to_keep: int | torch.Tensor = 1,
     ) -> torch.Tensor:
         """Return deterministic logits while exposing forward-time cache state."""
         del deepstack_visual_embeds, visual_pos_masks, cache_position, prefill_chunk_size, count_npu_time
+        del logits_to_keep
         self.forward_past_key_values = past_key_values
         return torch.zeros(
             inputs_embeds.shape[0],

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -298,6 +298,7 @@ class TestQwen3VLForConditionalGenerationForward:
         torch.nn.Module.__init__(wrapper)
         wrapper.config = SimpleNamespace(
             text_config=SimpleNamespace(vocab_size=vocab_size),
+            return_dict=True,
         )
         wrapper.model = _RecordingModel(
             vocab_size=vocab_size, kept_len=kept_len, hidden_size=hidden_size
@@ -349,6 +350,25 @@ class TestQwen3VLForConditionalGenerationForward:
 
         with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
             wrapper.forward(input_ids, input_ids=input_ids)
+
+    def test_forward_return_dict_false_returns_tuple(self) -> None:
+        """``return_dict=False`` must not leak into ``self.model`` and must yield a tuple.
+
+        Without ``@can_return_tuple``, ``return_dict`` would flow through to
+        ``self.model`` and the upstream ``Qwen3VLModel`` contract would return a
+        tuple whose ``.last_hidden_state`` dereference crashes the wrapper.
+        """
+        wrapper = self._make_wrapper(kept_len=2, vocab_size=5)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(input_ids=input_ids, return_dict=False)
+
+        assert isinstance(output, tuple)
+        # ``return_dict`` must be stripped before ``self.model`` is called.
+        assert "return_dict" not in wrapper.model.received
+        # Logits are the first non-None field of Qwen3VLCausalLMOutputWithPast
+        # (loss is None because no labels).
+        assert output[0].shape == (1, 2, 5)
 
     def test_forward_rejects_too_many_positional_args(self) -> None:
         """Extra positional args beyond upstream's signature must raise TypeError.

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -1,0 +1,309 @@
+"""Regression tests for the Qwen3-VL text decoder ``logits_to_keep`` path.
+
+Covers the three inference branches the Qwen3-VL text decoder implements
+inside its own ``llm_forward`` (mirroring the shared core), plus the outer
+``MobilintQwen3VLForConditionalGeneration.forward`` wrapper that has to pop
+``logits_to_keep`` from kwargs and thread it into the text model.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional
+
+import numpy as np
+import pytest
+import torch
+
+from tests.transformers.image_text_to_text.qwen3_vl_compat import (
+    skip_if_transformers_lacks_qwen3_vl_support,
+)
+
+skip_if_transformers_lacks_qwen3_vl_support()
+
+from mblt_model_zoo.hf_transformers.models.qwen3_vl.modeling_qwen3_vl import (  # noqa: E402
+    MobilintQwen3VLForConditionalGeneration,
+    MobilintQwen3VLTextModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake MXQ backends for the dual-input Qwen3-VL text decoder
+# ---------------------------------------------------------------------------
+
+
+class _StaticLastOnlyMxq:
+    """MXQ stub for the qwen3_vl decoder that emits only last-token logits."""
+
+    def __init__(self, vocab_size: int = 5):
+        self.vocab_size = vocab_size
+        self.calls: list[dict] = []
+
+    def get_model_output_shape(self):
+        return [(1, 1, self.vocab_size)]
+
+    def infer(self, inputs, _extra, cache_size):
+        inputs_chunk = np.asarray(inputs[0])
+        deepstack_chunk = np.asarray(inputs[1])
+        self.calls.append(
+            {
+                "inputs_shape": tuple(inputs_chunk.shape),
+                "deepstack_shape": tuple(deepstack_chunk.shape),
+                "cache_size": int(cache_size),
+            }
+        )
+        return [np.full((1, 1, self.vocab_size), fill_value=float(cache_size), dtype=np.float32)]
+
+
+class _DynamicAxisMxq:
+    """MXQ stub for the qwen3_vl decoder that emits per-position logits."""
+
+    def __init__(self, vocab_size: int = 5):
+        self.vocab_size = vocab_size
+        self.calls: list[dict] = []
+
+    def get_model_output_shape(self):
+        return [(1, -1, self.vocab_size)]
+
+    def infer(self, inputs, _extra, cache_size):
+        inputs_chunk = np.asarray(inputs[0])
+        chunk_len = int(inputs_chunk.shape[1])
+        base = int(cache_size) * self.vocab_size
+        values = (np.arange(chunk_len * self.vocab_size, dtype=np.float32) + base).reshape(
+            1, chunk_len, self.vocab_size
+        )
+        self.calls.append(
+            {
+                "inputs_shape": tuple(inputs_chunk.shape),
+                "cache_size": int(cache_size),
+                "chunk_len": chunk_len,
+            }
+        )
+        return [values]
+
+
+class _FakeBackend:
+    def __init__(self, mxq_model):
+        self.mxq_model = mxq_model
+
+
+class _BareQwen3VLTextModel(MobilintQwen3VLTextModel):
+    """Instantiate ``MobilintQwen3VLTextModel`` without booting the NPU backend.
+
+    Only the attributes ``llm_forward`` needs are populated; ``get_mxq_model``
+    is redirected to the fake backend via ``self.npu_backend``.
+    """
+
+    def __init__(self, mxq_model, *, vocab_size: int = 5, hidden_size: int = 3):
+        torch.nn.Module.__init__(self)
+        self.config = SimpleNamespace(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            pad_token_id=0,
+            npu_prefill_chunk_size=None,
+        )
+        self.npu_backend = _FakeBackend(mxq_model)
+        self.num_deepstack_layers = 0
+        self.npu_time = None
+
+    def get_mxq_model(self):  # noqa: D401 - trivial passthrough
+        return self.npu_backend.mxq_model
+
+
+# ---------------------------------------------------------------------------
+# Direct llm_forward branches
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3VLTextDecoderLogitsToKeep:
+    def _run(
+        self,
+        mxq,
+        *,
+        seq_len: int,
+        hidden_size: int = 3,
+        logits_to_keep,
+        prefill_chunk_size: Optional[int] = None,
+    ):
+        model = _BareQwen3VLTextModel(mxq, hidden_size=hidden_size)
+        inputs_embeds = torch.arange(seq_len * hidden_size, dtype=torch.float32).reshape(
+            1, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            deepstack_visual_embeds=None,
+            visual_pos_masks=None,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            logits_to_keep=logits_to_keep,
+        )
+        return model, logits
+
+    def test_default_keep_returns_last_token_logits(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5)
+        _model, logits = self._run(mxq, seq_len=6, logits_to_keep=1, prefill_chunk_size=3)
+
+        chunk_seqs = [c["inputs_shape"][1] for c in mxq.calls]
+        assert chunk_seqs == [3, 3]
+        # No squeeze on this path: (batch=1, 1, vocab).
+        assert logits.shape == (1, 1, mxq.vocab_size)
+
+    def test_dynamic_axis_keep_all_returns_every_position(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5)
+        model, logits = self._run(mxq, seq_len=6, logits_to_keep=0, prefill_chunk_size=3)
+
+        assert model._mxq_supports_all_logits() is True
+        assert logits.shape == (1, 6, mxq.vocab_size)
+
+        # Concatenation should be in call order, one chunk per prefill_chunk_size window.
+        expected_chunks = []
+        for chunk_len in (3, 3):
+            base = 0  # past_key_values is None so cache_size stays 0.
+            expected_chunks.append(
+                (np.arange(chunk_len * mxq.vocab_size, dtype=np.float32) + base).reshape(
+                    1, chunk_len, mxq.vocab_size
+                )
+            )
+        expected = np.concatenate(expected_chunks, axis=1)
+        np.testing.assert_allclose(logits.numpy(), expected)
+
+    def test_dynamic_axis_last_n_slices_kept_positions(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5)
+        _model, logits = self._run(mxq, seq_len=6, logits_to_keep=2, prefill_chunk_size=3)
+        assert logits.shape == (1, 2, mxq.vocab_size)
+
+    def test_dynamic_axis_tensor_indices_pick_out_positions(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5)
+        indices = torch.tensor([0, 3])
+        _model, logits = self._run(
+            mxq, seq_len=6, logits_to_keep=indices, prefill_chunk_size=3
+        )
+        assert logits.shape == (1, 2, mxq.vocab_size)
+
+    def test_fallback_interleaves_size_one_infer_for_kept_positions(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5)
+        indices = torch.tensor([2, 5])
+        _model, logits = self._run(
+            mxq, seq_len=6, logits_to_keep=indices, prefill_chunk_size=4
+        )
+
+        chunk_seqs = [c["inputs_shape"][1] for c in mxq.calls]
+        # Prefix stride is clamped to the next kept position (like the shared core).
+        assert chunk_seqs == [2, 1, 2, 1]
+        # No ``.squeeze(0)`` on this path: shape is (1, kept_len, vocab).
+        assert logits.shape == (1, len(indices), mxq.vocab_size)
+
+    def test_deepstack_chunk_shape_matches_input_chunk(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5)
+        model = _BareQwen3VLTextModel(mxq, hidden_size=3)
+        model.num_deepstack_layers = 2
+
+        seq_len = 4
+        inputs_embeds = torch.zeros(1, seq_len, 3)
+        cache_position = torch.arange(seq_len)
+
+        model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            deepstack_visual_embeds=None,
+            visual_pos_masks=None,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=2,
+            logits_to_keep=1,
+        )
+        # Deepstack chunk is built from a zero tensor of shape (num_layers, seq, hidden)
+        # sliced by the same [start:end] window as the inputs chunk. Each call
+        # sees (2, chunk_len, 3).
+        assert [c["deepstack_shape"] for c in mxq.calls] == [(2, 2, 3), (2, 2, 3)]
+
+
+# ---------------------------------------------------------------------------
+# Outer ``MobilintQwen3VLForConditionalGeneration.forward`` wrapper
+# ---------------------------------------------------------------------------
+
+
+class _ModelOutput:
+    """Subscriptable, attribute-accessible output mimicking ``Qwen3VLModelOutput``."""
+
+    def __init__(self, last_hidden_state: torch.Tensor) -> None:
+        self.last_hidden_state = last_hidden_state
+        self.past_key_values = None
+        self.hidden_states = None
+        self.attentions = None
+        self.rope_deltas = None
+
+    def __getitem__(self, index):  # noqa: D401 - matches HF ModelOutput contract
+        return self.last_hidden_state if index == 0 else None
+
+
+class _RecordingModel:
+    """Stand-in for ``self.model`` used to observe forwarded kwargs."""
+
+    def __init__(self, vocab_size: int, kept_len: int, hidden_size: int) -> None:
+        self.vocab_size = vocab_size
+        self.kept_len = kept_len
+        self.hidden_size = hidden_size
+        self.received: dict = {}
+
+    def __call__(self, **kwargs):
+        self.received = kwargs
+        last_hidden_state = torch.arange(
+            self.kept_len * self.vocab_size, dtype=torch.float32
+        ).reshape(1, self.kept_len, self.vocab_size)
+        return _ModelOutput(last_hidden_state)
+
+
+class TestQwen3VLForConditionalGenerationForward:
+    def _make_wrapper(self, kept_len: int = 3, vocab_size: int = 5, hidden_size: int = 4):
+        wrapper = MobilintQwen3VLForConditionalGeneration.__new__(
+            MobilintQwen3VLForConditionalGeneration
+        )
+        torch.nn.Module.__init__(wrapper)
+        wrapper.config = SimpleNamespace(
+            text_config=SimpleNamespace(vocab_size=vocab_size),
+        )
+        wrapper.model = _RecordingModel(
+            vocab_size=vocab_size, kept_len=kept_len, hidden_size=hidden_size
+        )
+        wrapper.lm_head = torch.nn.Identity()
+        return wrapper
+
+    def test_forward_pops_logits_to_keep_and_threads_to_model(self) -> None:
+        wrapper = self._make_wrapper(kept_len=2)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(input_ids=input_ids, logits_to_keep=torch.tensor([1, 3]))
+
+        # The wrapper must forward the raw ``logits_to_keep`` value to
+        # ``self.model``; upstream would otherwise re-slice the decoder output.
+        assert isinstance(output.logits, torch.Tensor)
+        assert output.logits.shape == (1, 2, wrapper.config.text_config.vocab_size)
+        assert "logits_to_keep" in wrapper.model.received
+        forwarded = wrapper.model.received["logits_to_keep"]
+        assert torch.is_tensor(forwarded)
+        assert forwarded.tolist() == [1, 3]
+        # ``labels`` and ``logits_to_keep`` must not leak into the model kwargs.
+        assert "labels" not in wrapper.model.received
+
+    def test_forward_defaults_to_keep_all_when_kwarg_absent(self) -> None:
+        wrapper = self._make_wrapper(kept_len=4)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        wrapper.forward(input_ids=input_ids)
+
+        # The wrapper's default is ``0`` (keep every position), matching the
+        # underlying text model's default.
+        assert wrapper.model.received.get("logits_to_keep") == 0
+
+    def test_forward_maps_positional_args_to_upstream_signature(self) -> None:
+        wrapper = self._make_wrapper(kept_len=1)
+        input_ids = torch.tensor([[7, 8, 9]], dtype=torch.long)
+
+        # Pass input_ids positionally so we exercise the upstream-parameter
+        # remapping done by the wrapper.
+        wrapper.forward(input_ids)
+
+        assert "input_ids" in wrapper.model.received
+        assert torch.equal(wrapper.model.received["input_ids"], input_ids)

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -351,6 +351,30 @@ class TestQwen3VLForConditionalGenerationForward:
         with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
             wrapper.forward(input_ids, input_ids=input_ids)
 
+    def test_forward_strips_loss_only_kwargs_before_model_call(self) -> None:
+        """Loss-only kwargs must not leak into ``self.model``.
+
+        Upstream ``Qwen3VLModel.forward`` forwards its ``**kwargs`` to
+        ``self.language_model``. Even though ``MobilintQwen3VLTextModel``
+        accepts ``**kwargs``, loss-only kwargs conceptually belong to loss
+        computation only and must be stripped for parity with Qwen2-VL.
+        """
+        wrapper = self._make_wrapper(kept_len=4, vocab_size=5)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        labels = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        output = wrapper.forward(
+            input_ids=input_ids,
+            labels=labels,
+            num_items_in_batch=2,
+            shift_labels=torch.tensor([[1, 2, 3, -100]], dtype=torch.long),
+        )
+
+        assert "num_items_in_batch" not in wrapper.model.received
+        assert "shift_labels" not in wrapper.model.received
+        # Loss still computes normally with the stripped loss-only kwargs.
+        assert output.loss is not None
+
     def test_forward_return_dict_false_returns_tuple(self) -> None:
         """``return_dict=False`` must not leak into ``self.model`` and must yield a tuple.
 

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -345,3 +345,28 @@ class TestQwen3VLForConditionalGenerationForward:
 
         with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
             wrapper.forward(input_ids, input_ids=input_ids)
+
+    def test_forward_rejects_too_many_positional_args(self) -> None:
+        """Extra positional args beyond upstream's signature must raise TypeError.
+
+        ``zip`` silently drops extras, so without an explicit length check a caller
+        passing too many positional args would have those extras discarded rather
+        than surfaced. Mirror CPython's own message so the failure reads naturally.
+        """
+        from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+            upstream_positional_params,
+        )
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLForConditionalGeneration,
+        )
+
+        wrapper = self._make_wrapper(kept_len=1)
+        param_count = len(upstream_positional_params(Qwen3VLForConditionalGeneration.forward))
+        extra_args = tuple(object() for _ in range(param_count + 1))
+
+        with pytest.raises(
+            TypeError,
+            match=rf"forward\(\) takes at most {param_count} positional arguments "
+            rf"but {param_count + 1} were given",
+        ):
+            wrapper.forward(*extra_args)

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -195,6 +195,34 @@ class TestQwen3VLTextDecoderLogitsToKeep:
         # No ``.squeeze(0)`` on this path: shape is (1, kept_len, vocab).
         assert logits.shape == (1, len(indices), mxq.vocab_size)
 
+    def test_fallback_empty_tensor_returns_empty_logits(self) -> None:
+        """An empty ``logits_to_keep`` tensor must not raise on np.concatenate."""
+        mxq = _StaticLastOnlyMxq(vocab_size=5)
+        _model, logits = self._run(
+            mxq,
+            seq_len=6,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=4,
+        )
+        # KV prefix still walks the whole sequence in normal-sized chunks.
+        chunk_seqs = [c["inputs_shape"][1] for c in mxq.calls]
+        assert chunk_seqs == [4, 2]
+        # Batch dim preserved (no ``.squeeze(0)`` on this path).
+        assert logits.shape == (1, 0, 0)
+
+    def test_fallback_all_out_of_range_indices_returns_empty_logits(self) -> None:
+        """All-out-of-range ``logits_to_keep`` must not raise on np.concatenate."""
+        mxq = _StaticLastOnlyMxq(vocab_size=5)
+        _model, logits = self._run(
+            mxq,
+            seq_len=6,
+            logits_to_keep=torch.tensor([100, -100]),
+            prefill_chunk_size=4,
+        )
+        chunk_seqs = [c["inputs_shape"][1] for c in mxq.calls]
+        assert chunk_seqs == [4, 2]
+        assert logits.shape == (1, 0, 0)
+
     def test_deepstack_chunk_shape_matches_input_chunk(self) -> None:
         mxq = _StaticLastOnlyMxq(vocab_size=5)
         model = _BareQwen3VLTextModel(mxq, hidden_size=3)

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -29,6 +29,11 @@ from mblt_model_zoo.hf_transformers.models.qwen3_vl.modeling_qwen3_vl import (  
 
 # ---------------------------------------------------------------------------
 # Fake MXQ backends for the dual-input Qwen3-VL text decoder
+#
+# These are intentionally NOT unified with ``tests/transformers/_fake_mxq.py``:
+# the Qwen3-VL decoder feeds two input buffers (inputs_embeds and deepstack
+# embeds) and its ``infer`` signature has no ``batch_params`` argument, so the
+# fakes exercise a different code path than the shared LLM core.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -215,18 +215,16 @@ class TestQwen3VLTextDecoderLogitsToKeep:
         # Batch dim preserved (no ``.squeeze(0)`` on this path).
         assert logits.shape == (1, 0, 0)
 
-    def test_fallback_all_out_of_range_indices_returns_empty_logits(self) -> None:
-        """All-out-of-range ``logits_to_keep`` must not raise on np.concatenate."""
+    def test_fallback_out_of_range_indices_raise_indexerror(self) -> None:
+        """HF fancy-indexing raises on out-of-range indices; the VL decoder inherits this."""
         mxq = _StaticLastOnlyMxq(vocab_size=5)
-        _model, logits = self._run(
-            mxq,
-            seq_len=6,
-            logits_to_keep=torch.tensor([100, -100]),
-            prefill_chunk_size=4,
-        )
-        chunk_seqs = [c["inputs_shape"][1] for c in mxq.calls]
-        assert chunk_seqs == [4, 2]
-        assert logits.shape == (1, 0, 0)
+        with pytest.raises(IndexError, match=r"100.*seq_len=6"):
+            self._run(
+                mxq,
+                seq_len=6,
+                logits_to_keep=torch.tensor([100, -100]),
+                prefill_chunk_size=4,
+            )
 
     def test_deepstack_chunk_shape_matches_input_chunk(self) -> None:
         mxq = _StaticLastOnlyMxq(vocab_size=5)

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -163,14 +163,18 @@ class TestQwen3VLTextDecoderLogitsToKeep:
         assert logits.shape == (1, 6, mxq.vocab_size)
 
         # Concatenation should be in call order, one chunk per prefill_chunk_size window.
+        # Without a caller cache, ``_do_infer`` uses ``start_index`` as cache_size so
+        # the NPU sees prior chunks' KV state — the fake mirrors that by offsetting.
         expected_chunks = []
+        running_cache_size = 0
         for chunk_len in (3, 3):
-            base = 0  # past_key_values is None so cache_size stays 0.
+            base = running_cache_size * mxq.vocab_size
             expected_chunks.append(
                 (np.arange(chunk_len * mxq.vocab_size, dtype=np.float32) + base).reshape(
                     1, chunk_len, mxq.vocab_size
                 )
             )
+            running_cache_size += chunk_len
         expected = np.concatenate(expected_chunks, axis=1)
         np.testing.assert_allclose(logits.numpy(), expected)
 

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -340,3 +340,10 @@ class TestQwen3VLForConditionalGenerationForward:
 
         assert "input_ids" in wrapper.model.received
         assert torch.equal(wrapper.model.received["input_ids"], input_ids)
+
+    def test_forward_rejects_duplicate_positional_and_keyword_arg(self) -> None:
+        wrapper = self._make_wrapper(kept_len=1)
+        input_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+        with pytest.raises(TypeError, match="multiple values for argument 'input_ids'"):
+            wrapper.forward(input_ids, input_ids=input_ids)

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_logits_to_keep.py
@@ -216,8 +216,10 @@ class TestQwen3VLTextDecoderLogitsToKeep:
         # KV prefix still walks the whole sequence in normal-sized chunks.
         chunk_seqs = [c["inputs_shape"][1] for c in mxq.calls]
         assert chunk_seqs == [4, 2]
-        # Batch dim preserved (no ``.squeeze(0)`` on this path).
-        assert logits.shape == (1, 0, 0)
+        # Batch dim preserved (no ``.squeeze(0)`` on this path); vocab dim
+        # comes from the compiled MXQ output shape so the empty-selector
+        # result matches the shared core's ``(batch, 0, vocab)`` contract.
+        assert logits.shape == (1, 0, mxq.vocab_size)
 
     def test_fallback_out_of_range_indices_raise_indexerror(self) -> None:
         """HF fancy-indexing raises on out-of-range indices; the VL decoder inherits this."""

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_upstream_contract.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_upstream_contract.py
@@ -1,0 +1,74 @@
+"""Upstream contract: ``Qwen3VLModel.forward`` must not slice its own output.
+
+``MobilintQwen3VLForConditionalGeneration.forward`` pops ``logits_to_keep``
+from kwargs, threads it into ``self.model`` (which forwards it via ``**kwargs``
+to the Mobilint text decoder), and then SKIPS the upstream
+``hidden_states[:, slice_indices, :]`` step because the Mobilint decoder
+already returns logits selected to the requested positions.
+
+That contract holds only as long as upstream ``Qwen3VLModel.forward`` itself
+does not do its own position selection. If a future HF transformers release
+moves the slice from ``Qwen3VLForConditionalGeneration.forward`` into
+``Qwen3VLModel.forward``, our wrapper would silently return pre-sliced values
+(KV would still be correct — only the logits would be wrong), and the existing
+``_RecordingModel``-based tests could not detect the drift.
+
+These tests pin that contract via source inspection.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from tests.transformers.image_text_to_text.qwen3_vl_compat import (
+    skip_if_transformers_lacks_qwen3_vl_support,
+)
+
+skip_if_transformers_lacks_qwen3_vl_support()
+
+from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLModel  # noqa: E402
+
+pytestmark = pytest.mark.upstream_contract
+
+
+def _forward_source() -> str:
+    return inspect.getsource(Qwen3VLModel.forward)
+
+
+class TestQwen3VLModelForwardSourceContract:
+    """Fail loudly if the upstream source acquires its own logits slicing."""
+
+    def test_no_slice_indices_local(self) -> None:
+        # ``slice_indices = slice(-logits_to_keep, None) ...`` is the exact
+        # pattern used in ``Qwen3VLForConditionalGeneration.forward``. It must
+        # not migrate into ``Qwen3VLModel.forward``.
+        assert "slice_indices" not in _forward_source()
+
+    def test_no_hidden_states_bracket_slice(self) -> None:
+        source = _forward_source()
+        # Explicit ``hidden_states[:, ..., :]`` / ``last_hidden_state[:, ..., :]``
+        # position selection would bypass the Mobilint decoder.
+        assert not re.search(r"hidden_states\s*\[\s*:\s*,", source)
+        assert not re.search(r"last_hidden_state\s*\[\s*:\s*,", source)
+
+    def test_no_gather_along_seq_dim(self) -> None:
+        # A ``.gather(1, indices)`` on the decoder output would be another way
+        # to implement position selection at the model level.
+        assert not re.search(r"\.gather\(\s*1\s*,", _forward_source())
+
+    def test_logits_to_keep_not_a_named_parameter(self) -> None:
+        # If upstream promotes ``logits_to_keep`` to a named parameter on
+        # ``Qwen3VLModel.forward``, it stops flowing through ``**kwargs`` to
+        # ``self.language_model`` and is very likely paired with local slicing.
+        params = inspect.signature(Qwen3VLModel.forward).parameters
+        assert "logits_to_keep" not in params
+
+    def test_kwargs_are_forwarded_to_language_model(self) -> None:
+        # Our wrapper depends on ``**kwargs`` reaching ``self.language_model``.
+        source = _forward_source()
+        match = re.search(r"self\.language_model\((?P<args>.*?)\)", source, re.DOTALL)
+        assert match is not None, "expected a self.language_model(...) call in upstream forward"
+        assert "**kwargs" in match.group("args")

--- a/tests/transformers/image_text_to_text/test_qwen3_vl_upstream_contract.py
+++ b/tests/transformers/image_text_to_text/test_qwen3_vl_upstream_contract.py
@@ -18,6 +18,7 @@ These tests pin that contract via source inspection.
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import re
 
@@ -29,7 +30,11 @@ from tests.transformers.image_text_to_text.qwen3_vl_compat import (
 
 skip_if_transformers_lacks_qwen3_vl_support()
 
-from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLModel  # noqa: E402
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (  # noqa: E402
+    Qwen3VLCausalLMOutputWithPast,
+    Qwen3VLModel,
+    Qwen3VLModelOutputWithPast,
+)
 
 pytestmark = pytest.mark.upstream_contract
 
@@ -72,3 +77,72 @@ class TestQwen3VLModelForwardSourceContract:
         match = re.search(r"self\.language_model\((?P<args>.*?)\)", source, re.DOTALL)
         assert match is not None, "expected a self.language_model(...) call in upstream forward"
         assert "**kwargs" in match.group("args")
+
+
+# ---------------------------------------------------------------------------
+# Safety net for dynamic output/loss adaptation.
+#
+# The Mobilint wrapper builds its returned ``Qwen3VLCausalLMOutputWithPast``
+# via ``mirror_output_fields`` and its loss kwargs via
+# ``build_loss_kwargs_dynamic``. Those helpers pick up new upstream additions
+# automatically, but they can only mirror fields present on the source model
+# output and can only supply loss kwargs whose value source lives in
+# ``LOSS_KWARG_SUPPLY_NAMES``. The two checks below catch the drift cases the
+# dynamic path cannot cover on its own.
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3VLCausalLMOutputFieldCoverage:
+    """Every CausalLM field must be reachable via override or model-output mirror."""
+
+    def test_uncovered_causal_lm_fields_have_defaults(self) -> None:
+        overrides = {"loss", "logits"}
+        model_output_fields = {field.name for field in dataclasses.fields(Qwen3VLModelOutputWithPast)}
+        uncovered = [
+            field
+            for field in dataclasses.fields(Qwen3VLCausalLMOutputWithPast)
+            if field.name not in overrides and field.name not in model_output_fields
+        ]
+        missing_default = [
+            field.name
+            for field in uncovered
+            if field.default is dataclasses.MISSING and field.default_factory is dataclasses.MISSING
+        ]
+        assert not missing_default, (
+            "Qwen3VLCausalLMOutputWithPast added a required field that "
+            "mirror_output_fields cannot fill: "
+            f"{missing_default}. The Mobilint wrapper must supply this field "
+            "as an explicit override, or upstream must add it to "
+            "Qwen3VLModelOutputWithPast so the mirror picks it up."
+        )
+
+
+class TestQwen3VLLossFunctionKwargsSupply:
+    """Every required loss parameter must be in the supply pool."""
+
+    def test_required_loss_params_are_in_supply_pool(self) -> None:
+        from transformers.loss.loss_utils import ForCausalLMLoss
+
+        from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+            LOSS_KWARG_SUPPLY_NAMES,
+        )
+
+        signature = inspect.signature(ForCausalLMLoss)
+        required_named = [
+            name
+            for name, parameter in signature.parameters.items()
+            if parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+            and parameter.default is inspect.Parameter.empty
+        ]
+        missing = [name for name in required_named if name not in LOSS_KWARG_SUPPLY_NAMES]
+        assert not missing, (
+            "ForCausalLMLoss requires parameters that build_loss_kwargs_dynamic "
+            f"does not know how to supply: {missing}. Extend "
+            "LOSS_KWARG_SUPPLY_NAMES and the ``supply`` dict in "
+            "build_loss_kwargs_dynamic together to cover them."
+        )

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -102,6 +102,42 @@ class TestOutputPositionsForLogitsToKeep:
         indices = torch.tensor([], dtype=torch.long)
         assert MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5) == []
 
+    def test_tensor_float_dtype_raises_type_error(self) -> None:
+        # Silently truncating ``1.9 -> 1`` diverges from PyTorch's
+        # ``hidden_states[:, tensor, :]``, which rejects float indices
+        # outright. Reject before ``int()`` erases the mistake.
+        indices = torch.tensor([1.9])
+        with pytest.raises(TypeError, match=r"integer dtype.*torch\.float"):
+            MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5)
+
+    def test_tensor_bool_dtype_raises_type_error(self) -> None:
+        # Boolean-mask indexing is not supported: coercing ``True/False``
+        # to ``1/0`` would silently reinterpret a mask as three integer
+        # positions.
+        indices = torch.tensor([True, False, True])
+        with pytest.raises(TypeError, match=r"integer dtype.*torch\.bool"):
+            MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5)
+
+    def test_tensor_bool_dtype_raises_via_is_last_only_selector(self) -> None:
+        # A single-element bool tensor must not sneak past the fast-path
+        # check by coercing ``True`` to ``1``.
+        indices = torch.tensor([True])
+        with pytest.raises(TypeError, match=r"integer dtype.*torch\.bool"):
+            MobilintModelMixin._is_last_only_selector(indices, seq_len=5)
+
+    def test_tensor_float_dtype_raises_via_llm_forward(self) -> None:
+        model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        inputs_embeds = torch.zeros(1, 4, 3)
+        cache_position = torch.arange(4)
+        with pytest.raises(TypeError, match=r"integer dtype.*torch\.float"):
+            model.llm_forward(
+                inputs_embeds=inputs_embeds,
+                past_key_values=None,
+                cache_position=cache_position,
+                prefill_chunk_size=4,
+                logits_to_keep=torch.tensor([0.0, 1.0]),
+            )
+
 
 class TestWalkPositionsForLogitsToKeep:
     """Cursor helper: sorted-unique for monotonic KV walks."""

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -31,44 +31,83 @@ from tests.transformers._fake_mxq import (
 
 
 # ---------------------------------------------------------------------------
-# _normalize_logits_to_keep
+# _output_positions_for_logits_to_keep / _walk_positions_for_logits_to_keep
 # ---------------------------------------------------------------------------
 
 
-class TestNormalizeLogitsToKeep:
+class TestOutputPositionsForLogitsToKeep:
+    """HF-compatible selector: caller order preserved, duplicates kept."""
+
     def test_int_zero_keeps_every_position(self) -> None:
-        assert MobilintModelMixin._normalize_logits_to_keep(0, 5) == [0, 1, 2, 3, 4]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(0, 5) == [0, 1, 2, 3, 4]
 
     def test_int_one_keeps_last_position(self) -> None:
-        assert MobilintModelMixin._normalize_logits_to_keep(1, 5) == [4]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(1, 5) == [4]
 
     def test_int_n_keeps_last_n_positions(self) -> None:
-        assert MobilintModelMixin._normalize_logits_to_keep(3, 5) == [2, 3, 4]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(3, 5) == [2, 3, 4]
 
     def test_int_oversized_keeps_all_positions(self) -> None:
-        assert MobilintModelMixin._normalize_logits_to_keep(9, 4) == [0, 1, 2, 3]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(9, 4) == [0, 1, 2, 3]
 
     def test_int_equal_seq_len_keeps_all_positions(self) -> None:
-        assert MobilintModelMixin._normalize_logits_to_keep(5, 5) == [0, 1, 2, 3, 4]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(5, 5) == [0, 1, 2, 3, 4]
 
     def test_int_negative_falls_back_to_all_positions(self) -> None:
-        assert MobilintModelMixin._normalize_logits_to_keep(-1, 3) == [0, 1, 2]
+        # Preserved from the initial implementation (commit d92a353) for
+        # backward compat; callers that want per-position selection pass a
+        # tensor, and negative ints only ever leaked in through misuse.
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(-1, 3) == [0, 1, 2]
 
-    def test_tensor_indices_are_sorted_and_deduped(self) -> None:
+    def test_tensor_preserves_caller_order(self) -> None:
         indices = torch.tensor([3, 0, 3, 2])
-        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == [0, 2, 3]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5) == [3, 0, 3, 2]
+
+    def test_tensor_preserves_duplicates(self) -> None:
+        indices = torch.tensor([2, 2])
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5) == [2, 2]
 
     def test_tensor_negative_indices_wrap(self) -> None:
         indices = torch.tensor([-1, -3])
-        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == [2, 4]
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5) == [4, 2]
 
-    def test_tensor_out_of_range_indices_are_dropped(self) -> None:
-        indices = torch.tensor([-100, 0, 4, 5, 99])
-        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == [0, 4]
+    def test_tensor_out_of_range_index_raises(self) -> None:
+        indices = torch.tensor([0, 4, 99])
+        with pytest.raises(IndexError, match=r"99.*seq_len=5"):
+            MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5)
+
+    def test_tensor_negative_out_of_range_index_raises(self) -> None:
+        # -100 wraps to -95, which is still < 0 and must not be silently dropped.
+        indices = torch.tensor([-100])
+        with pytest.raises(IndexError, match=r"-100.*seq_len=5"):
+            MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5)
 
     def test_tensor_empty_returns_empty_list(self) -> None:
         indices = torch.tensor([], dtype=torch.long)
-        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == []
+        assert MobilintModelMixin._output_positions_for_logits_to_keep(indices, seq_len=5) == []
+
+
+class TestWalkPositionsForLogitsToKeep:
+    """Cursor helper: sorted-unique for monotonic KV walks."""
+
+    def test_tensor_sorts_and_dedupes(self) -> None:
+        indices = torch.tensor([3, 0, 3, 2])
+        assert MobilintModelMixin._walk_positions_for_logits_to_keep(indices, seq_len=5) == [0, 2, 3]
+
+    def test_int_matches_output_helper(self) -> None:
+        # For int inputs the two helpers are structurally the same because
+        # int semantics never produce duplicates or unsorted output.
+        assert MobilintModelMixin._walk_positions_for_logits_to_keep(3, 5) == [2, 3, 4]
+        assert MobilintModelMixin._walk_positions_for_logits_to_keep(0, 4) == [0, 1, 2, 3]
+
+    def test_tensor_negative_indices_wrap(self) -> None:
+        indices = torch.tensor([-1, -3])
+        assert MobilintModelMixin._walk_positions_for_logits_to_keep(indices, seq_len=5) == [2, 4]
+
+    def test_tensor_out_of_range_index_raises(self) -> None:
+        indices = torch.tensor([0, 99])
+        with pytest.raises(IndexError, match=r"99.*seq_len=5"):
+            MobilintModelMixin._walk_positions_for_logits_to_keep(indices, seq_len=5)
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +251,54 @@ class TestLlmForwardSingle:
         )
         assert logits.shape == (3, mxq.vocab_size)
 
+    def test_dynamic_axis_tensor_preserves_caller_order_and_duplicates(self) -> None:
+        """HF fancy-indexing preserves caller order and duplicates; Path 2 mirrors that.
+
+        Building the "expected" from the fake's own per-chunk payload keeps
+        the assertion tied to observable behavior rather than the fake's
+        internal layout.
+        """
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        seq_len = 5
+        indices = torch.tensor([3, 0, 3, 2])
+        _model, logits = self._run(
+            mxq, seq_len=seq_len, hidden_size=3, logits_to_keep=indices, prefill_chunk_size=seq_len
+        )
+
+        # Reconstruct the single (chunk_len=5) payload the fake produced.
+        full = np.arange(seq_len * mxq.vocab_size, dtype=np.float32).reshape(seq_len, mxq.vocab_size)
+        expected = full[[3, 0, 3, 2], :]
+        assert logits.shape == (4, mxq.vocab_size)
+        np.testing.assert_allclose(logits.numpy(), expected)
+        # Duplicate index 3 → rows 0 and 2 are identical.
+        np.testing.assert_array_equal(logits[0].numpy(), logits[2].numpy())
+
+    def test_dynamic_axis_tensor_negative_indices_pick_positions_in_order(self) -> None:
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        seq_len = 4
+        _model, logits = self._run(
+            mxq,
+            seq_len=seq_len,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([-1, -2]),
+            prefill_chunk_size=seq_len,
+        )
+
+        full = np.arange(seq_len * mxq.vocab_size, dtype=np.float32).reshape(seq_len, mxq.vocab_size)
+        expected = full[[3, 2], :]  # -1 → 3, -2 → 2
+        np.testing.assert_allclose(logits.numpy(), expected)
+
+    def test_dynamic_axis_tensor_out_of_range_raises(self) -> None:
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        with pytest.raises(IndexError, match=r"99.*seq_len=5"):
+            self._run(
+                mxq,
+                seq_len=5,
+                hidden_size=3,
+                logits_to_keep=torch.tensor([0, 4, 99]),
+                prefill_chunk_size=5,
+            )
+
     def test_fallback_interleaves_size_one_infer_for_kept_positions(self) -> None:
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         indices = torch.tensor([2, 5])
@@ -263,19 +350,54 @@ class TestLlmForwardSingle:
         assert chunk_seqs == [4, 2]
         assert logits.shape == (0, 0)
 
-    def test_fallback_all_out_of_range_indices_returns_empty_logits(self) -> None:
-        """All-out-of-range ``logits_to_keep`` must not raise on np.concatenate."""
+    def test_fallback_out_of_range_indices_raise_indexerror(self) -> None:
+        """HF fancy-indexing raises on out-of-range indices; we mirror that."""
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
-        _model, logits = self._run(
-            mxq,
-            seq_len=6,
-            hidden_size=3,
-            logits_to_keep=torch.tensor([100, -100]),
+        with pytest.raises(IndexError, match=r"100.*seq_len=6"):
+            self._run(
+                mxq,
+                seq_len=6,
+                hidden_size=3,
+                logits_to_keep=torch.tensor([100, -100]),
+                prefill_chunk_size=4,
+            )
+
+    def test_fallback_tensor_preserves_caller_order_and_duplicates(self) -> None:
+        """Path 3 KV walk is sorted-unique; final output re-uses positions in caller order.
+
+        The KV cache is threaded through so ``cache_size`` (the fake fill) is
+        distinct at each captured position: size-1 infer at position p (with
+        prior positions already walked) returns ``full(vocab, p)``. That makes
+        the picked-per-position identity visible in the assembled tensor.
+        """
+        from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
+
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq)
+        cache = MobilintCache(mxq)
+        seq_len = 5
+        inputs_embeds = torch.zeros(1, seq_len, 3)
+        cache_position = torch.arange(seq_len)
+
+        indices = torch.tensor([3, 0, 3, 2])
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=cache_position,
             prefill_chunk_size=4,
+            logits_to_keep=indices,
         )
-        chunk_seqs = [c["shape"][2] for c in mxq.calls]
-        assert chunk_seqs == [4, 2]
-        assert logits.shape == (0, 0)
+
+        assert logits.shape == (4, mxq.vocab_size)
+        # Duplicate index 3 → rows 0 and 2 pick the same per_position tensor.
+        np.testing.assert_array_equal(logits[0].numpy(), logits[2].numpy())
+        # Fill at row 0 should match cache_size at position 3 (i.e. 3.0),
+        # row 1 → position 0 (fill=0), row 3 → position 2 (fill=2).
+        assert float(logits[0, 0]) == 3.0
+        assert float(logits[1, 0]) == 0.0
+        assert float(logits[3, 0]) == 2.0
+        # KV walk hit every position exactly once.
+        assert cache.get_seq_length() == seq_len
 
     def test_fallback_empty_tensor_still_advances_kv_cache(self) -> None:
         from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
@@ -388,6 +510,59 @@ class TestLlmForwardBatch:
         # Both items have position 0 and 2 in range → 2 kept positions each.
         assert logits.shape == (2, 2, mxq.vocab_size)
 
+    def test_dynamic_axis_tensor_preserves_caller_order_and_duplicates_per_item(self) -> None:
+        """Path 2 batched: caller order and duplicates survive per batch item.
+
+        With item lengths 4 and 2, ``logits_to_keep=[0, -1]`` resolves to
+        [0, 3] for item 0 and [0, 1] for item 1 — same kept length so no
+        padding, but the negative-wrap acts per-item.
+        """
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 0, 0]], dtype=torch.long)
+        indices = torch.tensor([0, -1])
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=indices,
+            prefill_chunk_size=4,
+        )
+        assert logits.shape == (2, 2, mxq.vocab_size)
+
+    def test_dynamic_axis_tensor_duplicates_produce_repeated_rows(self) -> None:
+        """A tensor with an explicit duplicate index emits the same row twice per item."""
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        indices = torch.tensor([2, 0, 2])
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=indices,
+            prefill_chunk_size=3,
+        )
+        assert logits.shape == (2, 3, mxq.vocab_size)
+        # For every item, row 0 (index 2) equals row 2 (also index 2).
+        for j in range(2):
+            np.testing.assert_array_equal(logits[j, 0].numpy(), logits[j, 2].numpy())
+
+    def test_fallback_tensor_duplicates_produce_repeated_rows_per_item(self) -> None:
+        """Path 3 batched: walk-positions drive the cursor, output-positions reassemble."""
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        indices = torch.tensor([2, 0, 2])
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=indices,
+            prefill_chunk_size=4,
+        )
+        assert logits.shape == (2, 3, mxq.vocab_size)
+        # Duplicate index 2 must yield identical rows within each batch item.
+        for j in range(2):
+            np.testing.assert_array_equal(logits[j, 0].numpy(), logits[j, 2].numpy())
+
     def test_fallback_interleaves_prefill_and_size_one_across_batch(self) -> None:
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long)
@@ -424,16 +599,19 @@ class TestLlmForwardBatch:
         assert torch.all(torch.isinf(logits[0, 3]) & (logits[0, 3] < 0))
 
     def test_fallback_asymmetric_batch_avoids_size_one_for_exhausted_item(self) -> None:
-        """One item has its only kept position at 0, the other has kept at 5.
+        """One item's walk-set is exhausted after cursor 0; the other keeps going to 5.
 
         With the previous batch-wide ``min_keep_start`` heuristic, every cursor
         step after position 0 would be forced to chunk=1 — even though item 1
         was done capturing after step 0 and item 0 didn't need another capture
         until position 5. The per-item pointer lets the middle walk use the
         caller's ``prefill_chunk_size``.
+
+        ``[0, -1]`` picks position 0 and the last valid position per item —
+        item 0 (seq_len=6) resolves to [0, 5]; item 1 (seq_len=1) resolves to
+        [0, 0] (walk-set collapses to {0} after dedup).
         """
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
-        # Item 0 seq_len=6 keeps {0, 5}; item 1 seq_len=1 keeps {0} (5 clamped away).
         attention_mask = torch.tensor(
             [[1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0]], dtype=torch.long
         )
@@ -441,7 +619,7 @@ class TestLlmForwardBatch:
             mxq,
             attention_mask=attention_mask,
             hidden_size=4,
-            logits_to_keep=torch.tensor([0, 5]),
+            logits_to_keep=torch.tensor([0, -1]),
             prefill_chunk_size=4,
         )
         # Expected trace: (chunk=1 at cursor 0 for both items), (chunk=4 for
@@ -451,10 +629,10 @@ class TestLlmForwardBatch:
         assert mxq.calls[1]["batch"] == [(0, 4, 0)]
         assert mxq.calls[2]["batch"] == [(0, 1, 0)]
 
-        # Item 0 keeps 2 positions; item 1 keeps 1 → padded stack (2, 2, vocab).
+        # Both items keep 2 positions (item 1's second row repeats position 0).
         assert logits.shape == (2, 2, mxq.vocab_size)
-        # Item 1's slot 1 is padding — -inf so softmax masks it.
-        assert torch.all(torch.isinf(logits[1, 1]) & (logits[1, 1] < 0))
+        # Item 1's duplicate index means row 0 == row 1 (both pick position 0).
+        np.testing.assert_array_equal(logits[1, 0].numpy(), logits[1, 1].numpy())
 
     def test_fallback_disjoint_per_item_kept_positions(self) -> None:
         """Kept sets share no positions: item 0 keeps {1}, item 1 keeps {5}.

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -181,6 +181,44 @@ class TestMxqSupportsAllLogits:
 
 
 # ---------------------------------------------------------------------------
+# _mxq_static_vocab_size
+# ---------------------------------------------------------------------------
+
+
+class TestMxqStaticVocabSize:
+    def test_first_call_returns_vocab_size(self) -> None:
+        mxq = StaticLastOnlyMxq(vocab_size=7)
+        model = make_model(mxq)
+        assert model._mxq_static_vocab_size() == 7
+
+    def test_result_is_cached_on_instance(self) -> None:
+        mxq = StaticLastOnlyMxq(vocab_size=5)
+        model = make_model(mxq)
+        assert model._mxq_static_vocab_size() == 5
+
+        # Flip the backend to a different vocab dim; a fresh probe would now
+        # return 9. The cached value must win — the compiled vocab dim is a
+        # fixed model property so we never want to re-probe.
+        mxq.get_model_output_shape = lambda: [(1, 1, 9)]  # type: ignore[assignment]
+        assert model._mxq_static_vocab_size() == 5
+
+    def test_raising_backend_propagates_error(self) -> None:
+        import qbruntime
+
+        class _ExplodingMxq(StaticLastOnlyMxq):
+            def get_model_output_shape(self):  # noqa: D401
+                raise qbruntime.QbRuntimeError("no shape for you")
+
+        model = make_model(_ExplodingMxq())
+        # Contract: probe failure re-raises rather than returning a sentinel.
+        # Path 2 has no valid fallback for an unknown vocab dim.
+        with pytest.raises(qbruntime.QbRuntimeError, match="no shape for you"):
+            model._mxq_static_vocab_size()
+        # Nothing was cached, so a subsequent call re-probes and re-raises.
+        assert getattr(model, "_mxq_static_vocab_cached", None) is None
+
+
+# ---------------------------------------------------------------------------
 # Single-item llm_forward paths
 # ---------------------------------------------------------------------------
 

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -344,6 +344,58 @@ class TestLlmForwardSingle:
         # only a subset yields logits.
         assert cache.get_seq_length() == seq_len
 
+    def test_fallback_empty_tensor_returns_empty_logits(self) -> None:
+        """An empty ``logits_to_keep`` tensor must not raise on np.concatenate."""
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        _model, logits = self._run(
+            mxq,
+            seq_len=6,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=4,
+        )
+        # No kept positions → no size-1 infer calls, but the KV prefix loop
+        # still walks the whole sequence in normal-sized chunks.
+        chunk_seqs = [c["shape"][2] for c in mxq.calls]
+        assert chunk_seqs == [4, 2]
+        assert logits.shape == (0, 0)
+
+    def test_fallback_all_out_of_range_indices_returns_empty_logits(self) -> None:
+        """All-out-of-range ``logits_to_keep`` must not raise on np.concatenate."""
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        _model, logits = self._run(
+            mxq,
+            seq_len=6,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([100, -100]),
+            prefill_chunk_size=4,
+        )
+        chunk_seqs = [c["shape"][2] for c in mxq.calls]
+        assert chunk_seqs == [4, 2]
+        assert logits.shape == (0, 0)
+
+    def test_fallback_empty_tensor_still_advances_kv_cache(self) -> None:
+        from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
+
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = _make_model(mxq)
+        cache = MobilintCache(mxq)
+        seq_len = 6
+        inputs_embeds = torch.zeros(1, seq_len, 3)
+        cache_position = torch.arange(seq_len)
+
+        model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=cache_position,
+            prefill_chunk_size=4,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+        )
+        # Even with no kept positions, the KV cache must be fully advanced so
+        # subsequent decode steps observe the same cache state as the other
+        # branches would leave behind.
+        assert cache.get_seq_length() == seq_len
+
 
 # ---------------------------------------------------------------------------
 # Batched _llm_forward_batch paths

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -15,6 +15,7 @@ Both the single-item and batched paths are exercised via fake MXQ backends.
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 import numpy as np
@@ -779,3 +780,135 @@ class TestBatchedEmptySelection:
         assert logits.shape == (2, 3, mxq.vocab_size)
         # Item 0 is entirely padding → all -inf.
         assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))
+
+
+# ---------------------------------------------------------------------------
+# One-shot slow-path warning on last-only MXQ + non-default logits_to_keep
+# ---------------------------------------------------------------------------
+
+
+class TestLastOnlySlowPathWarning:
+    """Path 3 fires a WARNING once per instance so manual .forward() callers
+    see the per-token infer cost without having to read source."""
+
+    _LOGGER_NAME = "mblt_model_zoo.hf_transformers.utils.modeling_utils"
+
+    @staticmethod
+    def _slow_path_warnings(records: list[logging.LogRecord]) -> list[logging.LogRecord]:
+        return [
+            r
+            for r in records
+            if r.levelno == logging.WARNING and "logits_to_keep" in r.getMessage()
+        ]
+
+    def _run_single(
+        self,
+        model,
+        *,
+        seq_len: int,
+        logits_to_keep,
+        hidden_size: int = 3,
+        prefill_chunk_size: int = 4,
+    ) -> None:
+        inputs_embeds = torch.arange(seq_len * hidden_size, dtype=torch.float32).reshape(
+            1, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            logits_to_keep=logits_to_keep,
+        )
+
+    def _run_batched(
+        self,
+        model,
+        *,
+        attention_mask: torch.Tensor,
+        logits_to_keep,
+        hidden_size: int = 4,
+        prefill_chunk_size: int = 4,
+    ) -> None:
+        batch, seq_len = attention_mask.shape
+        inputs_embeds = torch.arange(batch * seq_len * hidden_size, dtype=torch.float32).reshape(
+            batch, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            attention_mask=attention_mask,
+            logits_to_keep=logits_to_keep,
+        )
+
+    def test_warns_once_on_first_path3_entry_single_input(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            self._run_single(model, seq_len=6, logits_to_keep=0)
+            after_first = len(self._slow_path_warnings(caplog.records))
+            self._run_single(model, seq_len=6, logits_to_keep=0)
+            after_second = len(self._slow_path_warnings(caplog.records))
+
+        assert after_first == 1
+        assert after_second == 1
+        message = self._slow_path_warnings(caplog.records)[0].getMessage()
+        assert "logits_to_keep" in message
+
+    def test_warns_once_on_first_path3_entry_batched(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4), max_batch_size=4)
+        attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long)
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            self._run_batched(
+                model, attention_mask=attention_mask, logits_to_keep=torch.tensor([2, 3])
+            )
+            after_first = len(self._slow_path_warnings(caplog.records))
+            self._run_batched(
+                model, attention_mask=attention_mask, logits_to_keep=torch.tensor([2, 3])
+            )
+            after_second = len(self._slow_path_warnings(caplog.records))
+
+        assert after_first == 1
+        assert after_second == 1
+        assert "logits_to_keep" in self._slow_path_warnings(caplog.records)[0].getMessage()
+
+    def test_no_warning_on_fast_path(self, caplog: pytest.LogCaptureFixture) -> None:
+        single_model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        batched_model = make_model(
+            StaticLastOnlyMxq(vocab_size=5, max_width=4), max_batch_size=4
+        )
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            self._run_single(single_model, seq_len=6, logits_to_keep=1)
+            self._run_batched(batched_model, attention_mask=attention_mask, logits_to_keep=1)
+
+        assert self._slow_path_warnings(caplog.records) == []
+
+    def test_no_warning_on_dynamic_axis(self, caplog: pytest.LogCaptureFixture) -> None:
+        single_model = make_model(DynamicAxisMxq(vocab_size=5, max_width=4))
+        batched_model = make_model(
+            DynamicAxisMxq(vocab_size=5, max_width=4), max_batch_size=4
+        )
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            self._run_single(single_model, seq_len=6, logits_to_keep=0)
+            self._run_batched(batched_model, attention_mask=attention_mask, logits_to_keep=0)
+
+        assert self._slow_path_warnings(caplog.records) == []
+
+    def test_warning_is_per_instance(self, caplog: pytest.LogCaptureFixture) -> None:
+        model_a = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        model_b = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            self._run_single(model_a, seq_len=6, logits_to_keep=0)
+            self._run_single(model_b, seq_len=6, logits_to_keep=0)
+
+        # One warning per instance — the flag lives on the model, not the class.
+        assert len(self._slow_path_warnings(caplog.records)) == 2

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -450,8 +450,8 @@ class TestLlmForwardBatch:
         # Both items pad up to the longest kept-length (3 positions for item 1;
         # item 0 has 2 real positions and is right-padded).
         assert logits.shape == (2, 3, mxq.vocab_size)
-        # The padded tail of item 0 should be exactly zero.
-        assert torch.all(logits[0, 2] == 0)
+        # The padded tail of item 0 must be -inf so softmax zeros it out.
+        assert torch.all(torch.isinf(logits[0, 2]) & (logits[0, 2] < 0))
 
     def test_dynamic_axis_tensor_indices_apply_per_item(self) -> None:
         mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
@@ -499,5 +499,5 @@ class TestLlmForwardBatch:
             prefill_chunk_size=2,
         )
         assert logits.shape == (2, 4, mxq.vocab_size)
-        # Item 0's slot 3 is padding (zero row).
-        assert torch.all(logits[0, 3] == 0)
+        # Item 0's slot 3 is padding — filled with -inf so softmax masks it.
+        assert torch.all(torch.isinf(logits[0, 3]) & (logits[0, 3] < 0))

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -314,7 +314,9 @@ class TestLlmForwardSingle:
         assert logits.shape == (6, mxq.vocab_size)
 
         # Reconstruct the same per-chunk payload the fake produced so we can
-        # check the concatenation ordering.
+        # check the concatenation ordering. Without a caller cache, ``_do_infer``
+        # uses ``start`` as the running cache_size so the NPU sees prior chunks'
+        # KV state — the fake mirrors that by offsetting per chunk by cache_size.
         expected_chunks = []
         cache_size_running = 0
         for chunk_len in (3, 3):
@@ -325,7 +327,7 @@ class TestLlmForwardSingle:
                 )
                 + offset
             )
-            cache_size_running = 0  # past_key_values is None → cache_size stays 0
+            cache_size_running += chunk_len
         expected = np.concatenate(expected_chunks, axis=1).squeeze(0)
         np.testing.assert_allclose(logits.numpy(), expected)
 
@@ -405,6 +407,28 @@ class TestLlmForwardSingle:
         assert chunk_seqs == [2, 1, 2, 1]
         # ``.squeeze(0)`` in path 3 drops the leading batch axis.
         assert logits.shape == (len(indices), mxq.vocab_size)
+
+    def test_fallback_advances_cache_size_without_caller_cache(self) -> None:
+        """Path 3 with ``past_key_values=None`` must still tell the NPU about
+        prior tokens.
+
+        Without this, the discarded prefix ``_do_infer`` calls would pass
+        ``cache_size=0`` and each size-1 kept-position capture would be
+        evaluated as if it were the start of a fresh sequence — silently
+        corrupting keep-all / perplexity logits when ``.forward()`` is
+        called without ``use_cache=True`` (the new HF default is
+        ``logits_to_keep=0``, which triggers Path 3 on last-only MXQ).
+        """
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        indices = torch.tensor([2, 5])
+        _model, _logits = self._run(
+            mxq, seq_len=6, hidden_size=3, logits_to_keep=indices, prefill_chunk_size=4
+        )
+        # Chunks: (0..2 prefill), (2..3 capture), (3..5 prefill), (5..6 capture).
+        # cache_size at each infer entry equals the running "processed so far"
+        # count, which is the chunk's ``start`` position.
+        cache_sizes = [c["cache_size"] for c in mxq.calls]
+        assert cache_sizes == [0, 2, 3, 5]
 
     def test_fallback_advances_kv_cache_across_all_positions(self) -> None:
         from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
@@ -768,10 +792,12 @@ class TestLlmForwardBatch:
         )
         # Expected trace: (chunk=1 at cursor 0 for both items), (chunk=4 for
         # item 0 only, walking 1→5), (chunk=1 at cursor 5 for item 0).
+        # cache_sizes track the running cursor per item (start=cursor when
+        # past_key_values is None) so the NPU sees prior chunks' KV state.
         assert len(mxq.calls) == 3
         assert mxq.calls[0]["batch"] == [(0, 1, 0), (1, 1, 0)]
-        assert mxq.calls[1]["batch"] == [(0, 4, 0)]
-        assert mxq.calls[2]["batch"] == [(0, 1, 0)]
+        assert mxq.calls[1]["batch"] == [(0, 4, 1)]
+        assert mxq.calls[2]["batch"] == [(0, 1, 5)]
 
         # Both items keep 2 positions (item 1's second row repeats position 0).
         assert logits.shape == (2, 2, mxq.vocab_size)
@@ -803,7 +829,10 @@ class TestLlmForwardBatch:
         assert per_call == [(2, 1), (2, 1), (1, 3), (1, 1)]
 
         # Item 1 must not appear in the middle KV-only walk except by itself.
-        assert mxq.calls[2]["batch"] == [(1, 3, 0)]
+        # cache_size=2 because item 1 has been walked contiguously through
+        # cursor 0 and 1 by prior chunks (running cursor when the caller
+        # passes past_key_values=None).
+        assert mxq.calls[2]["batch"] == [(1, 3, 2)]
 
         assert logits.shape == (2, 1, mxq.vocab_size)
 

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 import torch
 
+from mblt_model_zoo.hf_transformers.utils import modeling_utils
 from mblt_model_zoo.hf_transformers.utils.modeling_utils import MobilintModelMixin
 from tests.transformers._fake_mxq import (
     DynamicAxisMxq,
@@ -101,6 +102,25 @@ class TestMxqSupportsAllLogits:
 
         model = make_model(_ExplodingMxq())
         assert model._mxq_supports_all_logits() is False
+
+    def test_probe_honors_patched_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The dynamic-axis sentinel is a module-level constant, not a hard-coded literal.
+
+        If a future backend represents "dynamic" with a different marker we
+        can retarget the probe by rebinding ``_MXQ_DYNAMIC_AXIS_SENTINEL``.
+        """
+        monkeypatch.setattr(modeling_utils, "_MXQ_DYNAMIC_AXIS_SENTINEL", -2)
+
+        class _NewSentinelMxq(StaticLastOnlyMxq):
+            def get_model_output_shape(self):
+                return [(1, -2, self.vocab_size)]
+
+        model = make_model(_NewSentinelMxq())
+        assert model._mxq_supports_all_logits() is True
+
+        # The old ``-1`` sentinel must no longer trigger the dynamic path.
+        stale = make_model(DynamicAxisMxq())
+        assert stale._mxq_supports_all_logits() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -1050,3 +1050,116 @@ class TestLastOnlySlowPathWarning:
 
         # One warning per instance — the flag lives on the model, not the class.
         assert len(self._slow_path_warnings(caplog.records)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Regression: batched tensor selector must hoist the device->host copy
+# ---------------------------------------------------------------------------
+
+
+class TestBatchCpuCopyHoist:
+    """Lock in the tensor-selector CPU-copy hoist and the ``lens_equal`` shared
+    result in :meth:`MobilintModelMixin._llm_forward_batch`.
+
+    The batch loop must not call ``logits_to_keep.detach().to("cpu").flatten()
+    .tolist()`` per batch item — one copy up front, then per-``seq_len``
+    wrap/validate via :meth:`_output_positions_from_cpu_indices`. When every
+    item shares the same length the result is computed once and shared.
+    """
+
+    @staticmethod
+    def _spy_from_cpu_indices(monkeypatch):
+        calls: list[tuple[int, int]] = []
+        orig_fn = MobilintModelMixin._output_positions_from_cpu_indices.__func__
+
+        @classmethod
+        def spy(cls, cpu_indices, seq_len):
+            calls.append((id(cpu_indices), seq_len))
+            return orig_fn(cls, cpu_indices, seq_len)
+
+        monkeypatch.setattr(
+            MobilintModelMixin, "_output_positions_from_cpu_indices", spy
+        )
+        return calls
+
+    @staticmethod
+    def _run_batched(model, *, attention_mask, logits_to_keep, hidden_size=4, prefill_chunk_size=4):
+        batch, seq_len = attention_mask.shape
+        inputs_embeds = torch.arange(batch * seq_len * hidden_size, dtype=torch.float32).reshape(
+            batch, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        return model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            attention_mask=attention_mask,
+            logits_to_keep=logits_to_keep,
+        )
+
+    def test_from_cpu_indices_unit_matches_full_helper(self) -> None:
+        """The new entry point resolves the same way as the tensor branch of
+        :meth:`_output_positions_for_logits_to_keep`, given a pre-materialized
+        CPU list — including HF-style negative wrap and range check.
+        """
+        assert MobilintModelMixin._output_positions_from_cpu_indices([0, -1, 2], seq_len=5) == [0, 4, 2]
+        with pytest.raises(IndexError, match=r"7.*seq_len=5"):
+            MobilintModelMixin._output_positions_from_cpu_indices([0, 7], seq_len=5)
+
+    def test_lens_equal_calls_helper_exactly_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Uniform-length batch + tensor selector: the resolver runs once and
+        every batch item shares the returned list — no per-item CPU copy and
+        no per-item wrap/validate.
+        """
+        calls = self._spy_from_cpu_indices(monkeypatch)
+        model = make_model(DynamicAxisMxq(vocab_size=5, max_width=4), max_batch_size=4)
+        attention_mask = torch.tensor(
+            [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]], dtype=torch.long
+        )
+        self._run_batched(
+            model,
+            attention_mask=attention_mask,
+            logits_to_keep=torch.tensor([0, 2]),
+            prefill_chunk_size=3,
+        )
+        assert len(calls) == 1
+        assert calls[0][1] == 3
+
+    def test_lens_mixed_shares_single_cpu_copy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mixed-length batch + tensor selector: wrap/validate necessarily runs
+        per seq_len, but every call must receive the SAME list identity —
+        proving the device->host copy was hoisted out of the loop.
+        """
+        calls = self._spy_from_cpu_indices(monkeypatch)
+        model = make_model(DynamicAxisMxq(vocab_size=5, max_width=4), max_batch_size=3)
+        attention_mask = torch.tensor(
+            [[1, 1, 1, 0], [1, 1, 1, 1], [1, 1, 0, 0]], dtype=torch.long
+        )
+        self._run_batched(
+            model,
+            attention_mask=attention_mask,
+            logits_to_keep=torch.tensor([0, 1]),
+            prefill_chunk_size=4,
+        )
+        assert len(calls) == 3
+        shared_ids = {c[0] for c in calls}
+        assert len(shared_ids) == 1, (
+            "device->host copy must be hoisted: every _output_positions_from_cpu_indices "
+            "call must receive the same list object, but got distinct ids per call"
+        )
+        assert sorted(c[1] for c in calls) == [2, 3, 4]
+
+    def test_int_selector_skips_from_cpu_indices(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Int selectors (non-tensor) have no device->host copy to hoist, so
+        the CPU-indices entry point must not be involved.
+        """
+        calls = self._spy_from_cpu_indices(monkeypatch)
+        model = make_model(DynamicAxisMxq(vocab_size=5, max_width=4), max_batch_size=2)
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        # int == 0 is not the default fast path (that's int == 1), so this
+        # exercises the shared branch with an int selector.
+        self._run_batched(
+            model, attention_mask=attention_mask, logits_to_keep=0, prefill_chunk_size=3
+        )
+        assert calls == []

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -54,11 +54,26 @@ class TestOutputPositionsForLogitsToKeep:
     def test_int_equal_seq_len_keeps_all_positions(self) -> None:
         assert MobilintModelMixin._output_positions_for_logits_to_keep(5, 5) == [0, 1, 2, 3, 4]
 
-    def test_int_negative_falls_back_to_all_positions(self) -> None:
-        # Preserved from the initial implementation (commit d92a353) for
-        # backward compat; callers that want per-position selection pass a
-        # tensor, and negative ints only ever leaked in through misuse.
-        assert MobilintModelMixin._output_positions_for_logits_to_keep(-1, 3) == [0, 1, 2]
+    def test_int_negative_raises_value_error(self) -> None:
+        # Negative ints are a caller mistake (HF doesn't accept them and the
+        # tensor-negative-wrap path is a separate code path). Reject explicitly
+        # rather than silently mapping to keep-all, which the initial
+        # implementation in commit d92a353 did.
+        with pytest.raises(ValueError, match=r"logits_to_keep must be a non-negative int.*got -1"):
+            MobilintModelMixin._output_positions_for_logits_to_keep(-1, 3)
+
+    def test_int_negative_raises_via_llm_forward(self) -> None:
+        model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        inputs_embeds = torch.zeros(1, 4, 3)
+        cache_position = torch.arange(4)
+        with pytest.raises(ValueError, match=r"logits_to_keep must be a non-negative int.*got -2"):
+            model.llm_forward(
+                inputs_embeds=inputs_embeds,
+                past_key_values=None,
+                cache_position=cache_position,
+                prefill_chunk_size=4,
+                logits_to_keep=-2,
+            )
 
     def test_tensor_preserves_caller_order(self) -> None:
         indices = torch.tensor([3, 0, 3, 2])

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -1,0 +1,451 @@
+"""Regression tests for the shared ``logits_to_keep`` path in ``MobilintModelMixin``.
+
+Covers three code branches introduced by the HF-style ``logits_to_keep``
+support in the shared LLM inference core:
+
+1. Fast path (``logits_to_keep == 1``): the original last-token behavior.
+2. Dynamic-axis MXQ path (``mxq_model.get_model_output_shape()[0][-2] == -1``):
+   the compiled model emits per-position logits, so all-chunk outputs are
+   concatenated then sliced.
+3. Last-only MXQ fallback: prefill non-kept prefix through normal chunks and
+   run a size-1 infer at each kept position.
+
+Both the single-item and batched paths are exercised via fake MXQ backends.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pytest
+import torch
+
+from mblt_model_zoo.hf_transformers.utils.modeling_utils import MobilintModelMixin
+
+
+# ---------------------------------------------------------------------------
+# Fake MXQ + backend helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeInputBufferInfo:
+    def __init__(self, max_width: int, max_cache_size: int = 128):
+        self.max_width = max_width
+        self.max_cache_size = max_cache_size
+
+
+class _StaticLastOnlyMxq:
+    """MXQ stub that emits only the last-token logits per infer call.
+
+    ``infer`` accepts both the single-item shape (``[chunk], None, cache_size``)
+    and the batched shape (``[chunk], None, 0, batch_params``). Every call is
+    recorded so tests can assert chunk boundaries.
+    """
+
+    def __init__(self, vocab_size: int = 5, max_width: int = 4):
+        self.vocab_size = vocab_size
+        self.max_width = max_width
+        self.calls: list[dict] = []
+        self._batched_counter = 0
+
+    def get_input_buffer_info(self):
+        return [_FakeInputBufferInfo(max_width=self.max_width)]
+
+    def get_model_output_shape(self):
+        # Static token axis (second-to-last); "1" signals last-token-only output.
+        return [(1, 1, self.vocab_size)]
+
+    def infer(self, inputs, _extra, cache_size, batch_params=None):
+        chunk = np.asarray(inputs[0])
+        if batch_params is None:
+            self.calls.append({"shape": tuple(chunk.shape), "cache_size": int(cache_size)})
+            return [np.full((1, 1, self.vocab_size), fill_value=float(cache_size), dtype=np.float32)]
+
+        self._batched_counter += 1
+        active_batch = len(batch_params)
+        payload = np.stack(
+            [
+                np.full((self.vocab_size,), fill_value=float(p.cache_id * 100 + self._batched_counter), dtype=np.float32)
+                for p in batch_params
+            ],
+            axis=0,
+        )
+        self.calls.append(
+            {
+                "shape": tuple(chunk.shape),
+                "batch": [(p.cache_id, p.sequence_length, p.cache_size) for p in batch_params],
+            }
+        )
+        assert payload.shape == (active_batch, self.vocab_size)
+        return [payload]
+
+
+class _DynamicAxisMxq:
+    """MXQ stub that emits per-position logits."""
+
+    def __init__(self, vocab_size: int = 5, max_width: int = 4):
+        self.vocab_size = vocab_size
+        self.max_width = max_width
+        self.calls: list[dict] = []
+        self._batched_counter = 0
+
+    def get_input_buffer_info(self):
+        return [_FakeInputBufferInfo(max_width=self.max_width)]
+
+    def get_model_output_shape(self):
+        # Dynamic token axis; the shared helper interprets this as all-logits.
+        return [(1, -1, self.vocab_size)]
+
+    def infer(self, inputs, _extra, cache_size, batch_params=None):
+        chunk = np.asarray(inputs[0])
+        if batch_params is None:
+            # Single-item: chunk is (1, 1, chunk_len, hidden). Emit
+            # (1, chunk_len, vocab) so the token axis is second-to-last.
+            chunk_len = int(chunk.shape[2])
+            offset = int(cache_size) * self.vocab_size
+            values = np.arange(chunk_len * self.vocab_size, dtype=np.float32) + offset
+            self.calls.append(
+                {"shape": tuple(chunk.shape), "cache_size": int(cache_size), "chunk_len": chunk_len}
+            )
+            return [values.reshape(1, chunk_len, self.vocab_size)]
+
+        self._batched_counter += 1
+        total_tokens = sum(int(p.sequence_length) for p in batch_params)
+        flat = np.arange(total_tokens * self.vocab_size, dtype=np.float32).reshape(
+            total_tokens, self.vocab_size
+        )
+        # Encode per-item id into the payload so batched tests can spot mixups.
+        offset = 0
+        for p in batch_params:
+            flat[offset : offset + int(p.sequence_length), :] += p.cache_id * 1000.0
+            offset += int(p.sequence_length)
+        self.calls.append(
+            {
+                "shape": tuple(chunk.shape),
+                "batch": [(p.cache_id, p.sequence_length, p.cache_size) for p in batch_params],
+            }
+        )
+        return [flat]
+
+
+class _FakeBackend:
+    def __init__(self, mxq_model):
+        self.mxq_model = mxq_model
+
+
+def _make_model(mxq, *, max_batch_size: int = 1) -> MobilintModelMixin:
+    """Construct a bare ``MobilintModelMixin`` without triggering NPU init."""
+    model = MobilintModelMixin.__new__(MobilintModelMixin)
+    model.npu_backend = _FakeBackend(mxq)
+    config_kwargs = {"npu_prefill_chunk_size": None}
+    if max_batch_size > 1:
+        config_kwargs["max_batch_size"] = max_batch_size
+    model.config = type("Config", (), config_kwargs)()
+    model.npu_time = None
+    return model
+
+
+# ---------------------------------------------------------------------------
+# _normalize_logits_to_keep
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLogitsToKeep:
+    def test_int_zero_keeps_every_position(self) -> None:
+        assert MobilintModelMixin._normalize_logits_to_keep(0, 5) == [0, 1, 2, 3, 4]
+
+    def test_int_one_keeps_last_position(self) -> None:
+        assert MobilintModelMixin._normalize_logits_to_keep(1, 5) == [4]
+
+    def test_int_n_keeps_last_n_positions(self) -> None:
+        assert MobilintModelMixin._normalize_logits_to_keep(3, 5) == [2, 3, 4]
+
+    def test_int_oversized_keeps_all_positions(self) -> None:
+        assert MobilintModelMixin._normalize_logits_to_keep(9, 4) == [0, 1, 2, 3]
+
+    def test_int_equal_seq_len_keeps_all_positions(self) -> None:
+        assert MobilintModelMixin._normalize_logits_to_keep(5, 5) == [0, 1, 2, 3, 4]
+
+    def test_int_negative_falls_back_to_all_positions(self) -> None:
+        assert MobilintModelMixin._normalize_logits_to_keep(-1, 3) == [0, 1, 2]
+
+    def test_tensor_indices_are_sorted_and_deduped(self) -> None:
+        indices = torch.tensor([3, 0, 3, 2])
+        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == [0, 2, 3]
+
+    def test_tensor_negative_indices_wrap(self) -> None:
+        indices = torch.tensor([-1, -3])
+        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == [2, 4]
+
+    def test_tensor_out_of_range_indices_are_dropped(self) -> None:
+        indices = torch.tensor([-100, 0, 4, 5, 99])
+        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == [0, 4]
+
+    def test_tensor_empty_returns_empty_list(self) -> None:
+        indices = torch.tensor([], dtype=torch.long)
+        assert MobilintModelMixin._normalize_logits_to_keep(indices, seq_len=5) == []
+
+
+# ---------------------------------------------------------------------------
+# _mxq_supports_all_logits
+# ---------------------------------------------------------------------------
+
+
+class TestMxqSupportsAllLogits:
+    def test_static_token_axis_returns_false(self) -> None:
+        model = _make_model(_StaticLastOnlyMxq())
+        assert model._mxq_supports_all_logits() is False
+
+    def test_dynamic_token_axis_returns_true(self) -> None:
+        model = _make_model(_DynamicAxisMxq())
+        assert model._mxq_supports_all_logits() is True
+
+    def test_result_is_cached_on_instance(self) -> None:
+        mxq = _StaticLastOnlyMxq()
+        model = _make_model(mxq)
+        assert model._mxq_supports_all_logits() is False
+
+        # Flip the underlying shape; a fresh probe would now claim dynamic.
+        mxq.get_model_output_shape = lambda: [(1, -1, mxq.vocab_size)]  # type: ignore[assignment]
+        # Cached: should still report False.
+        assert model._mxq_supports_all_logits() is False
+
+    def test_raising_backend_falls_back_to_false(self) -> None:
+        class _ExplodingMxq(_StaticLastOnlyMxq):
+            def get_model_output_shape(self):  # noqa: D401
+                raise RuntimeError("no shape for you")
+
+        model = _make_model(_ExplodingMxq())
+        assert model._mxq_supports_all_logits() is False
+
+
+# ---------------------------------------------------------------------------
+# Single-item llm_forward paths
+# ---------------------------------------------------------------------------
+
+
+class TestLlmForwardSingle:
+    def _run(
+        self,
+        mxq,
+        seq_len: int,
+        hidden_size: int,
+        *,
+        logits_to_keep,
+        prefill_chunk_size: Optional[int] = None,
+    ):
+        model = _make_model(mxq)
+        inputs_embeds = torch.arange(seq_len * hidden_size, dtype=torch.float32).reshape(
+            1, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            logits_to_keep=logits_to_keep,
+        )
+        return model, logits
+
+    def test_default_keep_uses_fast_path_with_last_token_logits(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        _model, logits = self._run(mxq, seq_len=6, hidden_size=3, logits_to_keep=1, prefill_chunk_size=3)
+
+        # Two chunks of size 3 with the caller's prefill_chunk_size.
+        chunk_seqs = [c["shape"][2] for c in mxq.calls]
+        assert chunk_seqs == [3, 3]
+        # Path 1 squeezes the outer batch axis → (1, vocab).
+        assert logits.shape == (1, mxq.vocab_size)
+
+    def test_default_keep_ignores_dynamic_axis_probe(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        model, logits = self._run(mxq, seq_len=6, hidden_size=3, logits_to_keep=1, prefill_chunk_size=3)
+
+        # is_default_keep short-circuits before probing, so no cached probe result yet.
+        assert getattr(model, "_mxq_all_logits_cached", None) is None
+        # Only the last chunk's logits are returned in shape (1, chunk_len, vocab)
+        # → squeeze(0) → (chunk_len, vocab) because dynamic mxq returned 3d.
+        assert logits.shape == (3, mxq.vocab_size)
+
+    def test_dynamic_axis_keep_all_returns_every_position(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        model, logits = self._run(
+            mxq, seq_len=6, hidden_size=3, logits_to_keep=0, prefill_chunk_size=3
+        )
+
+        assert model._mxq_supports_all_logits() is True
+        assert logits.shape == (6, mxq.vocab_size)
+
+        # Reconstruct the same per-chunk payload the fake produced so we can
+        # check the concatenation ordering.
+        expected_chunks = []
+        cache_size_running = 0
+        for chunk_len in (3, 3):
+            offset = cache_size_running * mxq.vocab_size
+            expected_chunks.append(
+                np.arange(chunk_len * mxq.vocab_size, dtype=np.float32).reshape(
+                    1, chunk_len, mxq.vocab_size
+                )
+                + offset
+            )
+            cache_size_running = 0  # past_key_values is None → cache_size stays 0
+        expected = np.concatenate(expected_chunks, axis=1).squeeze(0)
+        np.testing.assert_allclose(logits.numpy(), expected)
+
+    def test_dynamic_axis_keep_last_n_slices_expected_positions(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        _model, logits = self._run(
+            mxq, seq_len=6, hidden_size=3, logits_to_keep=2, prefill_chunk_size=3
+        )
+        assert logits.shape == (2, mxq.vocab_size)
+
+    def test_dynamic_axis_tensor_indices_pick_out_positions(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        indices = torch.tensor([0, 2, 5])
+        _model, logits = self._run(
+            mxq, seq_len=6, hidden_size=3, logits_to_keep=indices, prefill_chunk_size=3
+        )
+        assert logits.shape == (3, mxq.vocab_size)
+
+    def test_fallback_interleaves_size_one_infer_for_kept_positions(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        indices = torch.tensor([2, 5])
+        _model, logits = self._run(
+            mxq, seq_len=6, hidden_size=3, logits_to_keep=indices, prefill_chunk_size=4
+        )
+
+        # Fallback: prefill 0..2 (chunk of 2), size-1 at 2, prefill 3..5 (chunk of 2), size-1 at 5.
+        # The prefix stride is clamped to the next kept position, not the caller's chunk size.
+        chunk_seqs = [c["shape"][2] for c in mxq.calls]
+        assert chunk_seqs == [2, 1, 2, 1]
+        # ``.squeeze(0)`` in path 3 drops the leading batch axis.
+        assert logits.shape == (len(indices), mxq.vocab_size)
+
+    def test_fallback_advances_kv_cache_across_all_positions(self) -> None:
+        from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
+
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = _make_model(mxq)
+        cache = MobilintCache(mxq)
+        seq_len = 6
+        inputs_embeds = torch.zeros(1, seq_len, 3)
+        cache_position = torch.arange(seq_len)
+
+        model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=cache,
+            cache_position=cache_position,
+            prefill_chunk_size=4,
+            logits_to_keep=torch.tensor([2, 5]),
+        )
+        # KV cache must advance monotonically through every position, even when
+        # only a subset yields logits.
+        assert cache.get_seq_length() == seq_len
+
+
+# ---------------------------------------------------------------------------
+# Batched _llm_forward_batch paths
+# ---------------------------------------------------------------------------
+
+
+class TestLlmForwardBatch:
+    def _run(
+        self,
+        mxq,
+        *,
+        attention_mask: torch.Tensor,
+        hidden_size: int,
+        logits_to_keep,
+        prefill_chunk_size: Optional[int] = None,
+        max_batch_size: int = 4,
+    ):
+        model = _make_model(mxq, max_batch_size=max_batch_size)
+        batch, seq_len = attention_mask.shape
+        inputs_embeds = torch.arange(batch * seq_len * hidden_size, dtype=torch.float32).reshape(
+            batch, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            attention_mask=attention_mask,
+            logits_to_keep=logits_to_keep,
+        )
+        return model, logits
+
+    def test_default_keep_path_preserves_existing_shape(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=2)
+        attention_mask = torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long)
+        _model, logits = self._run(
+            mxq, attention_mask=attention_mask, hidden_size=4, logits_to_keep=1, prefill_chunk_size=2
+        )
+        assert logits.shape == (2, 1, mxq.vocab_size)
+
+    def test_dynamic_axis_keep_all_returns_per_item_padded_stack(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long)
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=0,
+            prefill_chunk_size=3,
+        )
+        # Both items pad up to the longest kept-length (3 positions for item 1;
+        # item 0 has 2 real positions and is right-padded).
+        assert logits.shape == (2, 3, mxq.vocab_size)
+        # The padded tail of item 0 should be exactly zero.
+        assert torch.all(logits[0, 2] == 0)
+
+    def test_dynamic_axis_tensor_indices_apply_per_item(self) -> None:
+        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 0]], dtype=torch.long)
+        indices = torch.tensor([0, 2])
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=indices,
+            prefill_chunk_size=4,
+        )
+        # Both items have position 0 and 2 in range → 2 kept positions each.
+        assert logits.shape == (2, 2, mxq.vocab_size)
+
+    def test_fallback_interleaves_prefill_and_size_one_across_batch(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long)
+        # Request positions 2 and 3 so the fallback branch runs; logits_to_keep=1
+        # would hit the fast path and skip the fallback entirely.
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([2, 3]),
+            prefill_chunk_size=2,
+        )
+        # Both items keep positions {2, 3}, so min_keep_start=2. First chunk
+        # advances cursor 0→2 with the caller's prefill_chunk_size, then chunks
+        # drop to 1 to capture positions 2 and 3.
+        chunk_widths = [c["batch"][0][1] for c in mxq.calls]
+        assert chunk_widths == [2, 1, 1]
+        assert logits.shape == (2, 2, mxq.vocab_size)
+
+    def test_fallback_handles_variable_per_item_kept_positions(self) -> None:
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        # Item 0 has 3 real tokens; item 1 has 4. Keep-all on both yields
+        # 3 and 4 positions respectively → padding on item 0.
+        attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 1, 1]], dtype=torch.long)
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=0,
+            prefill_chunk_size=2,
+        )
+        assert logits.shape == (2, 4, mxq.vocab_size)
+        # Item 0's slot 3 is padding (zero row).
+        assert torch.all(logits[0, 3] == 0)

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -22,128 +22,11 @@ import pytest
 import torch
 
 from mblt_model_zoo.hf_transformers.utils.modeling_utils import MobilintModelMixin
-
-
-# ---------------------------------------------------------------------------
-# Fake MXQ + backend helpers
-# ---------------------------------------------------------------------------
-
-
-class _FakeInputBufferInfo:
-    def __init__(self, max_width: int, max_cache_size: int = 128):
-        self.max_width = max_width
-        self.max_cache_size = max_cache_size
-
-
-class _StaticLastOnlyMxq:
-    """MXQ stub that emits only the last-token logits per infer call.
-
-    ``infer`` accepts both the single-item shape (``[chunk], None, cache_size``)
-    and the batched shape (``[chunk], None, 0, batch_params``). Every call is
-    recorded so tests can assert chunk boundaries.
-    """
-
-    def __init__(self, vocab_size: int = 5, max_width: int = 4):
-        self.vocab_size = vocab_size
-        self.max_width = max_width
-        self.calls: list[dict] = []
-        self._batched_counter = 0
-
-    def get_input_buffer_info(self):
-        return [_FakeInputBufferInfo(max_width=self.max_width)]
-
-    def get_model_output_shape(self):
-        # Static token axis (second-to-last); "1" signals last-token-only output.
-        return [(1, 1, self.vocab_size)]
-
-    def infer(self, inputs, _extra, cache_size, batch_params=None):
-        chunk = np.asarray(inputs[0])
-        if batch_params is None:
-            self.calls.append({"shape": tuple(chunk.shape), "cache_size": int(cache_size)})
-            return [np.full((1, 1, self.vocab_size), fill_value=float(cache_size), dtype=np.float32)]
-
-        self._batched_counter += 1
-        active_batch = len(batch_params)
-        payload = np.stack(
-            [
-                np.full((self.vocab_size,), fill_value=float(p.cache_id * 100 + self._batched_counter), dtype=np.float32)
-                for p in batch_params
-            ],
-            axis=0,
-        )
-        self.calls.append(
-            {
-                "shape": tuple(chunk.shape),
-                "batch": [(p.cache_id, p.sequence_length, p.cache_size) for p in batch_params],
-            }
-        )
-        assert payload.shape == (active_batch, self.vocab_size)
-        return [payload]
-
-
-class _DynamicAxisMxq:
-    """MXQ stub that emits per-position logits."""
-
-    def __init__(self, vocab_size: int = 5, max_width: int = 4):
-        self.vocab_size = vocab_size
-        self.max_width = max_width
-        self.calls: list[dict] = []
-        self._batched_counter = 0
-
-    def get_input_buffer_info(self):
-        return [_FakeInputBufferInfo(max_width=self.max_width)]
-
-    def get_model_output_shape(self):
-        # Dynamic token axis; the shared helper interprets this as all-logits.
-        return [(1, -1, self.vocab_size)]
-
-    def infer(self, inputs, _extra, cache_size, batch_params=None):
-        chunk = np.asarray(inputs[0])
-        if batch_params is None:
-            # Single-item: chunk is (1, 1, chunk_len, hidden). Emit
-            # (1, chunk_len, vocab) so the token axis is second-to-last.
-            chunk_len = int(chunk.shape[2])
-            offset = int(cache_size) * self.vocab_size
-            values = np.arange(chunk_len * self.vocab_size, dtype=np.float32) + offset
-            self.calls.append(
-                {"shape": tuple(chunk.shape), "cache_size": int(cache_size), "chunk_len": chunk_len}
-            )
-            return [values.reshape(1, chunk_len, self.vocab_size)]
-
-        self._batched_counter += 1
-        total_tokens = sum(int(p.sequence_length) for p in batch_params)
-        flat = np.arange(total_tokens * self.vocab_size, dtype=np.float32).reshape(
-            total_tokens, self.vocab_size
-        )
-        # Encode per-item id into the payload so batched tests can spot mixups.
-        offset = 0
-        for p in batch_params:
-            flat[offset : offset + int(p.sequence_length), :] += p.cache_id * 1000.0
-            offset += int(p.sequence_length)
-        self.calls.append(
-            {
-                "shape": tuple(chunk.shape),
-                "batch": [(p.cache_id, p.sequence_length, p.cache_size) for p in batch_params],
-            }
-        )
-        return [flat]
-
-
-class _FakeBackend:
-    def __init__(self, mxq_model):
-        self.mxq_model = mxq_model
-
-
-def _make_model(mxq, *, max_batch_size: int = 1) -> MobilintModelMixin:
-    """Construct a bare ``MobilintModelMixin`` without triggering NPU init."""
-    model = MobilintModelMixin.__new__(MobilintModelMixin)
-    model.npu_backend = _FakeBackend(mxq)
-    config_kwargs = {"npu_prefill_chunk_size": None}
-    if max_batch_size > 1:
-        config_kwargs["max_batch_size"] = max_batch_size
-    model.config = type("Config", (), config_kwargs)()
-    model.npu_time = None
-    return model
+from tests.transformers._fake_mxq import (
+    DynamicAxisMxq,
+    StaticLastOnlyMxq,
+    make_model,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -194,16 +77,16 @@ class TestNormalizeLogitsToKeep:
 
 class TestMxqSupportsAllLogits:
     def test_static_token_axis_returns_false(self) -> None:
-        model = _make_model(_StaticLastOnlyMxq())
+        model = make_model(StaticLastOnlyMxq())
         assert model._mxq_supports_all_logits() is False
 
     def test_dynamic_token_axis_returns_true(self) -> None:
-        model = _make_model(_DynamicAxisMxq())
+        model = make_model(DynamicAxisMxq())
         assert model._mxq_supports_all_logits() is True
 
     def test_result_is_cached_on_instance(self) -> None:
-        mxq = _StaticLastOnlyMxq()
-        model = _make_model(mxq)
+        mxq = StaticLastOnlyMxq()
+        model = make_model(mxq)
         assert model._mxq_supports_all_logits() is False
 
         # Flip the underlying shape; a fresh probe would now claim dynamic.
@@ -212,11 +95,11 @@ class TestMxqSupportsAllLogits:
         assert model._mxq_supports_all_logits() is False
 
     def test_raising_backend_falls_back_to_false(self) -> None:
-        class _ExplodingMxq(_StaticLastOnlyMxq):
+        class _ExplodingMxq(StaticLastOnlyMxq):
             def get_model_output_shape(self):  # noqa: D401
                 raise RuntimeError("no shape for you")
 
-        model = _make_model(_ExplodingMxq())
+        model = make_model(_ExplodingMxq())
         assert model._mxq_supports_all_logits() is False
 
 
@@ -235,7 +118,7 @@ class TestLlmForwardSingle:
         logits_to_keep,
         prefill_chunk_size: Optional[int] = None,
     ):
-        model = _make_model(mxq)
+        model = make_model(mxq)
         inputs_embeds = torch.arange(seq_len * hidden_size, dtype=torch.float32).reshape(
             1, seq_len, hidden_size
         )
@@ -250,7 +133,7 @@ class TestLlmForwardSingle:
         return model, logits
 
     def test_default_keep_uses_fast_path_with_last_token_logits(self) -> None:
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         _model, logits = self._run(mxq, seq_len=6, hidden_size=3, logits_to_keep=1, prefill_chunk_size=3)
 
         # Two chunks of size 3 with the caller's prefill_chunk_size.
@@ -260,7 +143,7 @@ class TestLlmForwardSingle:
         assert logits.shape == (1, mxq.vocab_size)
 
     def test_default_keep_ignores_dynamic_axis_probe(self) -> None:
-        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         model, logits = self._run(mxq, seq_len=6, hidden_size=3, logits_to_keep=1, prefill_chunk_size=3)
 
         # is_default_keep short-circuits before probing, so no cached probe result yet.
@@ -270,7 +153,7 @@ class TestLlmForwardSingle:
         assert logits.shape == (3, mxq.vocab_size)
 
     def test_dynamic_axis_keep_all_returns_every_position(self) -> None:
-        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         model, logits = self._run(
             mxq, seq_len=6, hidden_size=3, logits_to_keep=0, prefill_chunk_size=3
         )
@@ -295,14 +178,14 @@ class TestLlmForwardSingle:
         np.testing.assert_allclose(logits.numpy(), expected)
 
     def test_dynamic_axis_keep_last_n_slices_expected_positions(self) -> None:
-        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         _model, logits = self._run(
             mxq, seq_len=6, hidden_size=3, logits_to_keep=2, prefill_chunk_size=3
         )
         assert logits.shape == (2, mxq.vocab_size)
 
     def test_dynamic_axis_tensor_indices_pick_out_positions(self) -> None:
-        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         indices = torch.tensor([0, 2, 5])
         _model, logits = self._run(
             mxq, seq_len=6, hidden_size=3, logits_to_keep=indices, prefill_chunk_size=3
@@ -310,7 +193,7 @@ class TestLlmForwardSingle:
         assert logits.shape == (3, mxq.vocab_size)
 
     def test_fallback_interleaves_size_one_infer_for_kept_positions(self) -> None:
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         indices = torch.tensor([2, 5])
         _model, logits = self._run(
             mxq, seq_len=6, hidden_size=3, logits_to_keep=indices, prefill_chunk_size=4
@@ -326,8 +209,8 @@ class TestLlmForwardSingle:
     def test_fallback_advances_kv_cache_across_all_positions(self) -> None:
         from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
 
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
-        model = _make_model(mxq)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq)
         cache = MobilintCache(mxq)
         seq_len = 6
         inputs_embeds = torch.zeros(1, seq_len, 3)
@@ -346,7 +229,7 @@ class TestLlmForwardSingle:
 
     def test_fallback_empty_tensor_returns_empty_logits(self) -> None:
         """An empty ``logits_to_keep`` tensor must not raise on np.concatenate."""
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         _model, logits = self._run(
             mxq,
             seq_len=6,
@@ -362,7 +245,7 @@ class TestLlmForwardSingle:
 
     def test_fallback_all_out_of_range_indices_returns_empty_logits(self) -> None:
         """All-out-of-range ``logits_to_keep`` must not raise on np.concatenate."""
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         _model, logits = self._run(
             mxq,
             seq_len=6,
@@ -377,8 +260,8 @@ class TestLlmForwardSingle:
     def test_fallback_empty_tensor_still_advances_kv_cache(self) -> None:
         from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache
 
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
-        model = _make_model(mxq)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq)
         cache = MobilintCache(mxq)
         seq_len = 6
         inputs_embeds = torch.zeros(1, seq_len, 3)
@@ -413,7 +296,7 @@ class TestLlmForwardBatch:
         prefill_chunk_size: Optional[int] = None,
         max_batch_size: int = 4,
     ):
-        model = _make_model(mxq, max_batch_size=max_batch_size)
+        model = make_model(mxq, max_batch_size=max_batch_size)
         batch, seq_len = attention_mask.shape
         inputs_embeds = torch.arange(batch * seq_len * hidden_size, dtype=torch.float32).reshape(
             batch, seq_len, hidden_size
@@ -430,7 +313,7 @@ class TestLlmForwardBatch:
         return model, logits
 
     def test_default_keep_path_preserves_existing_shape(self) -> None:
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=2)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=2)
         attention_mask = torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long)
         _model, logits = self._run(
             mxq, attention_mask=attention_mask, hidden_size=4, logits_to_keep=1, prefill_chunk_size=2
@@ -438,7 +321,7 @@ class TestLlmForwardBatch:
         assert logits.shape == (2, 1, mxq.vocab_size)
 
     def test_dynamic_axis_keep_all_returns_per_item_padded_stack(self) -> None:
-        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long)
         _model, logits = self._run(
             mxq,
@@ -454,7 +337,7 @@ class TestLlmForwardBatch:
         assert torch.all(torch.isinf(logits[0, 2]) & (logits[0, 2] < 0))
 
     def test_dynamic_axis_tensor_indices_apply_per_item(self) -> None:
-        mxq = _DynamicAxisMxq(vocab_size=5, max_width=4)
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 0]], dtype=torch.long)
         indices = torch.tensor([0, 2])
         _model, logits = self._run(
@@ -468,7 +351,7 @@ class TestLlmForwardBatch:
         assert logits.shape == (2, 2, mxq.vocab_size)
 
     def test_fallback_interleaves_prefill_and_size_one_across_batch(self) -> None:
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long)
         # Request positions 2 and 3 so the fallback branch runs; logits_to_keep=1
         # would hit the fast path and skip the fallback entirely.
@@ -487,7 +370,7 @@ class TestLlmForwardBatch:
         assert logits.shape == (2, 2, mxq.vocab_size)
 
     def test_fallback_handles_variable_per_item_kept_positions(self) -> None:
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         # Item 0 has 3 real tokens; item 1 has 4. Keep-all on both yields
         # 3 and 4 positions respectively → padding on item 0.
         attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 1, 1]], dtype=torch.long)
@@ -511,7 +394,7 @@ class TestLlmForwardBatch:
         until position 5. The per-item pointer lets the middle walk use the
         caller's ``prefill_chunk_size``.
         """
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         # Item 0 seq_len=6 keeps {0, 5}; item 1 seq_len=1 keeps {0} (5 clamped away).
         attention_mask = torch.tensor(
             [[1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0]], dtype=torch.long
@@ -542,7 +425,7 @@ class TestLlmForwardBatch:
         after cursor=1, even though item 0 was inactive from cursor=2 onward
         and item 1 didn't need another capture until 5.
         """
-        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         # Item 0 seq_len=2 keeps {1}; item 1 seq_len=6 keeps {5} via last-index.
         attention_mask = torch.tensor(
             [[1, 1, 0, 0, 0, 0], [1, 1, 1, 1, 1, 1]], dtype=torch.long

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -336,6 +336,24 @@ class TestLlmForwardBatch:
         # The padded tail of item 0 must be -inf so softmax zeros it out.
         assert torch.all(torch.isinf(logits[0, 2]) & (logits[0, 2] < 0))
 
+    def test_dynamic_axis_zero_length_row_is_softmax_masked(self) -> None:
+        """A batch item whose attention_mask row is entirely zero must not crash
+        Path 2 on ``np.concatenate([])`` — Path 3 already tolerates this and
+        Path 2 should be symmetric. The zero-length row's slot in the stacked
+        output is right-padded with -inf so softmax assigns zero probability.
+        """
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.long)
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=0,
+            prefill_chunk_size=3,
+        )
+        assert logits.shape == (2, 3, mxq.vocab_size)
+        assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))
+
     def test_dynamic_axis_tensor_indices_apply_per_item(self) -> None:
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 0]], dtype=torch.long)

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -136,9 +136,11 @@ class TestMxqSupportsAllLogits:
         assert model._mxq_supports_all_logits() is False
 
     def test_raising_backend_falls_back_to_false(self) -> None:
+        import qbruntime
+
         class _ExplodingMxq(StaticLastOnlyMxq):
             def get_model_output_shape(self):  # noqa: D401
-                raise RuntimeError("no shape for you")
+                raise qbruntime.QbRuntimeError("no shape for you")
 
         model = make_model(_ExplodingMxq())
         assert model._mxq_supports_all_logits() is False

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -501,3 +501,65 @@ class TestLlmForwardBatch:
         assert logits.shape == (2, 4, mxq.vocab_size)
         # Item 0's slot 3 is padding — filled with -inf so softmax masks it.
         assert torch.all(torch.isinf(logits[0, 3]) & (logits[0, 3] < 0))
+
+    def test_fallback_asymmetric_batch_avoids_size_one_for_exhausted_item(self) -> None:
+        """One item has its only kept position at 0, the other has kept at 5.
+
+        With the previous batch-wide ``min_keep_start`` heuristic, every cursor
+        step after position 0 would be forced to chunk=1 — even though item 1
+        was done capturing after step 0 and item 0 didn't need another capture
+        until position 5. The per-item pointer lets the middle walk use the
+        caller's ``prefill_chunk_size``.
+        """
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        # Item 0 seq_len=6 keeps {0, 5}; item 1 seq_len=1 keeps {0} (5 clamped away).
+        attention_mask = torch.tensor(
+            [[1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0]], dtype=torch.long
+        )
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([0, 5]),
+            prefill_chunk_size=4,
+        )
+        # Expected trace: (chunk=1 at cursor 0 for both items), (chunk=4 for
+        # item 0 only, walking 1→5), (chunk=1 at cursor 5 for item 0).
+        assert len(mxq.calls) == 3
+        assert mxq.calls[0]["batch"] == [(0, 1, 0), (1, 1, 0)]
+        assert mxq.calls[1]["batch"] == [(0, 4, 0)]
+        assert mxq.calls[2]["batch"] == [(0, 1, 0)]
+
+        # Item 0 keeps 2 positions; item 1 keeps 1 → padded stack (2, 2, vocab).
+        assert logits.shape == (2, 2, mxq.vocab_size)
+        # Item 1's slot 1 is padding — -inf so softmax masks it.
+        assert torch.all(torch.isinf(logits[1, 1]) & (logits[1, 1] < 0))
+
+    def test_fallback_disjoint_per_item_kept_positions(self) -> None:
+        """Kept sets share no positions: item 0 keeps {1}, item 1 keeps {5}.
+
+        Previously ``min_keep_start=1`` forced chunk=1 across the entire walk
+        after cursor=1, even though item 0 was inactive from cursor=2 onward
+        and item 1 didn't need another capture until 5.
+        """
+        mxq = _StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        # Item 0 seq_len=2 keeps {1}; item 1 seq_len=6 keeps {5} via last-index.
+        attention_mask = torch.tensor(
+            [[1, 1, 0, 0, 0, 0], [1, 1, 1, 1, 1, 1]], dtype=torch.long
+        )
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([-1]),
+            prefill_chunk_size=4,
+        )
+        # Trace: chunk=1 @0 (both, no capture), chunk=1 @1 (both, capture item 0),
+        # chunk=3 @2 (item 1 only, KV walk), chunk=1 @5 (item 1, capture).
+        per_call = [(len(c["batch"]), c["batch"][0][1]) for c in mxq.calls]
+        assert per_call == [(2, 1), (2, 1), (1, 3), (1, 1)]
+
+        # Item 1 must not appear in the middle KV-only walk except by itself.
+        assert mxq.calls[2]["batch"] == [(1, 3, 0)]
+
+        assert logits.shape == (2, 1, mxq.vocab_size)

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -662,3 +662,120 @@ class TestLlmForwardBatch:
         assert mxq.calls[2]["batch"] == [(1, 3, 0)]
 
         assert logits.shape == (2, 1, mxq.vocab_size)
+
+
+# ---------------------------------------------------------------------------
+# Batched empty-selection early return
+# ---------------------------------------------------------------------------
+
+
+class TestBatchedEmptySelection:
+    """Path 2 and Path 3 short-circuit to a ``(batch, 0, 0)`` tensor when every
+    batch item has an empty selection.
+
+    Rationale: the padding loops in both paths build ``torch.full((rows, cols), -inf)``
+    tensors that happen to be benign when ``max_keep_len == 0`` (the ``item.shape[0]
+    < max_keep_len`` guard skips the fill). That reliance is fragile — a future
+    change to how ``max_keep_len`` or ``vocab_size`` is derived could break silently
+    — so both paths return the empty-shape contract explicitly instead.
+
+    Post-#1 (``_wrap_and_validate_indices`` raises on out-of-range), the only
+    caller-facing way to make every batch item land in this branch is an empty
+    ``logits_to_keep`` tensor. Out-of-range test scenarios like ``torch.tensor([100, 200])``
+    would raise ``IndexError`` before reaching the early return, so no dedicated
+    "all-out-of-range" test is included.
+    """
+
+    def _run(
+        self,
+        mxq,
+        *,
+        attention_mask: torch.Tensor,
+        hidden_size: int,
+        logits_to_keep,
+        prefill_chunk_size: Optional[int] = None,
+        max_batch_size: int = 4,
+        dtype: torch.dtype = torch.float32,
+    ):
+        model = make_model(mxq, max_batch_size=max_batch_size)
+        batch, seq_len = attention_mask.shape
+        inputs_embeds = torch.arange(batch * seq_len * hidden_size, dtype=dtype).reshape(
+            batch, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            attention_mask=attention_mask,
+            logits_to_keep=logits_to_keep,
+        )
+        return model, logits, inputs_embeds
+
+    def test_batched_all_empty_tensor_returns_zero_shape_dynamic_axis(self) -> None:
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        _model, logits, inputs_embeds = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=3,
+        )
+        assert logits.shape == (2, 0, 0)
+        assert logits.dtype == inputs_embeds.dtype
+        assert logits.device == inputs_embeds.device
+
+    def test_batched_all_empty_tensor_returns_zero_shape_last_only(self) -> None:
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        _model, logits, inputs_embeds = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=3,
+        )
+        assert logits.shape == (2, 0, 0)
+        assert logits.dtype == inputs_embeds.dtype
+        assert logits.device == inputs_embeds.device
+
+    def test_batched_mixed_empty_and_nonempty_still_pads_correctly_dynamic_axis(
+        self,
+    ) -> None:
+        """Guard the early-return: mixed empty/non-empty items must still pad,
+        not short-circuit. Item 0's attention_mask row is zero (seq_len=0 →
+        empty positions with ``logits_to_keep=0``); item 1 has 3 real positions.
+        """
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.long)
+        _model, logits, _inputs_embeds = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=0,
+            prefill_chunk_size=3,
+        )
+        # Not (2, 0, 0): item 1 contributed real positions, so padding must run.
+        assert logits.shape == (2, 3, mxq.vocab_size)
+        # Item 0 is entirely padding → all -inf.
+        assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))
+
+    def test_batched_mixed_empty_and_nonempty_still_pads_correctly_last_only(
+        self,
+    ) -> None:
+        """Same guard as above, but for Path 3 (last-only MXQ fallback)."""
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.long)
+        _model, logits, _inputs_embeds = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=0,
+            prefill_chunk_size=3,
+        )
+        # Not (2, 0, 0): item 1 contributed real positions, so padding must run.
+        assert logits.shape == (2, 3, mxq.vocab_size)
+        # Item 0 is entirely padding → all -inf.
+        assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -453,7 +453,15 @@ class TestLlmForwardSingle:
         assert cache.get_seq_length() == seq_len
 
     def test_fallback_empty_tensor_returns_empty_logits(self) -> None:
-        """An empty ``logits_to_keep`` tensor must not raise on np.concatenate."""
+        """An empty ``logits_to_keep`` tensor must not raise on np.concatenate.
+
+        The kept-positions axis is 0 but the vocab axis is preserved from the
+        compiled model so this matches Path 2's empty-selector output and
+        HF's ``hidden_states[:, empty, :]`` -> LM head -> ``(batch, 0, vocab)``
+        semantics. Previously Path 3 returned ``(1, 0, 0)`` here and the
+        single-input squeeze produced ``(0, 0)``, silently disagreeing with
+        the other two paths on rank / last-dim.
+        """
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         _model, logits = self._run(
             mxq,
@@ -466,7 +474,36 @@ class TestLlmForwardSingle:
         # still walks the whole sequence in normal-sized chunks.
         chunk_seqs = [c["shape"][2] for c in mxq.calls]
         assert chunk_seqs == [4, 2]
-        assert logits.shape == (0, 0)
+        assert logits.shape == (0, mxq.vocab_size)
+
+    def test_empty_tensor_shape_parity_across_paths(self) -> None:
+        """Path 2 (dynamic-axis) and Path 3 (last-only fallback) must return
+        the same shape for a single-input empty selector.
+
+        HF's ``hidden_states[:, empty, :]`` preserves the vocab axis, so
+        the caller sees ``(batch=0, vocab)`` after ``.squeeze(0)`` on both
+        paths — a divergence here would surface as a rank mismatch in
+        downstream code that stacks logits across turns or compares
+        against HF reference tensors.
+        """
+        dyn_mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        static_mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        _dyn_model, dyn_logits = self._run(
+            dyn_mxq,
+            seq_len=6,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=4,
+        )
+        _static_model, static_logits = self._run(
+            static_mxq,
+            seq_len=6,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=4,
+        )
+        assert dyn_logits.shape == static_logits.shape
+        assert dyn_logits.shape == (0, dyn_mxq.vocab_size)
 
     def test_fallback_out_of_range_indices_raise_indexerror(self) -> None:
         """HF fancy-indexing raises on out-of-range indices; we mirror that."""

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -594,23 +594,51 @@ class TestLlmForwardBatch:
         # The padded tail of item 0 must be -inf so softmax zeros it out.
         assert torch.all(torch.isinf(logits[0, 2]) & (logits[0, 2] < 0))
 
-    def test_dynamic_axis_zero_length_row_is_softmax_masked(self) -> None:
-        """A batch item whose attention_mask row is entirely zero must not crash
-        Path 2 on ``np.concatenate([])`` — Path 3 already tolerates this and
-        Path 2 should be symmetric. The zero-length row's slot in the stacked
-        output is right-padded with -inf so softmax assigns zero probability.
+    def test_dynamic_axis_zero_length_row_raises_value_error(self) -> None:
+        """A batch item whose attention_mask row is entirely zero is now a hard
+        error under Path 2, matching Path 1's long-standing behavior. Previously
+        Path 2 silently right-padded such rows with -inf, so the same batch
+        would fail on ``logits_to_keep=1`` (the ``.generate()`` default) but
+        pass on ``logits_to_keep=0`` — a footgun the unified check closes.
         """
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.long)
-        _model, logits = self._run(
-            mxq,
-            attention_mask=attention_mask,
-            hidden_size=4,
-            logits_to_keep=0,
-            prefill_chunk_size=3,
-        )
-        assert logits.shape == (2, 3, mxq.vocab_size)
-        assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))
+        with pytest.raises(ValueError, match=r"Zero-length rows"):
+            self._run(
+                mxq,
+                attention_mask=attention_mask,
+                hidden_size=4,
+                logits_to_keep=0,
+                prefill_chunk_size=3,
+            )
+
+    @pytest.mark.parametrize(
+        "mxq_cls,logits_to_keep",
+        [
+            (DynamicAxisMxq, 0),
+            (StaticLastOnlyMxq, torch.tensor([2, 3])),
+        ],
+        ids=["path2_dynamic_axis_keep_all", "path3_last_only_tensor_selector"],
+    )
+    def test_zero_length_row_raises_value_error_across_all_paths(
+        self, mxq_cls, logits_to_keep
+    ) -> None:
+        """Lock in the unified zero-length contract: the check fires before any
+        is_default_keep / supports_all decision, so Path 2 (dynamic-axis with
+        keep-all) and Path 3 (last-only with tensor selector) both raise —
+        not just Path 1. Prevents the asymmetry from silently regressing if
+        the check drifts back into any single path.
+        """
+        mxq = mxq_cls(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[0, 0, 0, 0], [1, 1, 1, 1]], dtype=torch.long)
+        with pytest.raises(ValueError, match=r"Zero-length rows"):
+            self._run(
+                mxq,
+                attention_mask=attention_mask,
+                hidden_size=4,
+                logits_to_keep=logits_to_keep,
+                prefill_chunk_size=4,
+            )
 
     def test_dynamic_axis_tensor_indices_apply_per_item(self) -> None:
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
@@ -857,44 +885,39 @@ class TestBatchedEmptySelection:
         assert logits.dtype == inputs_embeds.dtype
         assert logits.device == inputs_embeds.device
 
-    def test_batched_mixed_empty_and_nonempty_still_pads_correctly_dynamic_axis(
+    def test_batched_mixed_empty_and_nonempty_raises_value_error_dynamic_axis(
         self,
     ) -> None:
-        """Guard the early-return: mixed empty/non-empty items must still pad,
-        not short-circuit. Item 0's attention_mask row is zero (seq_len=0 →
-        empty positions with ``logits_to_keep=0``); item 1 has 3 real positions.
+        """Zero-length rows are rejected up front regardless of selector shape:
+        the empty-selector early return must NOT swallow the zero-length
+        contract. Item 0's attention_mask row is zero; item 1 has 3 real
+        positions — Path 2 must raise before considering the selector.
         """
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.long)
-        _model, logits, _inputs_embeds = self._run(
-            mxq,
-            attention_mask=attention_mask,
-            hidden_size=4,
-            logits_to_keep=0,
-            prefill_chunk_size=3,
-        )
-        # Not (2, 0, 0): item 1 contributed real positions, so padding must run.
-        assert logits.shape == (2, 3, mxq.vocab_size)
-        # Item 0 is entirely padding → all -inf.
-        assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))
+        with pytest.raises(ValueError, match=r"Zero-length rows"):
+            self._run(
+                mxq,
+                attention_mask=attention_mask,
+                hidden_size=4,
+                logits_to_keep=0,
+                prefill_chunk_size=3,
+            )
 
-    def test_batched_mixed_empty_and_nonempty_still_pads_correctly_last_only(
+    def test_batched_mixed_empty_and_nonempty_raises_value_error_last_only(
         self,
     ) -> None:
         """Same guard as above, but for Path 3 (last-only MXQ fallback)."""
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.long)
-        _model, logits, _inputs_embeds = self._run(
-            mxq,
-            attention_mask=attention_mask,
-            hidden_size=4,
-            logits_to_keep=0,
-            prefill_chunk_size=3,
-        )
-        # Not (2, 0, 0): item 1 contributed real positions, so padding must run.
-        assert logits.shape == (2, 3, mxq.vocab_size)
-        # Item 0 is entirely padding → all -inf.
-        assert torch.all(torch.isinf(logits[0]) & (logits[0] < 0))
+        with pytest.raises(ValueError, match=r"Zero-length rows"):
+            self._run(
+                mxq,
+                attention_mask=attention_mask,
+                hidden_size=4,
+                logits_to_keep=0,
+                prefill_chunk_size=3,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -300,9 +300,10 @@ class TestLlmForwardSingle:
 
         # is_default_keep short-circuits before probing, so no cached probe result yet.
         assert getattr(model, "_mxq_all_logits_cached", None) is None
-        # Only the last chunk's logits are returned in shape (1, chunk_len, vocab)
-        # → squeeze(0) → (chunk_len, vocab) because dynamic mxq returned 3d.
-        assert logits.shape == (3, mxq.vocab_size)
+        # Path 1 must slice the final chunk's per-position payload down to the
+        # last row so HF-style logits_to_keep=1 returns exactly one kept
+        # position, matching the static-last-only contract.
+        assert logits.shape == (1, mxq.vocab_size)
 
     def test_dynamic_axis_keep_all_returns_every_position(self) -> None:
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -204,6 +204,43 @@ class TestLlmForwardSingle:
         # Path 1 squeezes the outer batch axis → (1, vocab).
         assert logits.shape == (1, mxq.vocab_size)
 
+    def test_scalar_tensor_seq_len_minus_one_uses_fast_path(self) -> None:
+        """``torch.tensor([seq_len - 1])`` is the tensor equivalent of ``logits_to_keep=1``.
+
+        The dynamic-axis probe would set ``_mxq_all_logits_cached`` on the
+        instance; Path 1 short-circuits before probing, so its absence
+        after the call proves the shortcut fired.
+        """
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=6)
+        seq_len = 6
+        model, logits = self._run(
+            mxq,
+            seq_len=seq_len,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([seq_len - 1]),
+            prefill_chunk_size=seq_len,
+        )
+        assert getattr(model, "_mxq_all_logits_cached", None) is None
+        chunk_seqs = [c["shape"][2] for c in mxq.calls]
+        assert chunk_seqs == [seq_len]
+        assert logits.shape == (1, mxq.vocab_size)
+
+    def test_scalar_tensor_negative_one_uses_fast_path(self) -> None:
+        """``torch.tensor([-1])`` is the HF negative-wrap equivalent of ``[seq_len - 1]``."""
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=6)
+        seq_len = 6
+        model, logits = self._run(
+            mxq,
+            seq_len=seq_len,
+            hidden_size=3,
+            logits_to_keep=torch.tensor([-1]),
+            prefill_chunk_size=seq_len,
+        )
+        assert getattr(model, "_mxq_all_logits_cached", None) is None
+        chunk_seqs = [c["shape"][2] for c in mxq.calls]
+        assert chunk_seqs == [seq_len]
+        assert logits.shape == (1, mxq.vocab_size)
+
     def test_default_keep_ignores_dynamic_axis_probe(self) -> None:
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         model, logits = self._run(mxq, seq_len=6, hidden_size=3, logits_to_keep=1, prefill_chunk_size=3)
@@ -463,6 +500,29 @@ class TestLlmForwardBatch:
         _model, logits = self._run(
             mxq, attention_mask=attention_mask, hidden_size=4, logits_to_keep=1, prefill_chunk_size=2
         )
+        assert logits.shape == (2, 1, mxq.vocab_size)
+
+    def test_mixed_length_scalar_tensor_does_not_take_shortcut(self) -> None:
+        """A scalar tensor selector cannot uniformly represent "last position"
+        across a mixed-length batch, so Path 1 must not fire.
+
+        For lengths ``[2, 3]`` with ``torch.tensor([-1])`` the fallback
+        walks per-item and captures position 1 for item 0 and position 2
+        for item 1. The trace-visible tell that Path 1 was skipped is the
+        size-1 batched infer calls; Path 1 would have used the caller's
+        ``prefill_chunk_size`` for a single wider infer instead.
+        """
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long)
+        _model, logits = self._run(
+            mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([-1]),
+            prefill_chunk_size=4,
+        )
+        per_call_widths = [c["batch"][0][1] for c in mxq.calls]
+        assert per_call_widths == [1, 1, 1]
         assert logits.shape == (2, 1, mxq.vocab_size)
 
     def test_dynamic_axis_keep_all_returns_per_item_padded_stack(self) -> None:

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -1519,40 +1519,6 @@ class TestLogitsShapeMatrix:
         # is the contract this test enforces.
         return MobilintModelMixin._output_positions_for_logits_to_keep(selector, seq_len)
 
-    @staticmethod
-    def _skip_if_batched_path1_dynamic_axis_prefill(mxq_cls, selector, lens_equal: bool) -> None:
-        """Skip cells where batched Path 1 collides with dynamic-axis MXQ prefill.
-
-        Batched Path 1 reshapes ``_run_batch_infer``'s raw output to
-        ``(batch, 1, -1)`` on the assumption that the backend already
-        emits ``(batch, vocab)`` per infer — the static-last-only MXQ
-        contract. A dynamic-axis MXQ instead emits ``(total_tokens, vocab)``
-        for multi-token chunks (prefill), so the reshape yields
-        ``(batch, 1, chunk_len * vocab)`` and the final ``torch.stack``
-        raises when different chunks land in different items' final
-        slots.
-
-        This is a pre-existing production gap orthogonal to the shape
-        contract this class enforces (Path 1 was written assuming static
-        MXQ; dynamic MXQ falls into Path 2 for every non-default selector,
-        which handles the flat-output correctly). Skip the affected cells
-        with a documented reason so the matrix stays honest about the
-        combination it does not currently exercise.
-        """
-        if mxq_cls is not DynamicAxisMxq:
-            return
-        if isinstance(selector, int) and selector == 1:
-            path1_fires = True
-        else:
-            path1_fires = lens_equal and MobilintModelMixin._is_last_only_selector(
-                selector, TestLogitsShapeMatrix._SEQ_LEN
-            )
-        if path1_fires:
-            pytest.skip(
-                "batched Path 1 × dynamic-axis MXQ prefill is a known-untested "
-                "combination (production reshape assumes static-last-only backend)"
-            )
-
     @pytest.mark.parametrize("selector", _SELECTORS)
     @pytest.mark.parametrize("mxq_cls", _MXQ_CLASSES)
     def test_single_input_shape_contract(self, mxq_cls, selector) -> None:
@@ -1586,9 +1552,6 @@ class TestLogitsShapeMatrix:
         must be ``(batch, kept, vocab)``. Padding-driven max-len promotion
         is covered separately by :meth:`test_batched_padded_shape_contract`.
         """
-        # Uniform lengths → lens_equal=True, so tensor-scalar last-position
-        # selectors also route to Path 1.
-        self._skip_if_batched_path1_dynamic_axis_prefill(mxq_cls, selector, lens_equal=True)
         batch_size = 2
         mxq = mxq_cls(vocab_size=self._VOCAB_SIZE, max_width=self._SEQ_LEN)
         model = make_model(mxq, max_batch_size=batch_size)
@@ -1619,10 +1582,6 @@ class TestLogitsShapeMatrix:
         indices like ``[1, 3]`` would raise IndexError on item 0 (seq_len=3)
         before any shape assertion could fire.
         """
-        # Mixed lengths → lens_equal=False, so only ``int==1`` routes to
-        # Path 1; tensor-scalar last-position selectors fall through to
-        # Path 2 for dynamic-axis MXQ (which handles the flat output).
-        self._skip_if_batched_path1_dynamic_axis_prefill(mxq_cls, selector, lens_equal=False)
         mxq = mxq_cls(vocab_size=self._VOCAB_SIZE, max_width=self._SEQ_LEN)
         model = make_model(mxq, max_batch_size=2)
         attention_mask = torch.tensor(

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -15,7 +15,7 @@ Both the single-item and batched paths are exercised via fake MXQ backends.
 
 from __future__ import annotations
 
-import logging
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -926,17 +926,22 @@ class TestBatchedEmptySelection:
 
 
 class TestLastOnlySlowPathWarning:
-    """Path 3 fires a WARNING once per instance so manual .forward() callers
-    see the per-token infer cost without having to read source."""
+    """Path 3 fires a ``UserWarning`` once per instance so manual .forward()
+    callers see the per-token infer cost without having to read source.
 
-    _LOGGER_NAME = "mblt_model_zoo.hf_transformers.utils.modeling_utils"
+    The switch from ``logger.warning`` to ``warnings.warn`` is the reason
+    these tests use ``warnings.catch_warnings`` instead of ``caplog``: the
+    point of the change is that the warning's reported location is the
+    caller's, not this module — a property only visible through the
+    ``warnings`` machinery.
+    """
 
     @staticmethod
-    def _slow_path_warnings(records: list[logging.LogRecord]) -> list[logging.LogRecord]:
+    def _slow_path_warnings(caught: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
         return [
-            r
-            for r in records
-            if r.levelno == logging.WARNING and "logits_to_keep" in r.getMessage()
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning) and "logits_to_keep" in str(w.message)
         ]
 
     def _run_single(
@@ -983,73 +988,91 @@ class TestLastOnlySlowPathWarning:
             logits_to_keep=logits_to_keep,
         )
 
-    def test_warns_once_on_first_path3_entry_single_input(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_warns_once_on_first_path3_entry_single_input(self) -> None:
         model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
-        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             self._run_single(model, seq_len=6, logits_to_keep=0)
-            after_first = len(self._slow_path_warnings(caplog.records))
+            after_first = len(self._slow_path_warnings(caught))
             self._run_single(model, seq_len=6, logits_to_keep=0)
-            after_second = len(self._slow_path_warnings(caplog.records))
+            after_second = len(self._slow_path_warnings(caught))
 
         assert after_first == 1
         assert after_second == 1
-        message = self._slow_path_warnings(caplog.records)[0].getMessage()
+        message = str(self._slow_path_warnings(caught)[0].message)
         assert "logits_to_keep" in message
 
-    def test_warns_once_on_first_path3_entry_batched(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_warns_once_on_first_path3_entry_batched(self) -> None:
         model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4), max_batch_size=4)
         attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long)
-        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             self._run_batched(
                 model, attention_mask=attention_mask, logits_to_keep=torch.tensor([2, 3])
             )
-            after_first = len(self._slow_path_warnings(caplog.records))
+            after_first = len(self._slow_path_warnings(caught))
             self._run_batched(
                 model, attention_mask=attention_mask, logits_to_keep=torch.tensor([2, 3])
             )
-            after_second = len(self._slow_path_warnings(caplog.records))
+            after_second = len(self._slow_path_warnings(caught))
 
         assert after_first == 1
         assert after_second == 1
-        assert "logits_to_keep" in self._slow_path_warnings(caplog.records)[0].getMessage()
+        assert "logits_to_keep" in str(self._slow_path_warnings(caught)[0].message)
 
-    def test_no_warning_on_fast_path(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_no_warning_on_fast_path(self) -> None:
         single_model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
         batched_model = make_model(
             StaticLastOnlyMxq(vocab_size=5, max_width=4), max_batch_size=4
         )
         attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
-        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             self._run_single(single_model, seq_len=6, logits_to_keep=1)
             self._run_batched(batched_model, attention_mask=attention_mask, logits_to_keep=1)
 
-        assert self._slow_path_warnings(caplog.records) == []
+        assert self._slow_path_warnings(caught) == []
 
-    def test_no_warning_on_dynamic_axis(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_no_warning_on_dynamic_axis(self) -> None:
         single_model = make_model(DynamicAxisMxq(vocab_size=5, max_width=4))
         batched_model = make_model(
             DynamicAxisMxq(vocab_size=5, max_width=4), max_batch_size=4
         )
         attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
-        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             self._run_single(single_model, seq_len=6, logits_to_keep=0)
             self._run_batched(batched_model, attention_mask=attention_mask, logits_to_keep=0)
 
-        assert self._slow_path_warnings(caplog.records) == []
+        assert self._slow_path_warnings(caught) == []
 
-    def test_warning_is_per_instance(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_warning_is_per_instance(self) -> None:
         model_a = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
         model_b = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
-        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             self._run_single(model_a, seq_len=6, logits_to_keep=0)
             self._run_single(model_b, seq_len=6, logits_to_keep=0)
 
         # One warning per instance — the flag lives on the model, not the class.
-        assert len(self._slow_path_warnings(caplog.records)) == 2
+        assert len(self._slow_path_warnings(caught)) == 2
+
+    def test_warning_stacklevel_points_past_llm_forward(self) -> None:
+        """``stacklevel=4`` skips this helper, the Path 3 site, and ``llm_forward``
+        so the warning is attributed to the caller of ``llm_forward`` — i.e.,
+        this test method's own frame, not ``modeling_utils.py``.
+        """
+        model = make_model(StaticLastOnlyMxq(vocab_size=5, max_width=4))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._run_single(model, seq_len=6, logits_to_keep=0)
+
+        slow = self._slow_path_warnings(caught)
+        assert len(slow) == 1
+        # ``_run_single`` calls ``model.llm_forward`` directly, so the
+        # stacklevel=4 warning must land inside this test file, not the
+        # library module.
+        assert slow[0].filename.endswith("test_logits_to_keep.py")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -1444,3 +1444,204 @@ class TestBatchPath3PhaseTiming:
         timing = model.get_npu_timing()
         assert timing["decode_calls"] == 0
         assert timing["prefill_calls"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Cross-path shape contract matrix
+# ---------------------------------------------------------------------------
+
+
+class TestLogitsShapeMatrix:
+    """Every (path, selector, batch_size) cell must satisfy the HF-style
+    ``(batch, kept, vocab)`` shape contract.
+
+    Guards against a *category* of bug rather than a specific site: an empty
+    ``logits_to_keep`` tensor used to make Path 3 emit ``(1, 0, 0)`` (vocab
+    axis silently dropped) while Path 2 kept the vocab axis — a rank / last-
+    dim disagreement that would surface downstream anywhere logits from
+    different paths were stacked or compared. Because the contract is
+    encoded as a parametrized matrix, a new selector shape or a new path
+    is checked automatically once it is registered here.
+
+    Extension points:
+
+    - New selector: append to :attr:`_SELECTORS` (and, if it survives
+      mixed-length batches, :attr:`_PADDING_SAFE_SELECTORS`).
+    - New MXQ backend variant (e.g. a future partial-token-axis shape):
+      append to :attr:`_MXQ_CLASSES`.
+    - New execution path: registering an MXQ class that routes to it is
+      enough; no per-path test needs to change.
+
+    Vocab / kept / batch axes are read via ``shape[-1]`` / ``shape[-2]`` /
+    ``shape[0]`` so the same assertion works for the single-input entry
+    point (rank 2 after ``.squeeze(0)``) and the batched entry point
+    (rank 3). Both are cross-checked here.
+    """
+
+    _SEQ_LEN = 5
+    _HIDDEN_SIZE = 4
+    _VOCAB_SIZE = 5
+    _PREFILL_CHUNK_SIZE = 3
+
+    _SELECTORS = [
+        pytest.param(1, id="int_1_default"),
+        pytest.param(0, id="int_0_all"),
+        pytest.param(2, id="int_2_last_n"),
+        pytest.param(torch.tensor([], dtype=torch.long), id="tensor_empty"),
+        pytest.param(torch.tensor([2]), id="tensor_single_pos"),
+        pytest.param(torch.tensor([1, 3]), id="tensor_multi_pos"),
+        pytest.param(torch.tensor([2, 2]), id="tensor_duplicate_pos"),
+        pytest.param(torch.tensor([-1]), id="tensor_negative_last"),
+    ]
+
+    _MXQ_CLASSES = [
+        pytest.param(StaticLastOnlyMxq, id="static_last_only"),
+        pytest.param(DynamicAxisMxq, id="dynamic_axis"),
+    ]
+
+    # Padding-safe subset: mixed-length batches raise IndexError on positive
+    # tensor indices that exceed the shortest item's seq_len (item 0 here
+    # has seq_len=3). Selectors that resolve against each item's own
+    # seq_len — int keep-N and negative-wrap tensors — are the right
+    # coverage set for the padding path.
+    _PADDING_SAFE_SELECTORS = [
+        pytest.param(1, id="int_1_default"),
+        pytest.param(0, id="int_0_all"),
+        pytest.param(2, id="int_2_last_n"),
+        pytest.param(torch.tensor([], dtype=torch.long), id="tensor_empty"),
+        pytest.param(torch.tensor([-1]), id="tensor_negative_last"),
+    ]
+
+    @classmethod
+    def _expected_kept(cls, selector, seq_len: int) -> list[int]:
+        # Delegate to the production helper: whatever HF-style semantics
+        # it exposes (negative-wrap, duplicate preservation, int shortcut)
+        # is the contract this test enforces.
+        return MobilintModelMixin._output_positions_for_logits_to_keep(selector, seq_len)
+
+    @staticmethod
+    def _skip_if_batched_path1_dynamic_axis_prefill(mxq_cls, selector, lens_equal: bool) -> None:
+        """Skip cells where batched Path 1 collides with dynamic-axis MXQ prefill.
+
+        Batched Path 1 reshapes ``_run_batch_infer``'s raw output to
+        ``(batch, 1, -1)`` on the assumption that the backend already
+        emits ``(batch, vocab)`` per infer — the static-last-only MXQ
+        contract. A dynamic-axis MXQ instead emits ``(total_tokens, vocab)``
+        for multi-token chunks (prefill), so the reshape yields
+        ``(batch, 1, chunk_len * vocab)`` and the final ``torch.stack``
+        raises when different chunks land in different items' final
+        slots.
+
+        This is a pre-existing production gap orthogonal to the shape
+        contract this class enforces (Path 1 was written assuming static
+        MXQ; dynamic MXQ falls into Path 2 for every non-default selector,
+        which handles the flat-output correctly). Skip the affected cells
+        with a documented reason so the matrix stays honest about the
+        combination it does not currently exercise.
+        """
+        if mxq_cls is not DynamicAxisMxq:
+            return
+        if isinstance(selector, int) and selector == 1:
+            path1_fires = True
+        else:
+            path1_fires = lens_equal and MobilintModelMixin._is_last_only_selector(
+                selector, TestLogitsShapeMatrix._SEQ_LEN
+            )
+        if path1_fires:
+            pytest.skip(
+                "batched Path 1 × dynamic-axis MXQ prefill is a known-untested "
+                "combination (production reshape assumes static-last-only backend)"
+            )
+
+    @pytest.mark.parametrize("selector", _SELECTORS)
+    @pytest.mark.parametrize("mxq_cls", _MXQ_CLASSES)
+    def test_single_input_shape_contract(self, mxq_cls, selector) -> None:
+        """Batch=1 (single-input entry): rank 2 output whose last dim is
+        the compiled vocab dim and second-to-last dim is the HF output-
+        position count. The pre-squeeze contract is ``(1, kept, vocab)``;
+        both axes are re-checked via trailing-axis indexing so the
+        assertion is agnostic to the ``.squeeze(0)`` in ``llm_forward``.
+        """
+        mxq = mxq_cls(vocab_size=self._VOCAB_SIZE, max_width=self._SEQ_LEN)
+        model = make_model(mxq)
+        inputs_embeds = torch.zeros(1, self._SEQ_LEN, self._HIDDEN_SIZE)
+        cache_position = torch.arange(self._SEQ_LEN)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=self._PREFILL_CHUNK_SIZE,
+            logits_to_keep=selector,
+        )
+        expected_kept = self._expected_kept(selector, self._SEQ_LEN)
+        assert logits.ndim == 2
+        assert logits.shape[-1] == self._VOCAB_SIZE
+        assert logits.shape[-2] == len(expected_kept)
+
+    @pytest.mark.parametrize("selector", _SELECTORS)
+    @pytest.mark.parametrize("mxq_cls", _MXQ_CLASSES)
+    def test_batched_shape_contract(self, mxq_cls, selector) -> None:
+        """Batch=2 with uniform lengths (all-ones mask): every item shares
+        the same kept-position count so no padding is required. The output
+        must be ``(batch, kept, vocab)``. Padding-driven max-len promotion
+        is covered separately by :meth:`test_batched_padded_shape_contract`.
+        """
+        # Uniform lengths → lens_equal=True, so tensor-scalar last-position
+        # selectors also route to Path 1.
+        self._skip_if_batched_path1_dynamic_axis_prefill(mxq_cls, selector, lens_equal=True)
+        batch_size = 2
+        mxq = mxq_cls(vocab_size=self._VOCAB_SIZE, max_width=self._SEQ_LEN)
+        model = make_model(mxq, max_batch_size=batch_size)
+        attention_mask = torch.ones(batch_size, self._SEQ_LEN, dtype=torch.long)
+        inputs_embeds = torch.zeros(batch_size, self._SEQ_LEN, self._HIDDEN_SIZE)
+        cache_position = torch.arange(self._SEQ_LEN)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=self._PREFILL_CHUNK_SIZE,
+            attention_mask=attention_mask,
+            logits_to_keep=selector,
+        )
+        expected_kept = self._expected_kept(selector, self._SEQ_LEN)
+        assert logits.ndim == 3
+        assert logits.shape == (batch_size, len(expected_kept), self._VOCAB_SIZE)
+
+    @pytest.mark.parametrize("selector", _PADDING_SAFE_SELECTORS)
+    @pytest.mark.parametrize("mxq_cls", _MXQ_CLASSES)
+    def test_batched_padded_shape_contract(self, mxq_cls, selector) -> None:
+        """Batch=2 with mixed lengths [3, 5]: for selectors whose kept
+        count differs across items (e.g. ``int==0``) the batched output
+        promotes to ``(batch, max_kept_per_item, vocab)`` with the shorter
+        item right-padded — the vocab axis must survive that promotion.
+
+        Only :attr:`_PADDING_SAFE_SELECTORS` are exercised; positive tensor
+        indices like ``[1, 3]`` would raise IndexError on item 0 (seq_len=3)
+        before any shape assertion could fire.
+        """
+        # Mixed lengths → lens_equal=False, so only ``int==1`` routes to
+        # Path 1; tensor-scalar last-position selectors fall through to
+        # Path 2 for dynamic-axis MXQ (which handles the flat output).
+        self._skip_if_batched_path1_dynamic_axis_prefill(mxq_cls, selector, lens_equal=False)
+        mxq = mxq_cls(vocab_size=self._VOCAB_SIZE, max_width=self._SEQ_LEN)
+        model = make_model(mxq, max_batch_size=2)
+        attention_mask = torch.tensor(
+            [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]], dtype=torch.long
+        )
+        inputs_embeds = torch.zeros(2, self._SEQ_LEN, self._HIDDEN_SIZE)
+        cache_position = torch.arange(self._SEQ_LEN)
+        logits = model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=self._PREFILL_CHUNK_SIZE,
+            attention_mask=attention_mask,
+            logits_to_keep=selector,
+        )
+        expected_kept_per_item = [
+            self._expected_kept(selector, 3),
+            self._expected_kept(selector, 5),
+        ]
+        max_kept = max(len(kept) for kept in expected_kept_per_item)
+        assert logits.ndim == 3
+        assert logits.shape == (2, max_kept, self._VOCAB_SIZE)

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -1163,3 +1163,158 @@ class TestBatchCpuCopyHoist:
             model, attention_mask=attention_mask, logits_to_keep=0, prefill_chunk_size=3
         )
         assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Path 3 fallback phase classification for count_npu_time
+# ---------------------------------------------------------------------------
+
+
+class TestBatchPath3PhaseTiming:
+    """Path 3 chunk=1 capture calls are decode-shaped work (cursor > 0, cache
+    already populated) but the auto-heuristic inside ``_run_batch_infer`` keys
+    on ``max_sequence_length`` (batch-wide max, fixed at entry) — so without an
+    explicit override every capture would be misfiled under ``prefill_time``
+    and inflate the benchmark's prefill accounting.
+    """
+
+    def _capture_phase_calls(self, model) -> list[str]:
+        """Wrap ``_record_npu_timing`` so we can assert the phase ordering.
+
+        We hook on the instance rather than monkeypatching the class so
+        parallel test workers do not race, and so a bound-method wrap sees
+        the same ``self`` the production call site would use.
+        """
+        phases: list[str] = []
+        original = model._record_npu_timing
+
+        def spy(phase, elapsed):
+            phases.append(phase)
+            return original(phase, elapsed)
+
+        model._record_npu_timing = spy
+        return phases
+
+    def _run_batched(
+        self,
+        model,
+        *,
+        attention_mask: torch.Tensor,
+        logits_to_keep,
+        hidden_size: int = 4,
+        prefill_chunk_size: int = 4,
+    ):
+        batch, seq_len = attention_mask.shape
+        inputs_embeds = torch.arange(batch * seq_len * hidden_size, dtype=torch.float32).reshape(
+            batch, seq_len, hidden_size
+        )
+        cache_position = torch.arange(seq_len)
+        return model.llm_forward(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            cache_position=cache_position,
+            prefill_chunk_size=prefill_chunk_size,
+            attention_mask=attention_mask,
+            logits_to_keep=logits_to_keep,
+            count_npu_time=True,
+        )
+
+    def test_path3_chunk1_capture_records_decode_phase(self) -> None:
+        """The size-1 capture at a kept position must be filed as decode.
+
+        Trace for ``logits_to_keep=[2, 3]`` on two items of length 4 with
+        ``prefill_chunk_size=2``:
+
+        - cursor 0, chunk=2 (KV walk 0→2, no capture)              → prefill
+        - cursor 2, chunk=1 (capture position 2 for both items)    → decode
+        - cursor 3, chunk=1 (capture position 3 for both items)    → decode
+
+        The assertion pins each phase in order; a regression that reverts
+        Path 3 to the batch-wide auto-heuristic would flip both chunk=1
+        calls back to prefill.
+        """
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq, max_batch_size=4)
+        phases = self._capture_phase_calls(model)
+
+        self._run_batched(
+            model,
+            attention_mask=torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long),
+            logits_to_keep=torch.tensor([2, 3]),
+            prefill_chunk_size=2,
+        )
+
+        assert phases == ["prefill", "decode", "decode"]
+        timing = model.get_npu_timing()
+        assert timing["prefill_calls"] == 1
+        assert timing["decode_calls"] == 2
+
+    def test_path3_bulk_walk_at_cursor_gt_zero_still_records_prefill(self) -> None:
+        """Chunk>1 walks (bulk KV extension between captures) stay prefill.
+
+        Only the size-1 capture calls are decode-shaped; a chunk>1 walk at
+        cursor > 0 is still populating the KV cache from real input tokens,
+        i.e. prefill. Anchors the narrow scope of the fix so a future change
+        doesn't over-broaden the override to every cursor > 0 call.
+
+        With ``logits_to_keep=[-1]`` and asymmetric lengths [6, 1], the walk
+        goes: chunk=1 @0 (both), chunk=4 @1 (item 0 only, bulk walk), chunk=1
+        @5 (item 0 capture). The middle call is chunk=4 at cursor=1 with a
+        non-zero cache — a regression that overrides *every* Path 3 call to
+        decode would flip its phase.
+        """
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq, max_batch_size=4)
+        phases = self._capture_phase_calls(model)
+
+        self._run_batched(
+            model,
+            attention_mask=torch.tensor(
+                [[1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0]], dtype=torch.long
+            ),
+            logits_to_keep=torch.tensor([0, -1]),
+            prefill_chunk_size=4,
+        )
+
+        assert phases == ["decode", "prefill", "decode"]
+
+    def test_path1_default_keep_phase_uses_auto_heuristic(self) -> None:
+        """Path 1 (logits_to_keep=1) never sets phase_override, so its
+        classification must still come from the auto-heuristic. All chunks
+        run at ``max_sequence_length > 1`` → prefill.
+        """
+        mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq, max_batch_size=4)
+        phases = self._capture_phase_calls(model)
+
+        self._run_batched(
+            model,
+            attention_mask=torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long),
+            logits_to_keep=1,
+            prefill_chunk_size=2,
+        )
+
+        assert phases == ["prefill", "prefill"]
+        timing = model.get_npu_timing()
+        assert timing["decode_calls"] == 0
+        assert timing["prefill_calls"] == 2
+
+    def test_path2_dynamic_axis_phase_uses_auto_heuristic(self) -> None:
+        """Path 2 (dynamic-axis all-logits) also leaves phase_override=None.
+        Every chunk fires with ``max_sequence_length > 1`` → prefill.
+        """
+        mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        model = make_model(mxq, max_batch_size=4)
+        phases = self._capture_phase_calls(model)
+
+        self._run_batched(
+            model,
+            attention_mask=torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]], dtype=torch.long),
+            logits_to_keep=0,
+            prefill_chunk_size=2,
+        )
+
+        assert phases == ["prefill", "prefill"]
+        timing = model.get_npu_timing()
+        assert timing["decode_calls"] == 0
+        assert timing["prefill_calls"] == 2

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -925,6 +925,11 @@ class TestBatchedEmptySelection:
         return model, logits, inputs_embeds
 
     def test_batched_all_empty_tensor_returns_zero_shape_dynamic_axis(self) -> None:
+        """Empty selector across the whole batch preserves the compiled vocab
+        axis: ``(batch, 0, vocab)`` — matches HF's
+        ``hidden_states[:, empty, :]`` -> LM head semantics and the
+        single-input entry point's ``(0, vocab)`` after ``.squeeze(0)``.
+        """
         mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
         _model, logits, inputs_embeds = self._run(
@@ -934,11 +939,15 @@ class TestBatchedEmptySelection:
             logits_to_keep=torch.tensor([], dtype=torch.long),
             prefill_chunk_size=3,
         )
-        assert logits.shape == (2, 0, 0)
+        assert logits.shape == (2, 0, mxq.vocab_size)
         assert logits.dtype == inputs_embeds.dtype
         assert logits.device == inputs_embeds.device
 
     def test_batched_all_empty_tensor_returns_zero_shape_last_only(self) -> None:
+        """Path 3 batched fallback must preserve the vocab axis on an
+        all-empty selector, same as Path 2's batched empty branch and
+        Path 3's single-input fallback.
+        """
         mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
         attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
         _model, logits, inputs_embeds = self._run(
@@ -948,9 +957,36 @@ class TestBatchedEmptySelection:
             logits_to_keep=torch.tensor([], dtype=torch.long),
             prefill_chunk_size=3,
         )
-        assert logits.shape == (2, 0, 0)
+        assert logits.shape == (2, 0, mxq.vocab_size)
         assert logits.dtype == inputs_embeds.dtype
         assert logits.device == inputs_embeds.device
+
+    def test_batched_all_empty_tensor_shape_parity_across_paths(self) -> None:
+        """Path 2 (dynamic-axis) and Path 3 (last-only fallback) must agree
+        on the batched all-empty selector shape. A divergence would surface
+        as a rank/last-dim mismatch in downstream code that compares
+        batched logits across backends or concatenates them with non-empty
+        selections.
+        """
+        dyn_mxq = DynamicAxisMxq(vocab_size=5, max_width=4)
+        static_mxq = StaticLastOnlyMxq(vocab_size=5, max_width=4)
+        attention_mask = torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long)
+        _dyn_model, dyn_logits, _ = self._run(
+            dyn_mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=3,
+        )
+        _static_model, static_logits, _ = self._run(
+            static_mxq,
+            attention_mask=attention_mask,
+            hidden_size=4,
+            logits_to_keep=torch.tensor([], dtype=torch.long),
+            prefill_chunk_size=3,
+        )
+        assert dyn_logits.shape == static_logits.shape
+        assert dyn_logits.shape == (2, 0, dyn_mxq.vocab_size)
 
     def test_batched_mixed_empty_and_nonempty_raises_value_error_dynamic_axis(
         self,

--- a/tests/transformers/test_logits_to_keep.py
+++ b/tests/transformers/test_logits_to_keep.py
@@ -617,6 +617,31 @@ class TestLlmForwardBatch:
         )
         assert logits.shape == (2, 1, mxq.vocab_size)
 
+    def test_default_keep_path_survives_get_model_output_shape_failure(self) -> None:
+        """Batched Path 1 must not depend on ``get_model_output_shape()``.
+
+        Some backends can infer last-token logits without exposing the
+        compiled output shape via ``get_model_output_shape()``. Both the
+        boolean probe (``_mxq_supports_all_logits``) and the vocab probe
+        (``_mxq_static_vocab_size``) must be skipped on the fast path;
+        vocab is read from the raw ndarray's trailing axis instead.
+        """
+        import qbruntime
+
+        class _NoShapeStaticLastOnlyMxq(StaticLastOnlyMxq):
+            def get_model_output_shape(self):  # noqa: D401
+                raise qbruntime.QbRuntimeError("no shape for you")
+
+        mxq = _NoShapeStaticLastOnlyMxq(vocab_size=5, max_width=2)
+        attention_mask = torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long)
+        model, logits = self._run(
+            mxq, attention_mask=attention_mask, hidden_size=4, logits_to_keep=1, prefill_chunk_size=2
+        )
+        assert logits.shape == (2, 1, mxq.vocab_size)
+        # Nothing was cached: the fast path never called either probe.
+        assert getattr(model, "_mxq_all_logits_cached", None) is None
+        assert getattr(model, "_mxq_static_vocab_cached", None) is None
+
     def test_mixed_length_scalar_tensor_does_not_take_shortcut(self) -> None:
         """A scalar tensor selector cannot uniformly represent "last position"
         across a mixed-length batch, so Path 1 must not fire.

--- a/tests/transformers/test_mirror_output_fields.py
+++ b/tests/transformers/test_mirror_output_fields.py
@@ -1,0 +1,77 @@
+"""Regression tests for ``mirror_output_fields``.
+
+The helper populates a target dataclass by mirroring values from a source
+model output. When the source is itself a dataclass (the prod case — HF
+``ModelOutput`` subclasses are dataclasses), only its declared fields are
+eligible for mirroring so non-field attributes (``to_tuple``, ``keys``, ...)
+whose names may collide with target fields in the future cannot silently
+smuggle a wrong value through. Non-dataclass sources fall back to
+``hasattr``/``getattr`` so tests can pass simple namespaces.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from types import SimpleNamespace
+
+from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+    mirror_output_fields,
+)
+
+
+@dataclasses.dataclass
+class _Target:
+    last_hidden_state: object = None
+    past_key_values: object = None
+    keys: object = None
+
+
+@dataclasses.dataclass
+class _DataclassSource:
+    last_hidden_state: object = None
+    past_key_values: object = None
+
+
+class TestMirrorOutputFieldsDataclassSource:
+    def test_mirrors_declared_fields_only(self) -> None:
+        source = _DataclassSource(last_hidden_state="hs", past_key_values="pkv")
+        result = mirror_output_fields(_Target, source)
+        assert result.last_hidden_state == "hs"
+        assert result.past_key_values == "pkv"
+        assert result.keys is None
+
+    def test_non_field_attribute_collision_is_ignored(self) -> None:
+        """Non-field attribute on source must not be mirrored to a target field."""
+        source = _DataclassSource(last_hidden_state="hs", past_key_values="pkv")
+        # Simulate a future upstream adding a non-dataclass attribute with a
+        # name that happens to collide with a target field.
+        source.keys = "SMUGGLED"  # type: ignore[attr-defined]
+
+        result = mirror_output_fields(_Target, source)
+
+        assert result.keys is None, (
+            "mirror_output_fields must not pick up non-field attributes from "
+            "a dataclass source even when the name matches a target field"
+        )
+
+    def test_overrides_win_over_source(self) -> None:
+        source = _DataclassSource(last_hidden_state="hs", past_key_values="pkv")
+        result = mirror_output_fields(_Target, source, past_key_values="override")
+        assert result.past_key_values == "override"
+        assert result.last_hidden_state == "hs"
+
+
+class TestMirrorOutputFieldsDuckTypedSource:
+    """SimpleNamespace fallback path — used by existing contract tests."""
+
+    def test_hasattr_fallback_mirrors_present_attributes(self) -> None:
+        source = SimpleNamespace(last_hidden_state="hs", past_key_values="pkv")
+        result = mirror_output_fields(_Target, source)
+        assert result.last_hidden_state == "hs"
+        assert result.past_key_values == "pkv"
+
+    def test_hasattr_fallback_ignores_missing_attributes(self) -> None:
+        source = SimpleNamespace(last_hidden_state="hs")
+        result = mirror_output_fields(_Target, source)
+        assert result.last_hidden_state == "hs"
+        assert result.past_key_values is None

--- a/tests/transformers/test_upstream_positional_params.py
+++ b/tests/transformers/test_upstream_positional_params.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from mblt_model_zoo.hf_transformers.utils.generation_utils import upstream_positional_params
+import functools
+
+from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+    _upstream_positional_params_cached,
+    upstream_positional_params,
+)
 
 
 def test_upstream_positional_params_filters_self_args_kwargs_and_kw_only() -> None:
@@ -31,3 +36,23 @@ def test_upstream_positional_params_is_cached() -> None:
         del self, a, b
 
     assert upstream_positional_params(f) is upstream_positional_params(f)
+
+
+def test_upstream_positional_params_wrapped_shares_cache_entry_with_underlying() -> None:
+    def f(self, a, b):  # noqa: ANN001, ANN202
+        del self, a, b
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        return f(*args, **kwargs)
+
+    _upstream_positional_params_cached.cache_clear()
+    underlying = upstream_positional_params(f)
+    info_after_first = _upstream_positional_params_cached.cache_info()
+    wrapped = upstream_positional_params(wrapper)
+    info_after_second = _upstream_positional_params_cached.cache_info()
+
+    assert underlying == wrapped
+    assert info_after_first.misses == 1
+    assert info_after_second.misses == 1
+    assert info_after_second.hits == info_after_first.hits + 1

--- a/tests/transformers/test_upstream_positional_params.py
+++ b/tests/transformers/test_upstream_positional_params.py
@@ -5,8 +5,29 @@ from __future__ import annotations
 from mblt_model_zoo.hf_transformers.utils.generation_utils import upstream_positional_params
 
 
-def test_upstream_positional_params_filters_self_args_and_kwargs() -> None:
+def test_upstream_positional_params_filters_self_args_kwargs_and_kw_only() -> None:
     def f(self, a, b, *args, c=None, **kwargs):  # noqa: ANN001, ANN202
         del self, a, b, args, c, kwargs
 
-    assert upstream_positional_params(f) == ("a", "b", "c")
+    assert upstream_positional_params(f) == ("a", "b")
+
+
+def test_upstream_positional_params_includes_positional_only() -> None:
+    def f(self, a, /, b, *, c):  # noqa: ANN001, ANN202
+        del self, a, b, c
+
+    assert upstream_positional_params(f) == ("a", "b")
+
+
+def test_upstream_positional_params_all_keyword_only_returns_empty() -> None:
+    def f(self, *args, x, y):  # noqa: ANN001, ANN202
+        del self, args, x, y
+
+    assert upstream_positional_params(f) == ()
+
+
+def test_upstream_positional_params_is_cached() -> None:
+    def f(self, a, b):  # noqa: ANN001, ANN202
+        del self, a, b
+
+    assert upstream_positional_params(f) is upstream_positional_params(f)

--- a/tests/transformers/test_upstream_positional_params.py
+++ b/tests/transformers/test_upstream_positional_params.py
@@ -1,0 +1,12 @@
+"""Unit tests for ``upstream_positional_params``."""
+
+from __future__ import annotations
+
+from mblt_model_zoo.hf_transformers.utils.generation_utils import upstream_positional_params
+
+
+def test_upstream_positional_params_filters_self_args_and_kwargs() -> None:
+    def f(self, a, b, *args, c=None, **kwargs):  # noqa: ANN001, ANN202
+        del self, a, b, args, c, kwargs
+
+    assert upstream_positional_params(f) == ("a", "b", "c")

--- a/tests/transformers/text_generation/eagle3/test_qwen2_eagle3_edge_cases.py
+++ b/tests/transformers/text_generation/eagle3/test_qwen2_eagle3_edge_cases.py
@@ -254,22 +254,16 @@ def test_llm_forward_counts_single_token_first_call_as_prefill() -> None:
         def infer(self, inputs, *_args):
             return [np.zeros((1, inputs[0].shape[2], 4), dtype=np.float32)]
 
-    class _DummyModel:
-        llm_forward = MobilintModelMixin.llm_forward
+    model = MobilintModelMixin.__new__(MobilintModelMixin)
+    model.npu_backend = SimpleNamespace(mxq_model=_DummyMxq())
+    model.config = SimpleNamespace(npu_prefill_chunk_size=None)
+    model.npu_time = None
+    model.logged_phases = []
 
-        def __init__(self) -> None:
-            self.npu_backend = SimpleNamespace(mxq_model=_DummyMxq())
-            self.config = SimpleNamespace()
-            self.npu_time = None
-            self.logged_phases: list[str] = []
+    def _record_npu_timing(phase, _elapsed):
+        model.logged_phases.append(phase)
 
-        def resolve_prefill_chunk_size(self, value):
-            return 128 if value is None else int(value)
-
-        def _record_npu_timing(self, phase, _elapsed):
-            self.logged_phases.append(phase)
-
-    model = _DummyModel()
+    model._record_npu_timing = _record_npu_timing
     inputs_embeds = torch.zeros((1, 1, 4), dtype=torch.float32)
     cache_position = torch.tensor([0], dtype=torch.long)
 

--- a/tests/transformers/text_generation/test_batch_cache_validation.py
+++ b/tests/transformers/text_generation/test_batch_cache_validation.py
@@ -16,17 +16,26 @@ class _FakeInputBufferInfo:
 
 
 class _FakeMxqModel:
+    _VOCAB_SIZE = 5
+
     def __init__(self):
         self.calls: list[list[int]] = []
 
     def get_input_buffer_info(self):
         return [_FakeInputBufferInfo(max_width=2)]
 
+    def get_model_output_shape(self):
+        # Static last-only layout: token axis is 1, vocab is the compiled last dim.
+        # Path 1's runtime layout detection reads the last dim via
+        # ``_mxq_static_vocab_size`` to disambiguate per-item vs per-token outputs.
+        return [(1, 1, self._VOCAB_SIZE)]
+
     def infer(self, inputs, _, __, batch_params):
         self.calls.append([param.cache_id for param in batch_params])
         active_batch = len(batch_params)
-        vocab_size = 5
-        logits = torch.arange(active_batch * vocab_size, dtype=torch.float32).reshape(active_batch, vocab_size)
+        logits = torch.arange(active_batch * self._VOCAB_SIZE, dtype=torch.float32).reshape(
+            active_batch, self._VOCAB_SIZE
+        )
         return [logits.numpy()]
 
 

--- a/tests/transformers/text_generation/test_batch_cache_validation.py
+++ b/tests/transformers/text_generation/test_batch_cache_validation.py
@@ -26,8 +26,9 @@ class _FakeMxqModel:
 
     def get_model_output_shape(self):
         # Static last-only layout: token axis is 1, vocab is the compiled last dim.
-        # Path 1's runtime layout detection reads the last dim via
-        # ``_mxq_static_vocab_size`` to disambiguate per-item vs per-token outputs.
+        # Batched Path 1 no longer probes this — vocab comes from the raw
+        # ndarray's trailing axis — but Path 2/3 and the empty-selector
+        # helpers still call ``_mxq_static_vocab_size`` so the method stays.
         return [(1, 1, self._VOCAB_SIZE)]
 
     def infer(self, inputs, _, __, batch_params):


### PR DESCRIPTION
## 요약
- 공유 LLM 추론 코어(`MobilintModelMixin.llm_forward` / `_llm_forward_batch`)에 HF 스타일 `logits_to_keep: Union[int, torch.Tensor]` 파라미터를 추가하고, 기존 last-token fast path를 그대로 유지하면서 임의 위치 선택도 지원하는 3-way dispatch를 도입.
- 공유 코어로 라우팅되는 모든 Mobilint LLM/VLM `forward()`(cohere2, exaone, exaone4, llama, qwen2, qwen3, qwen2_vl, qwen3_asr, aya_vision)에 `logits_to_keep`를 배선했고, Qwen3-VL의 자체 `llm_forward`에도 동일한 3-branch 로직을 구현.
- Qwen2-VL / Qwen3-VL `*ForConditionalGeneration.forward`의 단순 `super().forward(*args, **kwargs)` 통과를 제거하여 upstream이 Mobilint 디코더의 위치 선택을 조용히 우회하지 못하도록 수정.
- `generation_utils` 관련 보조 리팩토링(`mirror_output_fields` 범위 축소, `upstream_positional_params` positional 전용화, `__wrapped__` 체인 정규화, upstream forward signature 캐싱)과 대규모 `logits_to_keep` 테스트 스위트 및 공유 fake MXQ 백엔드 추가.

## 주요 변경 사항
- **코어 dispatch (`utils/modeling_utils.py`):**
  - Path 1: `logits_to_keep == 1` fast path는 기존 그대로(기본 호출 동작 유지).
  - Path 2: dynamic token axis를 가진 MXQ 백엔드(`get_model_output_shape()[0][-2] == -1`, 인스턴스에 캐싱)는 호출자의 `prefill_chunk_size`를 유지하고 chunk 단위로 keep된 logits를 스트리밍·concat 후 요청 위치로 slice — peak memory를 억제.
  - Path 3: last-only MXQ + non-default 요청은 prefill(KV 캐시만) + kept 위치마다 size-1 infer로 fallback 처리하며, 사용자 호출부를 포함해 1회 warning.
  - Fast-path scalar-tensor last-only 요청, tensor `logits_to_keep`의 HF 순서/중복 semantics, 음수 int 거부, zero-length row, empty selection, MXQ static vocab 검증까지 모두 명시적으로 처리.
- **VL wrapper (`qwen2_vl`, `qwen3_vl`):** positional args를 upstream 파라미터 이름으로 매핑하고, `labels`와 `logits_to_keep`를 pop한 후 `self.model`에 kwargs로 명시 전달해 디코더가 미리 slice된 logits를 반환하도록 함. args/kwargs 충돌이나 positional args 과다 시 `TypeError` 발생. Qwen3-VL 텍스트 모델은 deepstack tensor를 함께 소비하는 dual-input 디코더에 맞춰 3-branch 로직을 별도 구현.
- **Generation utils:** `upstream_positional_params`를 positional-bindable 이름으로 제한하고 `*args` 제외, `mirror_output_fields`는 가능한 경우 dataclass 필드로 좁혀 적용, `lru_cache` helper의 `__wrapped__` 체인 정규화, upstream forward signature를 캐시하여 매 호출 `inspect` 제거.
- **기타:** Qwen ASR 의존성 격리, ASR 벤치 utils가 `QWEN_ASR_INSTALL_HINT` 재사용, eagle3 llm-forward dummy 수정, Path 3 chunk=1 캡처를 decode timing bucket으로 라우팅.

## 테스트
- 신규: `tests/transformers/test_logits_to_keep.py`(1.3k 줄)에서 공유 코어의 3-path 전부 커버, VL wrapper용 `test_qwen2_vl_logits_to_keep.py` / `test_qwen3_vl_logits_to_keep.py`, upstream slice 계약용 `test_qwen2_vl_upstream_contract.py` / `test_qwen3_vl_upstream_contract.py`, `mirror_output_fields`, `upstream_positional_params` 테스트 추가.
- 공유 fake MXQ 백엔드를 `tests/transformers/_fake_mxq.py`로 추출.
- 기존 `test_qwen3_vl_cache_contract.py` dummy override와 `eagle3/test_qwen2_eagle3_edge_cases.py` dummy가 새 `logits_to_keep` kwarg를 수용하도록 갱신.
- PR 생성 시점에는 미실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)