### PR TITLE
Fix NPU kwargs propagation and add core-mode fan-out to subconfigs

### DIFF
--- a/benchmark/transformers/asr_pipeline_utils.py
+++ b/benchmark/transformers/asr_pipeline_utils.py
@@ -172,6 +172,8 @@ def build_asr_pipeline(
     ensure_qwen3_asr_backend_registered: Any,
     apply_asr_core_mode_model_kwargs: Any,
     hf_pipeline: Any,
+    encoder_core_mode: str | None = None,
+    decoder_core_mode: str | None = None,
 ) -> Any:
     """Build one ASR pipeline/native model for benchmarking."""
 
@@ -221,7 +223,13 @@ def build_asr_pipeline(
     if device_map:
         kwargs["device_map"] = device_map
     model_kwargs: dict[str, Any] = {}
-    model_kwargs = apply_asr_core_mode_model_kwargs(model_kwargs, target.model_id, core_mode)
+    model_kwargs = apply_asr_core_mode_model_kwargs(
+        model_kwargs,
+        target.model_id,
+        core_mode,
+        encoder_core_mode=encoder_core_mode,
+        decoder_core_mode=decoder_core_mode,
+    )
     if target.mxq_path:
         model_kwargs["mxq_path"] = target.mxq_path
     if model_kwargs:

--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -212,6 +212,31 @@ def _uses_encoder_decoder_core_mode_kwargs(model_id: str) -> bool:
     return _is_qwen3_asr_model(model_id) or _is_whisper_like_model(model_id)
 
 
+def _append_asr_subconfig_core_mode_suffix(
+    label: str,
+    base: str,
+    core_mode: str | None,
+    *,
+    encoder_core_mode: str | None = None,
+    decoder_core_mode: str | None = None,
+) -> tuple[str, str]:
+    """Extend the label/base with a suffix identifying encoder/decoder core-mode overrides.
+
+    Only overrides that differ from the shared ``core_mode`` (and are non-None) are appended,
+    so runs without subconfig overrides keep the current filename layout untouched.
+    """
+
+    parts: list[str] = []
+    if encoder_core_mode is not None and encoder_core_mode != core_mode:
+        parts.append(f"enc{encoder_core_mode}")
+    if decoder_core_mode is not None and decoder_core_mode != core_mode:
+        parts.append(f"dec{decoder_core_mode}")
+    if not parts:
+        return label, base
+    suffix = "-" + "-".join(parts)
+    return f"{label}{suffix}", f"{base}{suffix}"
+
+
 def _apply_asr_core_mode_model_kwargs(
     model_kwargs: dict[str, Any],
     model_id: str,
@@ -725,6 +750,8 @@ def _build_no_samples_payload(
         },
         "mxq_path": target.mxq_path,
         "core_mode": core_mode,
+        "encoder_core_mode": getattr(args, "encoder_core_mode", None),
+        "decoder_core_mode": getattr(args, "decoder_core_mode", None),
         "status": "no_samples",
         "reason": reason,
     }
@@ -880,6 +907,8 @@ def _write_target_json(
         },
         "mxq_path": target.mxq_path,
         "core_mode": core_mode,
+        "encoder_core_mode": getattr(args, "encoder_core_mode", None),
+        "decoder_core_mode": getattr(args, "decoder_core_mode", None),
         "generate_kwargs": _generate_kwargs_for_target(args, target.model_id),
         "asr": asr_summary,
         "device": augmented_device_metric,
@@ -967,9 +996,20 @@ def _build_run_targets(args: argparse.Namespace) -> list[tuple[ASRBenchmarkTarge
     core_modes = [None] if (args.original_models and not args.mxq_dir) else _iter_core_modes_common(args.core_mode)
     if args.original_models and not args.mxq_dir and getattr(args, "_core_mode_explicit", False):
         print("Note: --core-mode is not supported for --original-models ASR native runs and will be ignored.")
+    encoder_core_mode = getattr(args, "encoder_core_mode", None)
+    decoder_core_mode = getattr(args, "decoder_core_mode", None)
     for target in targets:
+        subconfig_applies = _uses_encoder_decoder_core_mode_kwargs(target.model_id)
         for core_mode in core_modes:
             mode_label, mode_base = _append_core_mode_suffix_common(target.label, target.base, core_mode)
+            if subconfig_applies:
+                mode_label, mode_base = _append_asr_subconfig_core_mode_suffix(
+                    mode_label,
+                    mode_base,
+                    core_mode,
+                    encoder_core_mode=encoder_core_mode,
+                    decoder_core_mode=decoder_core_mode,
+                )
             run_targets.append((target, core_mode, mode_label, mode_base))
     return run_targets
 

--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -525,6 +525,21 @@ def _args_for_target_device_backend(
     )
 
 
+def _resolve_asr_subconfig_core_modes(args: argparse.Namespace) -> tuple[str | None, str | None]:
+    """Return the effective (encoder_core_mode, decoder_core_mode) for the run.
+
+    Encoder/decoder overrides are dropped whenever the shared ``--core-mode`` is
+    ignored for original-model native runs (``args.original_models`` without
+    ``args.mxq_dir``). Otherwise the CLI-provided values are used unchanged.
+    """
+    if args.original_models and not args.mxq_dir:
+        return None, None
+    return (
+        getattr(args, "encoder_core_mode", None),
+        getattr(args, "decoder_core_mode", None),
+    )
+
+
 def _build_asr_pipeline(
     target: ASRBenchmarkTarget,
     *,
@@ -1027,6 +1042,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     _collect_host_pc_info(output_dir)
     run_targets = _build_run_targets(args)
+    resolved_encoder_core_mode, resolved_decoder_core_mode = _resolve_asr_subconfig_core_modes(args)
     base_generate_kwargs = _resolve_generate_kwargs(args)
 
     if args.dry_run:
@@ -1085,8 +1101,8 @@ def main(argv: list[str] | None = None) -> int:
                     trust_remote_code=args.trust_remote_code,
                     core_mode=core_mode,
                     native_generate_kwargs=generate_kwargs,
-                    encoder_core_mode=getattr(args, "encoder_core_mode", None),
-                    decoder_core_mode=getattr(args, "decoder_core_mode", None),
+                    encoder_core_mode=resolved_encoder_core_mode,
+                    decoder_core_mode=resolved_decoder_core_mode,
                 )
             except Exception as exc:
                 if _is_cuda_oom_error(exc):

--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -114,6 +114,9 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     apply_core_mode_model_kwargs as _apply_core_mode_model_kwargs_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
+    apply_subconfig_core_mode_model_kwargs as _apply_subconfig_core_mode_model_kwargs_common,
+)
+from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     build_device_tracker as _build_device_tracker_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
@@ -213,17 +216,24 @@ def _apply_asr_core_mode_model_kwargs(
     model_kwargs: dict[str, Any],
     model_id: str,
     core_mode: str | None,
+    *,
+    encoder_core_mode: str | None = None,
+    decoder_core_mode: str | None = None,
 ) -> dict[str, Any]:
-    """Apply core-mode kwargs for ASR models, expanding composite encoder/decoder configs when needed."""
+    """Apply core-mode kwargs for ASR models, expanding composite encoder/decoder configs when needed.
+
+    ``encoder_core_mode``/``decoder_core_mode`` overrides take precedence over the shared value for
+    the matching prefix on encoder-decoder models.
+    """
     if not _uses_encoder_decoder_core_mode_kwargs(model_id):
         return _apply_core_mode_model_kwargs_common(model_kwargs, core_mode)
 
-    expanded: dict[str, Any] = {}
-    _apply_core_mode_model_kwargs_common(expanded, core_mode)
-    for prefix in ("encoder", "decoder"):
-        for key, value in expanded.items():
-            model_kwargs[f"{prefix}_{key}"] = value
-    return model_kwargs
+    return _apply_subconfig_core_mode_model_kwargs_common(
+        model_kwargs,
+        ("encoder", "decoder"),
+        core_mode,
+        subconfig_core_modes={"encoder": encoder_core_mode, "decoder": decoder_core_mode},
+    )
 
 
 def _optional_generate_kwargs_for_model(args: argparse.Namespace, model_id: str) -> dict[str, Any]:
@@ -420,6 +430,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="core mode passed to model_kwargs; all expands to single/global4/global8",
     )
+    for prefix in ("encoder", "decoder"):
+        parser.add_argument(
+            f"--{prefix}-core-mode",
+            choices=list(_CORE_MODE_CHOICES_COMMON),
+            default=None,
+            help=(
+                f"encoder-decoder ASR only: {prefix} NPU core mode override (falls back to --core-mode)"
+            ),
+        )
     _add_device_tracking_args(parser)
     args = parser.parse_args(argv)
     num_samples_explicit = _flag_present(raw_argv, "--num-samples")
@@ -491,6 +510,8 @@ def _build_asr_pipeline(
     trust_remote_code: bool,
     core_mode: str | None,
     native_generate_kwargs: Mapping[str, Any] | None = None,
+    encoder_core_mode: str | None = None,
+    decoder_core_mode: str | None = None,
 ):
     from transformers import pipeline as hf_pipeline
 
@@ -512,6 +533,8 @@ def _build_asr_pipeline(
         ensure_qwen3_asr_backend_registered=_ensure_qwen3_asr_backend_registered,
         apply_asr_core_mode_model_kwargs=_apply_asr_core_mode_model_kwargs,
         hf_pipeline=hf_pipeline,
+        encoder_core_mode=encoder_core_mode,
+        decoder_core_mode=decoder_core_mode,
     )
 
 
@@ -1022,6 +1045,8 @@ def main(argv: list[str] | None = None) -> int:
                     trust_remote_code=args.trust_remote_code,
                     core_mode=core_mode,
                     native_generate_kwargs=generate_kwargs,
+                    encoder_core_mode=getattr(args, "encoder_core_mode", None),
+                    decoder_core_mode=getattr(args, "decoder_core_mode", None),
                 )
             except Exception as exc:
                 if _is_cuda_oom_error(exc):

--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -747,6 +747,7 @@ def _build_no_samples_payload(
 ) -> dict[str, Any]:
     """Build a status-only payload for targets that produced no measured ASR samples."""
 
+    encoder_core_mode, decoder_core_mode = _resolve_asr_subconfig_core_modes(args)
     return {
         "schema_version": _ASR_BENCHMARK_SCHEMA_VERSION,
         "benchmark_type": "measure",
@@ -765,8 +766,8 @@ def _build_no_samples_payload(
         },
         "mxq_path": target.mxq_path,
         "core_mode": core_mode,
-        "encoder_core_mode": getattr(args, "encoder_core_mode", None),
-        "decoder_core_mode": getattr(args, "decoder_core_mode", None),
+        "encoder_core_mode": encoder_core_mode,
+        "decoder_core_mode": decoder_core_mode,
         "status": "no_samples",
         "reason": reason,
     }
@@ -904,6 +905,7 @@ def _write_target_json(
     reported_num_beams = _reported_num_beams(sample_timings)
     asr_summary = summary_to_dict(summary)
     augmented_device_metric = add_device_efficiency_metrics(asr_summary, device_metric)
+    encoder_core_mode, decoder_core_mode = _resolve_asr_subconfig_core_modes(args)
     payload: dict[str, Any] = {
         "schema_version": _ASR_BENCHMARK_SCHEMA_VERSION,
         "benchmark_type": "measure",
@@ -922,8 +924,8 @@ def _write_target_json(
         },
         "mxq_path": target.mxq_path,
         "core_mode": core_mode,
-        "encoder_core_mode": getattr(args, "encoder_core_mode", None),
-        "decoder_core_mode": getattr(args, "decoder_core_mode", None),
+        "encoder_core_mode": encoder_core_mode,
+        "decoder_core_mode": decoder_core_mode,
         "generate_kwargs": _generate_kwargs_for_target(args, target.model_id),
         "asr": asr_summary,
         "device": augmented_device_metric,
@@ -1011,8 +1013,7 @@ def _build_run_targets(args: argparse.Namespace) -> list[tuple[ASRBenchmarkTarge
     core_modes = [None] if (args.original_models and not args.mxq_dir) else _iter_core_modes_common(args.core_mode)
     if args.original_models and not args.mxq_dir and getattr(args, "_core_mode_explicit", False):
         print("Note: --core-mode is not supported for --original-models ASR native runs and will be ignored.")
-    encoder_core_mode = getattr(args, "encoder_core_mode", None)
-    decoder_core_mode = getattr(args, "decoder_core_mode", None)
+    encoder_core_mode, decoder_core_mode = _resolve_asr_subconfig_core_modes(args)
     for target in targets:
         subconfig_applies = _uses_encoder_decoder_core_mode_kwargs(target.model_id)
         for core_mode in core_modes:

--- a/benchmark/transformers/benchmark_image_text_to_text_models.py
+++ b/benchmark/transformers/benchmark_image_text_to_text_models.py
@@ -261,9 +261,7 @@ def _build_pipeline(
     if args.device_map:
         kwargs["device_map"] = args.device_map
     model_kwargs: dict[str, Any] = {}
-    disable_npu_specific_args = bool(getattr(args, "original_models", False) and not getattr(args, "mxq_dir", None))
-    vision_core_mode = None if disable_npu_specific_args else getattr(args, "vision_core_mode", None)
-    text_core_mode = None if disable_npu_specific_args else getattr(args, "text_core_mode", None)
+    vision_core_mode, text_core_mode = _resolve_vlm_subconfig_core_modes(args)
     model_kwargs = _apply_vlm_core_mode_model_kwargs(
         model_kwargs,
         core_mode,
@@ -310,15 +308,31 @@ def _append_vlm_subconfig_core_mode_suffix(
     return f"{label}{suffix}", f"{base}{suffix}"
 
 
+def _resolve_vlm_subconfig_core_modes(args: argparse.Namespace) -> tuple[str | None, str | None]:
+    """Return the effective (vision_core_mode, text_core_mode) for the run.
+
+    Vision/text overrides are dropped whenever ``_build_pipeline`` skips
+    NPU-specific parameters for original-model native runs (``args.original_models``
+    without ``args.mxq_dir``). Otherwise the CLI-provided values are used unchanged.
+    """
+    if getattr(args, "original_models", False) and not getattr(args, "mxq_dir", None):
+        return None, None
+    return (
+        getattr(args, "vision_core_mode", None),
+        getattr(args, "text_core_mode", None),
+    )
+
+
 def _vlm_subconfig_core_mode_payload_fields(
     args: argparse.Namespace,
     core_mode: str | None,
 ) -> dict[str, Any]:
     """Return the core_mode / vision_core_mode / text_core_mode fields for a VLM payload."""
+    vision_core_mode, text_core_mode = _resolve_vlm_subconfig_core_modes(args)
     return {
         "core_mode": core_mode,
-        "vision_core_mode": getattr(args, "vision_core_mode", None),
-        "text_core_mode": getattr(args, "text_core_mode", None),
+        "vision_core_mode": vision_core_mode,
+        "text_core_mode": text_core_mode,
     }
 
 
@@ -1602,8 +1616,7 @@ def _run_sweep(args: argparse.Namespace) -> int:
     run_targets: list[
         tuple[str, str | None, str, str, str | None, str | None, int, str, tuple[int, int, int], list[int]]
     ] = []
-    vision_core_mode = getattr(args, "vision_core_mode", None)
-    text_core_mode = getattr(args, "text_core_mode", None)
+    vision_core_mode, text_core_mode = _resolve_vlm_subconfig_core_modes(args)
     for target in targets:
         target_prefill_range, target_cache_lengths = _target_sweep_lengths(
             args,
@@ -1762,8 +1775,7 @@ def _collect_vlm_run_targets(
         )
     ]
     run_targets: list[tuple[str, str | None, str, str, str | None, str | None, int, str]] = []
-    vision_core_mode = getattr(args, "vision_core_mode", None)
-    text_core_mode = getattr(args, "text_core_mode", None)
+    vision_core_mode, text_core_mode = _resolve_vlm_subconfig_core_modes(args)
     for target in targets:
         for core_mode in _iter_core_modes_for_target(
             args,

--- a/benchmark/transformers/benchmark_image_text_to_text_models.py
+++ b/benchmark/transformers/benchmark_image_text_to_text_models.py
@@ -282,6 +282,43 @@ def _build_pipeline(
     return hf_pipeline(**kwargs)
 
 
+def _append_vlm_subconfig_core_mode_suffix(
+    label: str,
+    base: str,
+    core_mode: str | None,
+    *,
+    vision_core_mode: str | None = None,
+    text_core_mode: str | None = None,
+) -> tuple[str, str]:
+    """Extend the label/base with a suffix identifying vision/text core-mode overrides.
+
+    Only overrides that differ from the shared ``core_mode`` (and are non-None) are appended,
+    so runs without subconfig overrides keep the current filename layout untouched.
+    """
+
+    parts: list[str] = []
+    if vision_core_mode is not None and vision_core_mode != core_mode:
+        parts.append(f"vis{vision_core_mode}")
+    if text_core_mode is not None and text_core_mode != core_mode:
+        parts.append(f"txt{text_core_mode}")
+    if not parts:
+        return label, base
+    suffix = "-" + "-".join(parts)
+    return f"{label}{suffix}", f"{base}{suffix}"
+
+
+def _vlm_subconfig_core_mode_payload_fields(
+    args: argparse.Namespace,
+    core_mode: str | None,
+) -> dict[str, Any]:
+    """Return the core_mode / vision_core_mode / text_core_mode fields for a VLM payload."""
+    return {
+        "core_mode": core_mode,
+        "vision_core_mode": getattr(args, "vision_core_mode", None),
+        "text_core_mode": getattr(args, "text_core_mode", None),
+    }
+
+
 def _apply_vlm_core_mode_model_kwargs(
     model_kwargs: dict[str, Any],
     core_mode: str | None,
@@ -1562,6 +1599,8 @@ def _run_sweep(args: argparse.Namespace) -> int:
     run_targets: list[
         tuple[str, str | None, str, str, str | None, str | None, int, str, tuple[int, int, int], list[int]]
     ] = []
+    vision_core_mode = getattr(args, "vision_core_mode", None)
+    text_core_mode = getattr(args, "text_core_mode", None)
     for target in targets:
         target_prefill_range, target_cache_lengths = _target_sweep_lengths(
             args,
@@ -1574,6 +1613,13 @@ def _run_sweep(args: argparse.Namespace) -> int:
             disable_npu_specific_args=disable_npu_specific_args,
         ):
             mode_label, mode_base = _append_core_mode_suffix_common(target.label, target.base, core_mode)
+            mode_label, mode_base = _append_vlm_subconfig_core_mode_suffix(
+                mode_label,
+                mode_base,
+                core_mode,
+                vision_core_mode=vision_core_mode,
+                text_core_mode=text_core_mode,
+            )
             run_targets.append(
                 (
                     target.model_id,
@@ -1647,6 +1693,7 @@ def _run_sweep(args: argparse.Namespace) -> int:
             target_args.prefill_range = prefill_range
             target_args.cache_lengths = cache_lengths
             payload, rows = _run_model(target_args, label, pipeline)
+            payload.update(_vlm_subconfig_core_mode_payload_fields(target_args, core_mode))
             _write_json(json_path, payload)
             _write_csv(csv_path, rows)
             _plot_model(payload, png_path)
@@ -1712,6 +1759,8 @@ def _collect_vlm_run_targets(
         )
     ]
     run_targets: list[tuple[str, str | None, str, str, str | None, str | None, int, str]] = []
+    vision_core_mode = getattr(args, "vision_core_mode", None)
+    text_core_mode = getattr(args, "text_core_mode", None)
     for target in targets:
         for core_mode in _iter_core_modes_for_target(
             args,
@@ -1719,6 +1768,13 @@ def _collect_vlm_run_targets(
             disable_npu_specific_args=disable_npu_specific_args,
         ):
             mode_label, mode_base = _append_core_mode_suffix_common(target.label, target.base, core_mode)
+            mode_label, mode_base = _append_vlm_subconfig_core_mode_suffix(
+                mode_label,
+                mode_base,
+                core_mode,
+                vision_core_mode=vision_core_mode,
+                text_core_mode=text_core_mode,
+            )
             run_targets.append(
                 (
                     target.model_id,
@@ -2190,6 +2246,7 @@ def _run_measure(args: argparse.Namespace) -> int:
                 "task": "image-text-to-text",
                 "batch_mode": batch_mode,
                 "batch_size": batch_size,
+                **_vlm_subconfig_core_mode_payload_fields(args, core_mode),
                 "prompt": args.prompt,
                 "image_resolution": args.image_resolution,
                 "prefill": args.prefill,

--- a/benchmark/transformers/benchmark_image_text_to_text_models.py
+++ b/benchmark/transformers/benchmark_image_text_to_text_models.py
@@ -66,6 +66,9 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     apply_core_mode_model_kwargs as _apply_core_mode_model_kwargs_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
+    apply_subconfig_core_mode_model_kwargs as _apply_subconfig_core_mode_model_kwargs_common,
+)
+from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     build_device_tracker as _build_device_tracker,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
@@ -262,6 +265,8 @@ def _build_pipeline(
         model_kwargs,
         core_mode,
         default_single_target_cores=default_single_target_cores,
+        vision_core_mode=getattr(args, "vision_core_mode", None),
+        text_core_mode=getattr(args, "text_core_mode", None),
     )
     if mxq_path:
         model_kwargs["mxq_path"] = mxq_path
@@ -282,6 +287,8 @@ def _apply_vlm_core_mode_model_kwargs(
     core_mode: str | None,
     *,
     default_single_target_cores: Sequence[str] | None = ("0:0",),
+    vision_core_mode: str | None = None,
+    text_core_mode: str | None = None,
 ) -> dict[str, Any]:
     """Apply shared VLM NPU core-mode kwargs to both vision and text sub-configs.
 
@@ -290,25 +297,24 @@ def _apply_vlm_core_mode_model_kwargs(
     ``core_mode`` leaves them unused by the config loader, and Transformers forwards them to the
     model constructor where upstream VLM classes can reject them. This helper maps the benchmark's
     shared ``--core-mode`` option onto the VLM-specific ``vision_*`` and ``text_*`` config fields.
+    Per-subconfig overrides take precedence over the shared value for the matching prefix.
 
     Args:
         model_kwargs: Existing model kwargs to update.
         core_mode: Core mode requested by the benchmark CLI.
+        vision_core_mode: Optional vision-only core mode override.
+        text_core_mode: Optional text-only core mode override.
 
     Returns:
         The updated model kwargs.
     """
-    expanded: dict[str, Any] = {}
-    _apply_core_mode_model_kwargs_common(
-        expanded,
+    return _apply_subconfig_core_mode_model_kwargs_common(
+        model_kwargs,
+        ("vision", "text"),
         core_mode,
+        subconfig_core_modes={"vision": vision_core_mode, "text": text_core_mode},
         default_single_target_cores=default_single_target_cores,
     )
-
-    for prefix in ("vision", "text"):
-        for key, value in expanded.items():
-            model_kwargs[f"{prefix}_{key}"] = value
-    return model_kwargs
 
 
 def _collect_vlm_config_mxq_paths(config: dict[str, Any]) -> list[str]:
@@ -1301,6 +1307,13 @@ def _add_common_benchmark_args(parser: argparse.ArgumentParser) -> None:
         default="global8",
         help="core mode passed to model_kwargs; all expands to single/global4/global8 (default: global8)",
     )
+    for prefix in ("vision", "text"):
+        parser.add_argument(
+            f"--{prefix}-core-mode",
+            choices=list(_CORE_MODE_CHOICES_COMMON),
+            default=None,
+            help=f"{prefix} NPU core mode override (falls back to --core-mode when omitted)",
+        )
     parser.add_argument("--prompt", default="Describe the image in one sentence.")
     parser.add_argument(
         "--warmup", type=_parse_positive_int, default=1, help="number of warmup runs before measured runs"

--- a/benchmark/transformers/benchmark_image_text_to_text_models.py
+++ b/benchmark/transformers/benchmark_image_text_to_text_models.py
@@ -261,12 +261,15 @@ def _build_pipeline(
     if args.device_map:
         kwargs["device_map"] = args.device_map
     model_kwargs: dict[str, Any] = {}
+    disable_npu_specific_args = bool(getattr(args, "original_models", False) and not getattr(args, "mxq_dir", None))
+    vision_core_mode = None if disable_npu_specific_args else getattr(args, "vision_core_mode", None)
+    text_core_mode = None if disable_npu_specific_args else getattr(args, "text_core_mode", None)
     model_kwargs = _apply_vlm_core_mode_model_kwargs(
         model_kwargs,
         core_mode,
         default_single_target_cores=default_single_target_cores,
-        vision_core_mode=getattr(args, "vision_core_mode", None),
-        text_core_mode=getattr(args, "text_core_mode", None),
+        vision_core_mode=vision_core_mode,
+        text_core_mode=text_core_mode,
     )
     if mxq_path:
         model_kwargs["mxq_path"] = mxq_path

--- a/mblt_model_zoo/cli/tps.py
+++ b/mblt_model_zoo/cli/tps.py
@@ -824,18 +824,44 @@ def _print_device_status(args: argparse.Namespace, tracker: Any) -> None:
     _print_device_status_common(args, tracker)
 
 
+_SUBCONFIG_MXQ_PATH_ATTRS: tuple[str, ...] = (
+    "base_mxq_path",
+    "draft_mxq_path",
+    "fc_mxq_path",
+    "vision_mxq_path",
+    "text_mxq_path",
+)
+
+
+def _effective_mxq_path_for_defaults(args: argparse.Namespace) -> str | None:
+    """Return any MXQ path (base or subconfig prefix) provided by the user.
+
+    Used only to steer default-device/backend resolution: if any MXQ artifact was
+    supplied, the target should be treated as Mobilint even without ``--mxq-path``.
+    """
+    base = getattr(args, "mxq_path", None)
+    if base:
+        return base
+    for attr in _SUBCONFIG_MXQ_PATH_ATTRS:
+        value = getattr(args, attr, None)
+        if value:
+            return value
+    return None
+
+
 def _normalize_runtime_defaults(args: argparse.Namespace) -> None:
+    effective_mxq_path = _effective_mxq_path_for_defaults(args)
     args.device = _resolve_default_device_common(
         device=args.device,
         device_explicit=args.device is not None,
         model_id=args.model,
-        mxq_path=args.mxq_path,
+        mxq_path=effective_mxq_path,
     )
     args.device_backend = _resolve_default_device_backend_common(
         device_backend=args.device_backend or "none",
         device_backend_explicit=args.device_backend is not None,
         model_id=args.model,
-        mxq_path=args.mxq_path,
+        mxq_path=effective_mxq_path,
     )
 
 

--- a/mblt_model_zoo/cli/tps.py
+++ b/mblt_model_zoo/cli/tps.py
@@ -24,6 +24,9 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     apply_core_mode_model_kwargs as _apply_core_mode_model_kwargs_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
+    apply_subconfig_core_mode_model_kwargs as _apply_subconfig_core_mode_model_kwargs_common,
+)
+from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     build_device_tracker as _build_device_tracker_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
@@ -82,6 +85,20 @@ class Eagle3PipelineOptions:
     base_target_clusters: list[int] | None = None
     draft_target_clusters: list[int] | None = None
     fc_target_clusters: list[int] | None = None
+
+
+@dataclass(frozen=True)
+class SubconfigPipelineOptions:
+    """Bundle VLM vision/text subconfig overrides for pipeline construction."""
+
+    vision_core_mode: str | None = None
+    text_core_mode: str | None = None
+    vision_target_cores: list[str] | None = None
+    text_target_cores: list[str] | None = None
+    vision_target_clusters: list[int] | None = None
+    text_target_clusters: list[int] | None = None
+    vision_mxq_path: str | None = None
+    text_mxq_path: str | None = None
 
 
 def _warn_eagle3_override(
@@ -222,20 +239,29 @@ def _apply_vlm_core_mode_model_kwargs(
     target_cores: list[str] | None = None,
     target_clusters: list[int] | None = None,
     default_single_target_cores: Sequence[str] | None = None,
+    vision_core_mode: str | None = None,
+    text_core_mode: str | None = None,
+    vision_target_cores: list[str] | None = None,
+    text_target_cores: list[str] | None = None,
+    vision_target_clusters: list[int] | None = None,
+    text_target_clusters: list[int] | None = None,
 ) -> dict[str, Any]:
-    """Apply shared VLM core-mode kwargs to both vision and text sub-configs."""
-    expanded: dict[str, Any] = {}
-    _apply_core_mode_model_kwargs_common(
-        expanded,
+    """Apply shared VLM core-mode kwargs to both vision and text sub-configs.
+
+    ``vision_*`` and ``text_*`` overrides take precedence over the base values for their prefix,
+    while the base values continue to fill in any subconfig left unspecified.
+    """
+    return _apply_subconfig_core_mode_model_kwargs_common(
+        model_kwargs,
+        ("vision", "text"),
         core_mode,
-        target_cores=target_cores,
-        target_clusters=target_clusters,
+        subconfig_core_modes={"vision": vision_core_mode, "text": text_core_mode},
+        base_target_cores=target_cores,
+        subconfig_target_cores={"vision": vision_target_cores, "text": text_target_cores},
+        base_target_clusters=target_clusters,
+        subconfig_target_clusters={"vision": vision_target_clusters, "text": text_target_clusters},
         default_single_target_cores=default_single_target_cores,
     )
-    for prefix in ("vision", "text"):
-        for key, value in expanded.items():
-            model_kwargs[f"{prefix}_{key}"] = value
-    return model_kwargs
 
 
 def _normalize_max_batch_size(value: Any) -> int | None:
@@ -372,6 +398,7 @@ def _build_pipeline(
     target_cores: Union[list[str], None],
     target_clusters: Union[list[int], None],
     default_single_target_cores: Sequence[str] | None = ("0:0",),
+    subconfig_options: SubconfigPipelineOptions | None = None,
 ) -> Any:
     _require_transformers_deps()
     from transformers import pipeline as hf_pipeline
@@ -422,6 +449,7 @@ def _build_pipeline(
             eagle3_options.fc_target_clusters,
         )
     )
+    subconfig_options = subconfig_options or SubconfigPipelineOptions()
     if _is_vlm_task(task):
         model_kwargs = _apply_vlm_core_mode_model_kwargs(
             model_kwargs,
@@ -429,7 +457,17 @@ def _build_pipeline(
             target_cores=target_cores,
             target_clusters=target_clusters,
             default_single_target_cores=default_single_target_cores,
+            vision_core_mode=subconfig_options.vision_core_mode,
+            text_core_mode=subconfig_options.text_core_mode,
+            vision_target_cores=subconfig_options.vision_target_cores,
+            text_target_cores=subconfig_options.text_target_cores,
+            vision_target_clusters=subconfig_options.vision_target_clusters,
+            text_target_clusters=subconfig_options.text_target_clusters,
         )
+        if subconfig_options.vision_mxq_path:
+            model_kwargs["vision_mxq_path"] = subconfig_options.vision_mxq_path
+        if subconfig_options.text_mxq_path:
+            model_kwargs["text_mxq_path"] = subconfig_options.text_mxq_path
     elif eagle3_prefix_requested:
         _warn_eagle3_override("--core-mode", "--base-core-mode", core_mode, eagle3_options.base_core_mode)
         _warn_eagle3_override("--core-mode", "--draft-core-mode", core_mode, eagle3_options.draft_core_mode)
@@ -532,6 +570,20 @@ def _build_pipeline(
         return _configure_asr_pipeline_num_beams(task, hf_pipeline(**pipeline_kwargs))
     except Exception as e:
         _raise_cuda_nvml_hint(e)
+
+
+def _extract_subconfig_pipeline_kwargs(args: argparse.Namespace) -> SubconfigPipelineOptions:
+    """Return VLM subconfig overrides from parsed CLI arguments."""
+    return SubconfigPipelineOptions(
+        vision_core_mode=getattr(args, "vision_core_mode", None),
+        text_core_mode=getattr(args, "text_core_mode", None),
+        vision_target_cores=getattr(args, "vision_target_cores", None),
+        text_target_cores=getattr(args, "text_target_cores", None),
+        vision_target_clusters=getattr(args, "vision_target_clusters", None),
+        text_target_clusters=getattr(args, "text_target_clusters", None),
+        vision_mxq_path=getattr(args, "vision_mxq_path", None),
+        text_mxq_path=getattr(args, "text_mxq_path", None),
+    )
 
 
 def _extract_eagle3_pipeline_kwargs(args: argparse.Namespace) -> Eagle3PipelineOptions:
@@ -1122,6 +1174,7 @@ def _run_text_measure(args: argparse.Namespace) -> int:
         target_cores=args.target_cores,
         target_clusters=args.target_clusters,
         default_single_target_cores=_default_single_target_cores_for_args(args),
+        subconfig_options=_extract_subconfig_pipeline_kwargs(args),
     )
     batch_size = _resolve_cli_batch_size(args, pipeline)
 
@@ -1414,6 +1467,7 @@ def _run_vlm_measure(args: argparse.Namespace) -> int:
         target_cores=args.target_cores,
         target_clusters=args.target_clusters,
         default_single_target_cores=_default_single_target_cores_for_args(args),
+        subconfig_options=_extract_subconfig_pipeline_kwargs(args),
     )
     batch_size = _resolve_cli_batch_size(args, pipeline)
 
@@ -1722,6 +1776,7 @@ def _run_text_sweep(args: argparse.Namespace) -> int:
         target_cores=args.target_cores,
         target_clusters=args.target_clusters,
         default_single_target_cores=_default_single_target_cores_for_args(args),
+        subconfig_options=_extract_subconfig_pipeline_kwargs(args),
     )
     batch_size = _resolve_cli_batch_size(args, pipeline)
 
@@ -2212,6 +2267,7 @@ def _run_vlm_sweep(args: argparse.Namespace) -> int:
         target_cores=args.target_cores,
         target_clusters=args.target_clusters,
         default_single_target_cores=_default_single_target_cores_for_args(args),
+        subconfig_options=_extract_subconfig_pipeline_kwargs(args),
     )
     batch_size = _resolve_cli_batch_size(args, pipeline)
 
@@ -2761,6 +2817,12 @@ def add_tps_parser(
             p.add_argument(
                 f"--{prefix}-mxq-path", default=None, help=f"override {prefix} mxq_path for pipeline loading"
             )
+        for prefix in ("vision", "text"):
+            p.add_argument(
+                f"--{prefix}-mxq-path",
+                default=None,
+                help=f"VLM only: override {prefix} mxq_path for pipeline loading",
+            )
         p.add_argument(
             "--core-mode",
             choices=list(_CORE_MODE_CHOICES),
@@ -2797,6 +2859,25 @@ def add_tps_parser(
                 type=_parse_target_clusters,
                 default=None,
                 help=f'{prefix} target clusters (e.g., "0;1")',
+            )
+        for prefix in ("vision", "text"):
+            p.add_argument(
+                f"--{prefix}-core-mode",
+                choices=list(_CORE_MODE_CHOICES),
+                default=None,
+                help=f"VLM only: {prefix} NPU core mode override (falls back to --core-mode)",
+            )
+            p.add_argument(
+                f"--{prefix}-target-cores",
+                type=_parse_target_cores,
+                default=None,
+                help=f'VLM only: {prefix} target cores override (e.g., "0:0;0:1")',
+            )
+            p.add_argument(
+                f"--{prefix}-target-clusters",
+                type=_parse_target_clusters,
+                default=None,
+                help=f'VLM only: {prefix} target clusters override (e.g., "0;1")',
             )
         p.add_argument("--device-map", default=None, help="transformers device_map (optional)")
         p.add_argument("--dtype", default=None, help="dtype (e.g., auto, float16, bfloat16)")

--- a/mblt_model_zoo/hf_transformers/models/aya_vision/configuration_aya_vision.py
+++ b/mblt_model_zoo/hf_transformers/models/aya_vision/configuration_aya_vision.py
@@ -23,7 +23,13 @@ class MobilintAyaVisionConfig(MobilintVisionTextConfigMixin, AyaVisionConfig):
             text_config = dict(text_config)
             text_config.setdefault("model_type", "mobilint-cohere2")
 
+        # Defense in depth: pop prefixed NPU kwargs before AyaVisionConfig's
+        # own setattr loop so we never depend on sub-config existence ordering.
+        text_kwargs, vision_kwargs = self._split_sub_backend_kwargs(kwargs)
+
         AyaVisionConfig.__init__(self, vision_config=vision_config, text_config=text_config, **kwargs)
+
+        self._apply_sub_backend_kwargs(text_kwargs, vision_kwargs)
 
         if self.vision_feature_select_strategy != "full":
             raise ValueError(

--- a/mblt_model_zoo/hf_transformers/models/blip/configuration_blip.py
+++ b/mblt_model_zoo/hf_transformers/models/blip/configuration_blip.py
@@ -44,6 +44,11 @@ class MobilintBlipConfig(MobilintVisionTextConfigMixin, BlipConfig):
         label_smoothing: float = 0.0,
         **kwargs: Any,
     ) -> None:
+        # Strip `text_*` / `vision_*` NPU keys before PretrainedConfig.__init__
+        # so its setattr-loop does not fire our prefixed property setters
+        # before `self.text_config` / `self.vision_config` are built.
+        text_kwargs, vision_kwargs = self._split_sub_backend_kwargs(kwargs)
+
         PretrainedConfig.__init__(self, **kwargs)
 
         if text_config is None:
@@ -56,6 +61,8 @@ class MobilintBlipConfig(MobilintVisionTextConfigMixin, BlipConfig):
 
         self.text_config = MobilintBlipTextConfig(**text_config)
         self.vision_config = MobilintBlipVisionConfig(**vision_config)
+
+        self._apply_sub_backend_kwargs(text_kwargs, vision_kwargs)
 
         self.text_config.encoder_hidden_size = self.vision_config.hidden_size
 

--- a/mblt_model_zoo/hf_transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -31,7 +31,14 @@ class MobilintQwen2VLConfig(MobilintVisionTextConfigMixin, Qwen2VLConfig):
 
     @wraps(Qwen2VLConfig.__init__)
     def __init__(self, **kwargs):
+        # Qwen2VLConfig calls `super().__init__(**kwargs)` before creating the
+        # sub-configs, which drives PretrainedConfig into setattr'ing unknown
+        # kwargs — that triggers our `text_*` / `vision_*` property setters
+        # before `self.text_config` / `self.vision_config` exist. Strip and
+        # re-apply after sub-configs are constructed.
+        text_kwargs, vision_kwargs = self._split_sub_backend_kwargs(kwargs)
         Qwen2VLConfig.__init__(self, **kwargs)
+        self._apply_sub_backend_kwargs(text_kwargs, vision_kwargs)
 
         self.tie_word_embeddings = False
         self._attn_implementation = "eager"

--- a/mblt_model_zoo/hf_transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -31,7 +31,13 @@ class MobilintQwen3VLConfig(MobilintVisionTextConfigMixin, Qwen3VLConfig):
 
     @wraps(Qwen3VLConfig.__init__)
     def __init__(self, **kwargs):
+        # Guard against JSON roundtrips (or upstream ordering changes) that
+        # would surface flat `text_*` / `vision_*` NPU keys during
+        # `PretrainedConfig.__init__`, which would trigger the prefixed
+        # property setters before sub-configs are available.
+        text_kwargs, vision_kwargs = self._split_sub_backend_kwargs(kwargs)
         Qwen3VLConfig.__init__(self, **kwargs)
+        self._apply_sub_backend_kwargs(text_kwargs, vision_kwargs)
 
         self.tie_word_embeddings = False
         self._attn_implementation = "eager"

--- a/mblt_model_zoo/hf_transformers/utils/benchmark_cli_common.py
+++ b/mblt_model_zoo/hf_transformers/utils/benchmark_cli_common.py
@@ -229,6 +229,68 @@ def apply_core_mode_model_kwargs(
     return model_kwargs
 
 
+def coalesce_subconfig(preferred: Any, fallback: Any) -> Any:
+    """Return the subconfig-specific value when set, otherwise fall back to the base value."""
+    return preferred if preferred is not None else fallback
+
+
+def apply_subconfig_core_mode_model_kwargs(
+    model_kwargs: dict[str, Any],
+    prefixes: Sequence[str],
+    base_core_mode: str | None,
+    *,
+    subconfig_core_modes: Mapping[str, str | None] | None = None,
+    base_target_cores: list[str] | None = None,
+    subconfig_target_cores: Mapping[str, list[str] | None] | None = None,
+    base_target_clusters: list[int] | None = None,
+    subconfig_target_clusters: Mapping[str, list[int] | None] | None = None,
+    base_mxq_path: str | None = None,
+    subconfig_mxq_paths: Mapping[str, str | None] | None = None,
+    default_single_target_cores: Sequence[str] | None = DEFAULT_SINGLE_TARGET_CORES,
+) -> dict[str, Any]:
+    """Apply core-mode kwargs to each subconfig, letting each override the base value.
+
+    Subconfig prefixes (e.g., ``"vision"``, ``"text"``, ``"encoder"``, ``"decoder"``) each get
+    their own ``{prefix}_core_mode`` etc. Missing subconfig entries inherit the base value.
+
+    Args:
+        model_kwargs: Existing model kwargs to update in place.
+        prefixes: Subconfig prefixes to populate.
+        base_core_mode: Fallback core mode when a subconfig does not specify one.
+        subconfig_core_modes: Optional per-prefix core mode overrides.
+        base_target_cores: Fallback target cores when a subconfig does not specify one.
+        subconfig_target_cores: Optional per-prefix target cores overrides.
+        base_target_clusters: Fallback target clusters when a subconfig does not specify one.
+        subconfig_target_clusters: Optional per-prefix target clusters overrides.
+        base_mxq_path: Fallback mxq path applied to each subconfig when not overridden.
+        subconfig_mxq_paths: Optional per-prefix mxq path overrides.
+        default_single_target_cores: Default cores injected for single mode when nothing is set.
+
+    Returns:
+        The updated ``model_kwargs``.
+    """
+    subconfig_core_modes = subconfig_core_modes or {}
+    subconfig_target_cores = subconfig_target_cores or {}
+    subconfig_target_clusters = subconfig_target_clusters or {}
+    subconfig_mxq_paths = subconfig_mxq_paths or {}
+    for prefix in prefixes:
+        effective_core_mode = coalesce_subconfig(subconfig_core_modes.get(prefix), base_core_mode)
+        effective_target_cores = coalesce_subconfig(subconfig_target_cores.get(prefix), base_target_cores)
+        effective_target_clusters = coalesce_subconfig(subconfig_target_clusters.get(prefix), base_target_clusters)
+        apply_core_mode_model_kwargs(
+            model_kwargs,
+            effective_core_mode,
+            prefix=prefix,
+            target_cores=effective_target_cores,
+            target_clusters=effective_target_clusters,
+            default_single_target_cores=default_single_target_cores,
+        )
+        effective_mxq_path = coalesce_subconfig(subconfig_mxq_paths.get(prefix), base_mxq_path)
+        if effective_mxq_path:
+            model_kwargs[f"{prefix}_mxq_path"] = effective_mxq_path
+    return model_kwargs
+
+
 def infer_gpu_ids(device: str | None, device_gpu_id: Optional[list[int]]) -> Optional[int | list[int]]:
     """Infer GPU tracker ids from explicit tracker args or CUDA device text."""
 

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -291,6 +291,50 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
 class MobilintVisionTextConfigMixin(PretrainedConfig):
     sub_configs = {"vision_config": MobilintConfigMixin, "text_config": MobilintConfigMixin}
 
+    _SUB_BACKEND_FIELDS = (
+        "mxq_path",
+        "dev_no",
+        "max_batch_size",
+        "core_mode",
+        "target_cores",
+        "target_clusters",
+        "npu_prefill_chunk_size",
+    )
+
+    @classmethod
+    def _split_sub_backend_kwargs(cls, kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Pop ``text_*`` / ``vision_*`` NPU keys out of ``kwargs`` in place.
+
+        Upstream composite configs (e.g. ``Qwen2VLConfig``, ``BlipConfig``) may
+        call ``PretrainedConfig.__init__(**kwargs)`` before instantiating their
+        sub-configs, which triggers the prefixed property setters on this mixin
+        while ``self.text_config`` / ``self.vision_config`` do not yet exist.
+        Removing the keys up front and re-applying them after the sub-configs
+        are built avoids that ordering hazard.
+        """
+        text_kwargs: dict[str, Any] = {}
+        vision_kwargs: dict[str, Any] = {}
+        for field in cls._SUB_BACKEND_FIELDS:
+            text_key = f"text_{field}"
+            if text_key in kwargs:
+                text_kwargs[field] = kwargs.pop(text_key)
+            vision_key = f"vision_{field}"
+            if vision_key in kwargs:
+                vision_kwargs[field] = kwargs.pop(vision_key)
+        return text_kwargs, vision_kwargs
+
+    def _apply_sub_backend_kwargs(
+        self, text_kwargs: dict[str, Any], vision_kwargs: dict[str, Any]
+    ) -> None:
+        text_config = getattr(self, "text_config", None)
+        if text_config is not None:
+            for key, value in text_kwargs.items():
+                setattr(text_config, key, value)
+        vision_config = getattr(self, "vision_config", None)
+        if vision_config is not None:
+            for key, value in vision_kwargs.items():
+                setattr(vision_config, key, value)
+
     @PretrainedConfig.name_or_path.setter
     def name_or_path(self, value):
         PretrainedConfig.name_or_path.fset(self, value)
@@ -552,6 +596,54 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
         draft_config = getattr(self, "draft_config", None)
         if draft_config is not None:
             draft_config.name_or_path = value
+
+    @property
+    def base_dev_no(self) -> int:
+        return self.base_npu_backend.dev_no
+
+    @base_dev_no.setter
+    def base_dev_no(self, value: int) -> None:
+        self.base_npu_backend.dev_no = value
+
+    @property
+    def draft_dev_no(self) -> int:
+        return self.draft_npu_backend.dev_no
+
+    @draft_dev_no.setter
+    def draft_dev_no(self, value: int) -> None:
+        self.draft_npu_backend.dev_no = value
+
+    @property
+    def fc_dev_no(self) -> int:
+        return self.fc_npu_backend.dev_no
+
+    @fc_dev_no.setter
+    def fc_dev_no(self, value: int) -> None:
+        self.fc_npu_backend.dev_no = value
+
+    @property
+    def base_max_batch_size(self) -> int:
+        return self.base_npu_backend.max_batch_size
+
+    @base_max_batch_size.setter
+    def base_max_batch_size(self, value: int) -> None:
+        self.base_npu_backend.max_batch_size = max(1, value)
+
+    @property
+    def draft_max_batch_size(self) -> int:
+        return self.draft_npu_backend.max_batch_size
+
+    @draft_max_batch_size.setter
+    def draft_max_batch_size(self, value: int) -> None:
+        self.draft_npu_backend.max_batch_size = max(1, value)
+
+    @property
+    def fc_max_batch_size(self) -> int:
+        return self.fc_npu_backend.max_batch_size
+
+    @fc_max_batch_size.setter
+    def fc_max_batch_size(self, value: int) -> None:
+        self.fc_npu_backend.max_batch_size = max(1, value)
 
     @property
     def base_core_mode(self) -> str:

--- a/tests/transformers/test_subconfig_core_mode_propagate.py
+++ b/tests/transformers/test_subconfig_core_mode_propagate.py
@@ -331,3 +331,180 @@ def test_extract_subconfig_pipeline_kwargs_from_namespace() -> None:
     assert options.text_target_clusters == [1]
     assert options.text_mxq_path == "/tmp/text.mxq"
     assert options.vision_target_cores == ["0:0"]
+
+
+def test_append_asr_subconfig_core_mode_suffix_noop_without_overrides() -> None:
+    """Verify no suffix is added when neither encoder nor decoder overrides are set."""
+    label, base = asr_bench._append_asr_subconfig_core_mode_suffix(
+        "openai/whisper-tiny-single",
+        "openai__whisper-tiny-single",
+        "single",
+    )
+    assert label == "openai/whisper-tiny-single"
+    assert base == "openai__whisper-tiny-single"
+
+
+def test_append_asr_subconfig_core_mode_suffix_noop_when_matches_base() -> None:
+    """Verify a subconfig override that matches the base core mode adds no suffix."""
+    label, base = asr_bench._append_asr_subconfig_core_mode_suffix(
+        "openai/whisper-tiny-single",
+        "openai__whisper-tiny-single",
+        "single",
+        encoder_core_mode="single",
+        decoder_core_mode="single",
+    )
+    assert label == "openai/whisper-tiny-single"
+    assert base == "openai__whisper-tiny-single"
+
+
+def test_append_asr_subconfig_core_mode_suffix_encoder_only() -> None:
+    """Verify encoder-only overrides append an `enc<mode>` suffix."""
+    label, base = asr_bench._append_asr_subconfig_core_mode_suffix(
+        "openai/whisper-tiny-single",
+        "openai__whisper-tiny-single",
+        "single",
+        encoder_core_mode="global8",
+    )
+    assert label == "openai/whisper-tiny-single-encglobal8"
+    assert base == "openai__whisper-tiny-single-encglobal8"
+
+
+def test_append_asr_subconfig_core_mode_suffix_decoder_only() -> None:
+    """Verify decoder-only overrides append a `dec<mode>` suffix."""
+    label, base = asr_bench._append_asr_subconfig_core_mode_suffix(
+        "openai/whisper-tiny-single",
+        "openai__whisper-tiny-single",
+        "single",
+        decoder_core_mode="global4",
+    )
+    assert label == "openai/whisper-tiny-single-decglobal4"
+    assert base == "openai__whisper-tiny-single-decglobal4"
+
+
+def test_append_asr_subconfig_core_mode_suffix_encoder_and_decoder() -> None:
+    """Verify both overrides combine into an `enc<mode>-dec<mode>` suffix."""
+    label, base = asr_bench._append_asr_subconfig_core_mode_suffix(
+        "openai/whisper-tiny-single",
+        "openai__whisper-tiny-single",
+        "single",
+        encoder_core_mode="global8",
+        decoder_core_mode="global4",
+    )
+    assert label == "openai/whisper-tiny-single-encglobal8-decglobal4"
+    assert base == "openai__whisper-tiny-single-encglobal8-decglobal4"
+
+
+def test_asr_build_run_targets_distinguishes_subconfig_variants() -> None:
+    """Verify _build_run_targets writes distinct mode_base values per encoder/decoder combo."""
+    common_flags = [
+        "--model",
+        "openai/whisper-tiny",
+        "--core-mode",
+        "single",
+    ]
+
+    default_base = asr_bench._build_run_targets(asr_bench._parse_args(common_flags))[0][3]
+    encoder_override_base = asr_bench._build_run_targets(
+        asr_bench._parse_args(common_flags + ["--encoder-core-mode", "global8"])
+    )[0][3]
+    decoder_override_base = asr_bench._build_run_targets(
+        asr_bench._parse_args(common_flags + ["--decoder-core-mode", "global4"])
+    )[0][3]
+    both_override_base = asr_bench._build_run_targets(
+        asr_bench._parse_args(
+            common_flags
+            + ["--encoder-core-mode", "global8", "--decoder-core-mode", "global4"]
+        )
+    )[0][3]
+
+    assert default_base.endswith("-single")
+    assert encoder_override_base.endswith("-single-encglobal8")
+    assert decoder_override_base.endswith("-single-decglobal4")
+    assert both_override_base.endswith("-single-encglobal8-decglobal4")
+    assert len({default_base, encoder_override_base, decoder_override_base, both_override_base}) == 4
+
+
+def test_asr_build_run_targets_ignores_subconfig_for_non_encoder_decoder_models() -> None:
+    """Verify non encoder-decoder ASR models keep the current mode_base layout."""
+    args = asr_bench._parse_args(
+        [
+            "--model",
+            "facebook/wav2vec2-base-960h",
+            "--core-mode",
+            "single",
+            "--encoder-core-mode",
+            "global8",
+        ]
+    )
+    mode_base = asr_bench._build_run_targets(args)[0][3]
+
+    assert mode_base.endswith("-single")
+    assert "enc" not in mode_base.split("-single", 1)[1]
+
+
+def test_asr_write_target_json_records_subconfig_core_modes(tmp_path) -> None:
+    """Verify _write_target_json records encoder/decoder core-mode fields in the payload."""
+    import json
+
+    target = asr_bench.ASRBenchmarkTarget(
+        model_id="openai/whisper-tiny",
+        revision_candidates=[None],
+        label="openai/whisper-tiny",
+        base="openai__whisper-tiny",
+        mxq_path=None,
+        is_original=False,
+    )
+    args = asr_bench._parse_args(
+        [
+            "--num-beams",
+            "1",
+            "--encoder-core-mode",
+            "global8",
+            "--decoder-core-mode",
+            "global4",
+        ]
+    )
+    summary = asr_bench.ASRMetricSummary(
+        num_samples=1,
+        total_audio_s=1.0,
+        total_generate_s=0.5,
+        wer=0.0,
+        cer=0.0,
+        mean_latency_s=0.5,
+        p50_latency_s=0.5,
+        p95_latency_s=0.5,
+        throughput_samples_per_s=2.0,
+        rtf=0.5,
+        inverse_rtf=2.0,
+        decode_tokens_per_s=10.0,
+        avg_tokens_per_sample=5.0,
+    )
+    timing = asr_bench.SampleTiming(
+        sample_id="s1",
+        audio_duration_s=1.0,
+        generate_time_s=0.5,
+        num_generated_tokens=5,
+        num_beams=1,
+        reference="hello",
+        hypothesis="hello",
+        effective_generate_kwargs={"num_beams": 1},
+    )
+    out_path = tmp_path / "whisper-tiny-single-encglobal8-decglobal4_beams1.json"
+
+    asr_bench._write_target_json(
+        out_path,
+        target=target,
+        label="openai/whisper-tiny-single-encglobal8-decglobal4",
+        args=args,
+        revision=None,
+        core_mode="single",
+        summary=summary,
+        device_metric={},
+        device_trace={},
+        sample_timings=[timing],
+    )
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["core_mode"] == "single"
+    assert payload["encoder_core_mode"] == "global8"
+    assert payload["decoder_core_mode"] == "global4"

--- a/tests/transformers/test_subconfig_core_mode_propagate.py
+++ b/tests/transformers/test_subconfig_core_mode_propagate.py
@@ -1,0 +1,333 @@
+"""Tests for base->subconfig core-mode propagation across CLI and benchmark entry points."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+_TRANSFORMERS_BENCHMARK_DIR = Path(__file__).resolve().parents[2] / "benchmark" / "transformers"
+if str(_TRANSFORMERS_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_TRANSFORMERS_BENCHMARK_DIR))
+
+from benchmark.transformers import benchmark_automatic_speech_recognition_models as asr_bench  # noqa: E402
+from benchmark.transformers import benchmark_image_text_to_text_models as vlm_bench  # noqa: E402
+from mblt_model_zoo.cli import tps as tps_cli  # noqa: E402
+from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (  # noqa: E402
+    apply_subconfig_core_mode_model_kwargs,
+    coalesce_subconfig,
+)
+
+
+def test_coalesce_subconfig_prefers_override() -> None:
+    """Verify explicit subconfig value wins over base fallback."""
+    assert coalesce_subconfig("global4", "single") == "global4"
+
+
+def test_coalesce_subconfig_falls_back_to_base_when_missing() -> None:
+    """Verify base value is used when the subconfig value is None."""
+    assert coalesce_subconfig(None, "single") == "single"
+
+
+def test_coalesce_subconfig_keeps_none_when_both_missing() -> None:
+    """Verify neither override nor base results in None."""
+    assert coalesce_subconfig(None, None) is None
+
+
+def test_apply_subconfig_core_mode_propagates_base_to_all_prefixes() -> None:
+    """Verify base core mode fills in every subconfig when no override is set."""
+    kwargs = apply_subconfig_core_mode_model_kwargs(
+        {},
+        ("vision", "text"),
+        "single",
+    )
+    assert kwargs == {
+        "vision_core_mode": "single",
+        "vision_target_cores": ["0:0"],
+        "text_core_mode": "single",
+        "text_target_cores": ["0:0"],
+    }
+
+
+def test_apply_subconfig_core_mode_lets_one_subconfig_override() -> None:
+    """Verify a per-subconfig core mode replaces the base value for that prefix only."""
+    kwargs = apply_subconfig_core_mode_model_kwargs(
+        {},
+        ("vision", "text"),
+        "single",
+        subconfig_core_modes={"vision": "global8"},
+    )
+    assert kwargs == {
+        "vision_core_mode": "global8",
+        "vision_target_clusters": [0, 1],
+        "text_core_mode": "single",
+        "text_target_cores": ["0:0"],
+    }
+
+
+def test_apply_subconfig_core_mode_without_base_keeps_none() -> None:
+    """Verify omitting base and subconfig values leaves everything unset."""
+    kwargs = apply_subconfig_core_mode_model_kwargs(
+        {},
+        ("vision", "text"),
+        None,
+    )
+    assert kwargs == {}
+
+
+def test_apply_subconfig_core_mode_supports_encoder_decoder() -> None:
+    """Verify encoder-decoder prefixes get their base fallback and overrides."""
+    kwargs = apply_subconfig_core_mode_model_kwargs(
+        {},
+        ("encoder", "decoder"),
+        "single",
+        subconfig_core_modes={"decoder": "global4"},
+    )
+    assert kwargs["encoder_core_mode"] == "single"
+    assert kwargs["decoder_core_mode"] == "global4"
+    assert kwargs["encoder_target_cores"] == ["0:0"]
+    assert kwargs["decoder_target_clusters"] == [0]
+
+
+def test_apply_subconfig_core_mode_forwards_target_overrides() -> None:
+    """Verify target-cores and target-clusters follow the same fallback rule."""
+    kwargs = apply_subconfig_core_mode_model_kwargs(
+        {},
+        ("vision", "text"),
+        "single",
+        base_target_cores=["0:1"],
+        subconfig_target_cores={"text": ["0:2"]},
+    )
+    assert kwargs["vision_target_cores"] == ["0:1"]
+    assert kwargs["text_target_cores"] == ["0:2"]
+
+
+def test_apply_subconfig_core_mode_forwards_mxq_paths() -> None:
+    """Verify per-subconfig mxq paths override the base fallback."""
+    kwargs = apply_subconfig_core_mode_model_kwargs(
+        {},
+        ("vision", "text"),
+        None,
+        base_mxq_path="/base.mxq",
+        subconfig_mxq_paths={"vision": "/vision.mxq"},
+    )
+    assert kwargs["vision_mxq_path"] == "/vision.mxq"
+    assert kwargs["text_mxq_path"] == "/base.mxq"
+
+
+def test_vlm_benchmark_helper_uses_vision_override() -> None:
+    """Verify VLM benchmark helper honors vision override with text fallback."""
+    kwargs = vlm_bench._apply_vlm_core_mode_model_kwargs(
+        {},
+        "single",
+        vision_core_mode="global8",
+    )
+    assert kwargs["vision_core_mode"] == "global8"
+    assert kwargs["text_core_mode"] == "single"
+
+
+def test_asr_benchmark_helper_uses_encoder_decoder_overrides() -> None:
+    """Verify ASR encoder-decoder helper propagates base to unset prefixes."""
+    kwargs = asr_bench._apply_asr_core_mode_model_kwargs(
+        {},
+        "openai/whisper-tiny",
+        "single",
+        encoder_core_mode="global8",
+    )
+    assert kwargs["encoder_core_mode"] == "global8"
+    assert kwargs["decoder_core_mode"] == "single"
+
+
+def test_asr_benchmark_helper_ignores_subconfig_for_non_encoder_decoder() -> None:
+    """Verify non encoder-decoder ASR models keep top-level core-mode kwargs untouched."""
+    kwargs = asr_bench._apply_asr_core_mode_model_kwargs(
+        {},
+        "some/plain-asr-model",
+        "single",
+        encoder_core_mode="global8",
+    )
+    assert kwargs.get("core_mode") == "single"
+    assert "encoder_core_mode" not in kwargs
+
+
+def test_asr_benchmark_parser_accepts_encoder_decoder_core_modes() -> None:
+    """Verify the ASR benchmark CLI parses encoder/decoder core-mode options."""
+    args = asr_bench._parse_args(["--core-mode", "single", "--encoder-core-mode", "global8"])
+    assert args.encoder_core_mode == "global8"
+    assert args.decoder_core_mode is None
+    assert args.core_mode == "single"
+
+
+def test_vlm_benchmark_parser_accepts_vision_text_core_modes() -> None:
+    """Verify the VLM benchmark CLI parses vision/text core-mode options for measure and sweep."""
+    parser = vlm_bench._build_arg_parser()
+    for command in ("measure", "sweep"):
+        args = parser.parse_args(
+            [command, "--core-mode", "single", "--vision-core-mode", "global8"]
+        )
+        assert args.vision_core_mode == "global8"
+        assert args.text_core_mode is None
+        assert args.core_mode == "single"
+
+
+def test_tps_cli_parser_accepts_vlm_subconfig_options() -> None:
+    """Verify the TPS CLI parses vision/text subconfig options for measure and sweep."""
+    from mblt_model_zoo.cli.main import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "tps",
+            "measure",
+            "--task",
+            "image-text-to-text",
+            "--model",
+            "mobilint/vlm",
+            "--core-mode",
+            "single",
+            "--vision-core-mode",
+            "global8",
+            "--text-mxq-path",
+            "/tmp/text.mxq",
+        ]
+    )
+    assert args.vision_core_mode == "global8"
+    assert args.text_core_mode is None
+    assert args.core_mode == "single"
+    assert args.text_mxq_path == "/tmp/text.mxq"
+
+
+def test_tps_cli_build_pipeline_vlm_propagates_subconfig(monkeypatch) -> None:
+    """Verify TPS `_build_pipeline` threads subconfig overrides for a VLM task."""
+    captured: dict[str, object] = {}
+
+    def _fake_pipeline(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model_kwargs=kwargs.get("model_kwargs", {}))
+
+    monkeypatch.setattr(tps_cli, "_require_transformers_deps", lambda: None)
+    monkeypatch.setattr(importlib.import_module("transformers"), "pipeline", _fake_pipeline)
+
+    subconfig_options = tps_cli.SubconfigPipelineOptions(vision_core_mode="global8")
+
+    tps_cli._build_pipeline(
+        task="image-text-to-text",
+        model="mobilint/vlm",
+        tokenizer=None,
+        device="cpu",
+        trust_remote_code=True,
+        dtype=None,
+        device_map=None,
+        revision=None,
+        embedding_weight=None,
+        eagle3_options=tps_cli.Eagle3PipelineOptions(),
+        mxq_path=None,
+        core_mode="single",
+        target_cores=None,
+        target_clusters=None,
+        default_single_target_cores=("0:0",),
+        subconfig_options=subconfig_options,
+    )
+
+    model_kwargs = captured["model_kwargs"]
+    assert isinstance(model_kwargs, dict)
+    assert model_kwargs["vision_core_mode"] == "global8"
+    assert model_kwargs["text_core_mode"] == "single"
+    assert model_kwargs["vision_target_clusters"] == [0, 1]
+    assert model_kwargs["text_target_cores"] == ["0:0"]
+
+
+def test_tps_cli_build_pipeline_vlm_base_only_propagates_to_both(monkeypatch) -> None:
+    """Verify VLM base-only core mode is applied to both vision and text subconfigs."""
+    captured: dict[str, object] = {}
+
+    def _fake_pipeline(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model_kwargs=kwargs.get("model_kwargs", {}))
+
+    monkeypatch.setattr(tps_cli, "_require_transformers_deps", lambda: None)
+    monkeypatch.setattr(importlib.import_module("transformers"), "pipeline", _fake_pipeline)
+
+    tps_cli._build_pipeline(
+        task="image-text-to-text",
+        model="mobilint/vlm",
+        tokenizer=None,
+        device="cpu",
+        trust_remote_code=True,
+        dtype=None,
+        device_map=None,
+        revision=None,
+        embedding_weight=None,
+        eagle3_options=tps_cli.Eagle3PipelineOptions(),
+        mxq_path=None,
+        core_mode="global4",
+        target_cores=None,
+        target_clusters=None,
+        default_single_target_cores=("0:0",),
+    )
+
+    model_kwargs = captured["model_kwargs"]
+    assert model_kwargs["vision_core_mode"] == "global4"
+    assert model_kwargs["text_core_mode"] == "global4"
+    assert model_kwargs["vision_target_clusters"] == [0]
+    assert model_kwargs["text_target_clusters"] == [0]
+
+
+def test_tps_cli_build_pipeline_vlm_subconfig_mxq_overrides_base_mxq(monkeypatch) -> None:
+    """Verify per-subconfig mxq path overrides do not collide with base mxq_path."""
+    captured: dict[str, object] = {}
+
+    def _fake_pipeline(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model_kwargs=kwargs.get("model_kwargs", {}))
+
+    monkeypatch.setattr(tps_cli, "_require_transformers_deps", lambda: None)
+    monkeypatch.setattr(importlib.import_module("transformers"), "pipeline", _fake_pipeline)
+
+    subconfig_options = tps_cli.SubconfigPipelineOptions(vision_mxq_path="/tmp/vision.mxq")
+
+    tps_cli._build_pipeline(
+        task="image-text-to-text",
+        model="mobilint/vlm",
+        tokenizer=None,
+        device="cpu",
+        trust_remote_code=True,
+        dtype=None,
+        device_map=None,
+        revision=None,
+        embedding_weight=None,
+        eagle3_options=tps_cli.Eagle3PipelineOptions(),
+        mxq_path="/tmp/global.mxq",
+        core_mode="single",
+        target_cores=None,
+        target_clusters=None,
+        default_single_target_cores=("0:0",),
+        subconfig_options=subconfig_options,
+    )
+
+    model_kwargs = captured["model_kwargs"]
+    assert model_kwargs["mxq_path"] == "/tmp/global.mxq"
+    assert model_kwargs["vision_mxq_path"] == "/tmp/vision.mxq"
+    assert "text_mxq_path" not in model_kwargs
+
+
+def test_extract_subconfig_pipeline_kwargs_from_namespace() -> None:
+    """Verify subconfig option extraction reads all recognized fields from CLI args."""
+    import argparse
+
+    args = argparse.Namespace(
+        vision_core_mode="global8",
+        text_core_mode=None,
+        vision_target_cores=["0:0"],
+        text_target_cores=None,
+        vision_target_clusters=None,
+        text_target_clusters=[1],
+        vision_mxq_path=None,
+        text_mxq_path="/tmp/text.mxq",
+    )
+    options = tps_cli._extract_subconfig_pipeline_kwargs(args)
+    assert options.vision_core_mode == "global8"
+    assert options.text_target_clusters == [1]
+    assert options.text_mxq_path == "/tmp/text.mxq"
+    assert options.vision_target_cores == ["0:0"]

--- a/tests/transformers/test_subconfig_core_mode_propagate.py
+++ b/tests/transformers/test_subconfig_core_mode_propagate.py
@@ -559,6 +559,100 @@ def test_resolve_asr_subconfig_core_modes_keeps_overrides_without_original_model
     assert asr_bench._resolve_asr_subconfig_core_modes(args) == ("global8", "global4")
 
 
+def test_asr_build_run_targets_drops_subconfig_suffix_for_original_native(monkeypatch) -> None:
+    """Verify --original-models without --mxq-dir strips enc/dec suffixes from filenames.
+
+    The pipeline is called with encoder/decoder_core_mode=None in this case, so the
+    generated filename must not claim overrides that never reached the model.
+    """
+    monkeypatch.setattr(asr_bench, "_resolve_original_model_ids", lambda model_ids: list(model_ids))
+    args = asr_bench._parse_args(
+        [
+            "--model",
+            "openai/whisper-tiny",
+            "--original-models",
+            "--encoder-core-mode",
+            "global8",
+            "--decoder-core-mode",
+            "global4",
+        ]
+    )
+    mode_base = asr_bench._build_run_targets(args)[0][3]
+    assert "-enc" not in mode_base
+    assert "-dec" not in mode_base
+
+
+def test_asr_write_target_json_drops_subconfig_core_modes_for_original_native(tmp_path) -> None:
+    """Verify _write_target_json records None for encoder/decoder core-mode on native original runs."""
+    import json
+
+    target = asr_bench.ASRBenchmarkTarget(
+        model_id="openai/whisper-tiny",
+        revision_candidates=[None],
+        label="openai/whisper-tiny",
+        base="openai__whisper-tiny",
+        mxq_path=None,
+        is_original=True,
+    )
+    args = asr_bench._parse_args(
+        [
+            "--model",
+            "openai/whisper-tiny",
+            "--original-models",
+            "--num-beams",
+            "1",
+            "--encoder-core-mode",
+            "global8",
+            "--decoder-core-mode",
+            "global4",
+        ]
+    )
+    summary = asr_bench.ASRMetricSummary(
+        num_samples=1,
+        total_audio_s=1.0,
+        total_generate_s=0.5,
+        wer=0.0,
+        cer=0.0,
+        mean_latency_s=0.5,
+        p50_latency_s=0.5,
+        p95_latency_s=0.5,
+        throughput_samples_per_s=2.0,
+        rtf=0.5,
+        inverse_rtf=2.0,
+        decode_tokens_per_s=10.0,
+        avg_tokens_per_sample=5.0,
+    )
+    timing = asr_bench.SampleTiming(
+        sample_id="s1",
+        audio_duration_s=1.0,
+        generate_time_s=0.5,
+        num_generated_tokens=5,
+        num_beams=1,
+        reference="hello",
+        hypothesis="hello",
+        effective_generate_kwargs={"num_beams": 1},
+    )
+    out_path = tmp_path / "whisper-tiny_beams1.json"
+
+    asr_bench._write_target_json(
+        out_path,
+        target=target,
+        label="openai/whisper-tiny",
+        args=args,
+        revision=None,
+        core_mode=None,
+        summary=summary,
+        device_metric={},
+        device_trace={},
+        sample_timings=[timing],
+    )
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["core_mode"] is None
+    assert payload["encoder_core_mode"] is None
+    assert payload["decoder_core_mode"] is None
+
+
 def test_build_asr_pipeline_no_subconfig_kwargs_when_disabled(monkeypatch) -> None:
     """Verify _build_asr_pipeline with encoder/decoder=None doesn't leak subconfig kwargs.
 

--- a/tests/transformers/test_subconfig_core_mode_propagate.py
+++ b/tests/transformers/test_subconfig_core_mode_propagate.py
@@ -508,3 +508,98 @@ def test_asr_write_target_json_records_subconfig_core_modes(tmp_path) -> None:
     assert payload["core_mode"] == "single"
     assert payload["encoder_core_mode"] == "global8"
     assert payload["decoder_core_mode"] == "global4"
+
+
+def test_resolve_asr_subconfig_core_modes_drops_overrides_for_original_native_runs() -> None:
+    """Verify --original-models without --mxq-dir yields (None, None) for subconfig core modes."""
+    args = asr_bench._parse_args(
+        [
+            "--model",
+            "openai/whisper-tiny",
+            "--original-models",
+            "--core-mode",
+            "single",
+            "--encoder-core-mode",
+            "global8",
+            "--decoder-core-mode",
+            "global4",
+        ]
+    )
+    assert asr_bench._resolve_asr_subconfig_core_modes(args) == (None, None)
+
+
+def test_resolve_asr_subconfig_core_modes_keeps_overrides_with_mxq_dir(tmp_path) -> None:
+    """Verify --original-models WITH --mxq-dir still keeps encoder/decoder overrides."""
+    args = asr_bench._parse_args(
+        [
+            "--original-models",
+            "--mxq-dir",
+            str(tmp_path),
+            "--encoder-core-mode",
+            "global8",
+            "--decoder-core-mode",
+            "global4",
+        ]
+    )
+    assert asr_bench._resolve_asr_subconfig_core_modes(args) == ("global8", "global4")
+
+
+def test_resolve_asr_subconfig_core_modes_keeps_overrides_without_original_models() -> None:
+    """Verify overrides pass through when --original-models is not set."""
+    args = asr_bench._parse_args(
+        [
+            "--model",
+            "openai/whisper-tiny",
+            "--encoder-core-mode",
+            "global8",
+            "--decoder-core-mode",
+            "global4",
+        ]
+    )
+    assert asr_bench._resolve_asr_subconfig_core_modes(args) == ("global8", "global4")
+
+
+def test_build_asr_pipeline_no_subconfig_kwargs_when_disabled(monkeypatch) -> None:
+    """Verify _build_asr_pipeline with encoder/decoder=None doesn't leak subconfig kwargs.
+
+    Mirrors what ``main()`` passes when the shared --core-mode is ignored for
+    original-model native runs.
+    """
+    captured: dict[str, object] = {}
+
+    def _fake_pipeline(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model=types.SimpleNamespace(generation_config=None))
+
+    import transformers  # local import to avoid module-import time cost
+
+    monkeypatch.setattr(transformers, "pipeline", _fake_pipeline)
+
+    target = asr_bench.ASRBenchmarkTarget(
+        model_id="openai/whisper-tiny",
+        revision_candidates=[None],
+        label="openai/whisper-tiny",
+        base="openai__whisper-tiny",
+        mxq_path=None,
+        is_original=True,
+    )
+    asr_bench._build_asr_pipeline(
+        target,
+        revision=None,
+        device=None,
+        device_map=None,
+        dtype=None,
+        trust_remote_code=True,
+        core_mode=None,
+        native_generate_kwargs=None,
+        encoder_core_mode=None,
+        decoder_core_mode=None,
+    )
+
+    model_kwargs = captured.get("model_kwargs", {})
+    assert "encoder_core_mode" not in model_kwargs
+    assert "decoder_core_mode" not in model_kwargs
+    assert "encoder_target_cores" not in model_kwargs
+    assert "decoder_target_cores" not in model_kwargs
+    assert "encoder_target_clusters" not in model_kwargs
+    assert "decoder_target_clusters" not in model_kwargs

--- a/tests/transformers/test_tps_cli_subconfig_mxq_device_defaults.py
+++ b/tests/transformers/test_tps_cli_subconfig_mxq_device_defaults.py
@@ -1,0 +1,135 @@
+"""Tests for TPS CLI device-default resolution when only subconfig MXQ paths are given.
+
+The TPS CLI treats any MXQ artifact as a signal to prefer CPU/NPU defaults, but the
+subconfig-scoped ``--vision-mxq-path`` / ``--text-mxq-path`` / EAGLE-3 prefix paths must
+count the same as the base ``--mxq-path`` so a non-``mobilint/`` model still gets the
+NPU-oriented defaults without extra flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from mblt_model_zoo.cli import tps as tps_cli
+
+
+_NON_MOBILINT_MODEL = "someorg/some-model"
+
+
+def _base_args(**overrides: object) -> argparse.Namespace:
+    """Return an argparse Namespace shaped like the TPS CLI after argparse runs."""
+    ns = argparse.Namespace(
+        model=_NON_MOBILINT_MODEL,
+        device=None,
+        device_backend=None,
+        mxq_path=None,
+        base_mxq_path=None,
+        draft_mxq_path=None,
+        fc_mxq_path=None,
+        vision_mxq_path=None,
+        text_mxq_path=None,
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_vision_mxq_path_triggers_npu_defaults_without_base_mxq_path() -> None:
+    """Only ``--vision-mxq-path`` on a non-mobilint model should still pick CPU/NPU."""
+    args = _base_args(vision_mxq_path="/tmp/vision.mxq")
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cpu"
+    assert args.device_backend == "npu"
+
+
+def test_text_mxq_path_triggers_npu_defaults_without_base_mxq_path() -> None:
+    """Only ``--text-mxq-path`` on a non-mobilint model should still pick CPU/NPU."""
+    args = _base_args(text_mxq_path="/tmp/text.mxq")
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cpu"
+    assert args.device_backend == "npu"
+
+
+@pytest.mark.parametrize("attr", ["base_mxq_path", "draft_mxq_path", "fc_mxq_path"])
+def test_eagle3_prefix_mxq_path_triggers_npu_defaults(attr: str) -> None:
+    """Any EAGLE-3 prefix MXQ path should also steer defaults toward CPU/NPU."""
+    args = _base_args(**{attr: f"/tmp/{attr}.mxq"})
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cpu"
+    assert args.device_backend == "npu"
+
+
+def test_base_mxq_path_alone_still_triggers_npu_defaults() -> None:
+    """Existing behavior: ``--mxq-path`` on a non-mobilint model resolves to CPU/NPU."""
+    args = _base_args(mxq_path="/tmp/global.mxq")
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cpu"
+    assert args.device_backend == "npu"
+
+
+def test_no_mxq_path_on_non_mobilint_model_keeps_gpu_defaults() -> None:
+    """Without any MXQ artifact, a non-mobilint model should default to cuda/gpu."""
+    args = _base_args()
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cuda"
+    assert args.device_backend == "gpu"
+
+
+def test_explicit_device_and_backend_are_preserved_with_subconfig_mxq() -> None:
+    """Explicit ``--device`` / ``--device-backend`` must win over the subconfig-derived default."""
+    args = _base_args(
+        vision_mxq_path="/tmp/vision.mxq",
+        device="cuda:0",
+        device_backend="gpu",
+    )
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cuda:0"
+    assert args.device_backend == "gpu"
+
+
+def test_effective_mxq_path_prefers_base_over_subconfig() -> None:
+    """When both base and subconfig MXQ paths are set, the base one is used for the decision."""
+    args = _base_args(
+        mxq_path="/tmp/global.mxq",
+        vision_mxq_path="/tmp/vision.mxq",
+    )
+
+    assert tps_cli._effective_mxq_path_for_defaults(args) == "/tmp/global.mxq"
+
+
+def test_effective_mxq_path_returns_none_when_all_absent() -> None:
+    """No MXQ path should yield ``None`` so the resolver keeps its non-mobilint branch."""
+    args = _base_args()
+
+    assert tps_cli._effective_mxq_path_for_defaults(args) is None
+
+
+def test_effective_mxq_path_tolerates_missing_attrs() -> None:
+    """Older Namespaces without every MXQ attribute must not raise AttributeError."""
+    ns = argparse.Namespace(model=_NON_MOBILINT_MODEL, vision_mxq_path="/tmp/vision.mxq")
+
+    assert tps_cli._effective_mxq_path_for_defaults(ns) == "/tmp/vision.mxq"
+
+
+def test_mobilint_model_id_still_wins_without_any_mxq_path() -> None:
+    """A ``mobilint/`` model id keeps the CPU/NPU defaults independently of this change."""
+    args = _base_args(model="mobilint/some-model")
+
+    tps_cli._normalize_runtime_defaults(args)
+
+    assert args.device == "cpu"
+    assert args.device_backend == "npu"

--- a/tests/transformers/test_vlm_benchmark_subconfig_result_keys.py
+++ b/tests/transformers/test_vlm_benchmark_subconfig_result_keys.py
@@ -1,0 +1,211 @@
+"""Tests for VLM benchmark result-key identity when vision/text subconfig core modes differ."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_TRANSFORMERS_BENCHMARK_DIR = Path(__file__).resolve().parents[2] / "benchmark" / "transformers"
+if str(_TRANSFORMERS_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_TRANSFORMERS_BENCHMARK_DIR))
+
+from benchmark.transformers import benchmark_image_text_to_text_models as vlm_bench  # noqa: E402
+from benchmark.transformers.benchmark_text_generation_models import (  # noqa: E402
+    TextBenchmarkTarget,
+)
+
+
+def test_append_vlm_subconfig_core_mode_suffix_noop_without_overrides() -> None:
+    """Verify no suffix is added when neither vision nor text overrides are set."""
+    label, base = vlm_bench._append_vlm_subconfig_core_mode_suffix(
+        "Qwen/Qwen2-VL-2B-single",
+        "Qwen__Qwen2-VL-2B-single",
+        "single",
+    )
+    assert label == "Qwen/Qwen2-VL-2B-single"
+    assert base == "Qwen__Qwen2-VL-2B-single"
+
+
+def test_append_vlm_subconfig_core_mode_suffix_noop_when_matches_base() -> None:
+    """Verify a subconfig override that matches the base core mode adds no suffix."""
+    label, base = vlm_bench._append_vlm_subconfig_core_mode_suffix(
+        "Qwen/Qwen2-VL-2B-single",
+        "Qwen__Qwen2-VL-2B-single",
+        "single",
+        vision_core_mode="single",
+        text_core_mode="single",
+    )
+    assert label == "Qwen/Qwen2-VL-2B-single"
+    assert base == "Qwen__Qwen2-VL-2B-single"
+
+
+def test_append_vlm_subconfig_core_mode_suffix_vision_only() -> None:
+    """Verify vision-only overrides append a `vis<mode>` suffix."""
+    label, base = vlm_bench._append_vlm_subconfig_core_mode_suffix(
+        "Qwen/Qwen2-VL-2B-single",
+        "Qwen__Qwen2-VL-2B-single",
+        "single",
+        vision_core_mode="global8",
+    )
+    assert label == "Qwen/Qwen2-VL-2B-single-visglobal8"
+    assert base == "Qwen__Qwen2-VL-2B-single-visglobal8"
+
+
+def test_append_vlm_subconfig_core_mode_suffix_text_only() -> None:
+    """Verify text-only overrides append a `txt<mode>` suffix."""
+    label, base = vlm_bench._append_vlm_subconfig_core_mode_suffix(
+        "Qwen/Qwen2-VL-2B-single",
+        "Qwen__Qwen2-VL-2B-single",
+        "single",
+        text_core_mode="global4",
+    )
+    assert label == "Qwen/Qwen2-VL-2B-single-txtglobal4"
+    assert base == "Qwen__Qwen2-VL-2B-single-txtglobal4"
+
+
+def test_append_vlm_subconfig_core_mode_suffix_vision_and_text() -> None:
+    """Verify both overrides combine into a `vis<mode>-txt<mode>` suffix."""
+    label, base = vlm_bench._append_vlm_subconfig_core_mode_suffix(
+        "Qwen/Qwen2-VL-2B-single",
+        "Qwen__Qwen2-VL-2B-single",
+        "single",
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )
+    assert label == "Qwen/Qwen2-VL-2B-single-visglobal8-txtglobal4"
+    assert base == "Qwen__Qwen2-VL-2B-single-visglobal8-txtglobal4"
+
+
+def test_append_vlm_subconfig_core_mode_suffix_handles_none_base() -> None:
+    """Verify overrides still apply when the base core_mode is None (e.g., --original-models)."""
+    label, base = vlm_bench._append_vlm_subconfig_core_mode_suffix(
+        "Qwen/Qwen2-VL-2B",
+        "Qwen__Qwen2-VL-2B",
+        None,
+        vision_core_mode="global8",
+    )
+    assert label == "Qwen/Qwen2-VL-2B-visglobal8"
+    assert base == "Qwen__Qwen2-VL-2B-visglobal8"
+
+
+def test_vlm_subconfig_core_mode_payload_fields_default() -> None:
+    """Verify payload fields are None when subconfig overrides are absent."""
+    args = argparse.Namespace(vision_core_mode=None, text_core_mode=None)
+    fields = vlm_bench._vlm_subconfig_core_mode_payload_fields(args, "single")
+    assert fields == {
+        "core_mode": "single",
+        "vision_core_mode": None,
+        "text_core_mode": None,
+    }
+
+
+def test_vlm_subconfig_core_mode_payload_fields_with_overrides() -> None:
+    """Verify payload fields capture the effective per-subconfig core modes."""
+    args = argparse.Namespace(vision_core_mode="global8", text_core_mode="global4")
+    fields = vlm_bench._vlm_subconfig_core_mode_payload_fields(args, "single")
+    assert fields == {
+        "core_mode": "single",
+        "vision_core_mode": "global8",
+        "text_core_mode": "global4",
+    }
+
+
+def test_vlm_subconfig_core_mode_payload_fields_missing_attrs() -> None:
+    """Verify the helper tolerates argparse namespaces missing vision/text attrs."""
+    args = argparse.Namespace()
+    fields = vlm_bench._vlm_subconfig_core_mode_payload_fields(args, None)
+    assert fields == {
+        "core_mode": None,
+        "vision_core_mode": None,
+        "text_core_mode": None,
+    }
+
+
+def _make_text_target(model_id: str = "Qwen/Qwen2-VL-2B") -> TextBenchmarkTarget:
+    return TextBenchmarkTarget(
+        model_id=model_id,
+        revision_candidates=[None],
+        label=model_id,
+        base=model_id.replace("/", "__"),
+        mxq_path=None,
+        max_batch_size=1,
+        batch_mode="non_batch",
+    )
+
+
+def _mode_bases_for(
+    monkeypatch,
+    *,
+    core_mode: str,
+    vision_core_mode: str | None = None,
+    text_core_mode: str | None = None,
+) -> list[str]:
+    """Drive `_collect_vlm_run_targets` with stubbed deps and return the mode_bases."""
+
+    text_target = _make_text_target()
+    monkeypatch.setattr(
+        vlm_bench,
+        "_iter_targets",
+        lambda model_ids, revision, all_revisions: [
+            (text_target.model_id, None, text_target.label, text_target.base)
+        ],
+    )
+    monkeypatch.setattr(
+        vlm_bench,
+        "_filter_text_targets_by_batch_mode",
+        lambda raw_targets, *, batch_mode=None, task=None: [text_target],
+    )
+    monkeypatch.setattr(
+        vlm_bench,
+        "_iter_core_modes_for_target",
+        lambda args, batch_mode, disable_npu_specific_args=False: [core_mode],
+    )
+    args = argparse.Namespace(
+        models=[text_target.model_id],
+        mxq_dir=None,
+        mxq_path=None,
+        revision=None,
+        all=False,
+        original_models=False,
+        batch_mode="non_batch",
+        core_mode=core_mode,
+        vision_core_mode=vision_core_mode,
+        text_core_mode=text_core_mode,
+        output_dir=None,
+    )
+    _, _, run_targets = vlm_bench._collect_vlm_run_targets(args)
+    # run_targets tuple layout: (model_id, revision, mode_label, mode_base, mxq_path, core_mode, ...)
+    return [rt[3] for rt in run_targets]
+
+
+def test_collect_vlm_run_targets_distinguishes_subconfig_variants(monkeypatch, tmp_path) -> None:
+    """Verify vision/text overrides yield distinct mode_base filenames per combo."""
+    monkeypatch.chdir(tmp_path)
+
+    default_base = _mode_bases_for(monkeypatch, core_mode="single")[0]
+    vision_base = _mode_bases_for(
+        monkeypatch, core_mode="single", vision_core_mode="global8"
+    )[0]
+    text_base = _mode_bases_for(
+        monkeypatch, core_mode="single", text_core_mode="global4"
+    )[0]
+    both_base = _mode_bases_for(
+        monkeypatch,
+        core_mode="single",
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )[0]
+    matching_base = _mode_bases_for(
+        monkeypatch,
+        core_mode="single",
+        vision_core_mode="single",
+        text_core_mode="single",
+    )[0]
+
+    assert default_base.endswith("-single")
+    assert vision_base.endswith("-single-visglobal8")
+    assert text_base.endswith("-single-txtglobal4")
+    assert both_base.endswith("-single-visglobal8-txtglobal4")
+    assert matching_base == default_base
+    assert len({default_base, vision_base, text_base, both_base}) == 4

--- a/tests/transformers/test_vlm_benchmark_subconfig_result_keys.py
+++ b/tests/transformers/test_vlm_benchmark_subconfig_result_keys.py
@@ -138,9 +138,10 @@ def _make_text_target(model_id: str = "Qwen/Qwen2-VL-2B") -> TextBenchmarkTarget
 def _mode_bases_for(
     monkeypatch,
     *,
-    core_mode: str,
+    core_mode: str | None,
     vision_core_mode: str | None = None,
     text_core_mode: str | None = None,
+    original_models: bool = False,
 ) -> list[str]:
     """Drive `_collect_vlm_run_targets` with stubbed deps and return the mode_bases."""
 
@@ -162,13 +163,14 @@ def _mode_bases_for(
         "_iter_core_modes_for_target",
         lambda args, batch_mode, disable_npu_specific_args=False: [core_mode],
     )
+    monkeypatch.setattr(vlm_bench, "_resolve_original_model_ids", lambda model_ids: list(model_ids))
     args = argparse.Namespace(
         models=[text_target.model_id],
         mxq_dir=None,
         mxq_path=None,
         revision=None,
         all=False,
-        original_models=False,
+        original_models=original_models,
         batch_mode="non_batch",
         core_mode=core_mode,
         vision_core_mode=vision_core_mode,
@@ -299,3 +301,52 @@ def test_build_pipeline_non_original_keeps_subconfig_core_modes(monkeypatch) -> 
     model_kwargs = captured.get("model_kwargs", {})
     assert model_kwargs["vision_core_mode"] == "global8"
     assert model_kwargs["text_core_mode"] == "global4"
+
+
+def test_collect_vlm_run_targets_drops_subconfig_suffix_for_original_native(monkeypatch) -> None:
+    """Verify --original-models without --mxq-dir strips vis/txt suffixes from filenames.
+
+    The pipeline drops vision/text_core_mode in this case, so filenames must not
+    claim overrides that never reached the model.
+    """
+    mode_base = _mode_bases_for(
+        monkeypatch,
+        core_mode=None,
+        vision_core_mode="global8",
+        text_core_mode="global4",
+        original_models=True,
+    )[0]
+    assert "-vis" not in mode_base
+    assert "-txt" not in mode_base
+
+
+def test_vlm_subconfig_core_mode_payload_fields_drops_overrides_for_original_native() -> None:
+    """Verify payload records None for vision/text_core_mode on original-model native runs."""
+    args = argparse.Namespace(
+        original_models=True,
+        mxq_dir=None,
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )
+    fields = vlm_bench._vlm_subconfig_core_mode_payload_fields(args, None)
+    assert fields == {
+        "core_mode": None,
+        "vision_core_mode": None,
+        "text_core_mode": None,
+    }
+
+
+def test_vlm_subconfig_core_mode_payload_fields_keeps_overrides_with_mxq_dir(tmp_path) -> None:
+    """Verify --original-models WITH --mxq-dir still records the subconfig overrides."""
+    args = argparse.Namespace(
+        original_models=True,
+        mxq_dir=str(tmp_path),
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )
+    fields = vlm_bench._vlm_subconfig_core_mode_payload_fields(args, "single")
+    assert fields == {
+        "core_mode": "single",
+        "vision_core_mode": "global8",
+        "text_core_mode": "global4",
+    }

--- a/tests/transformers/test_vlm_benchmark_subconfig_result_keys.py
+++ b/tests/transformers/test_vlm_benchmark_subconfig_result_keys.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import types
 from pathlib import Path
 
 _TRANSFORMERS_BENCHMARK_DIR = Path(__file__).resolve().parents[2] / "benchmark" / "transformers"
@@ -209,3 +210,92 @@ def test_collect_vlm_run_targets_distinguishes_subconfig_variants(monkeypatch, t
     assert both_base.endswith("-single-visglobal8-txtglobal4")
     assert matching_base == default_base
     assert len({default_base, vision_base, text_base, both_base}) == 4
+
+
+def _make_vlm_pipeline_args(
+    *,
+    original_models: bool,
+    mxq_dir: str | None,
+    vision_core_mode: str | None,
+    text_core_mode: str | None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        trust_remote_code=True,
+        tokenizer=None,
+        device=None,
+        device_map=None,
+        dtype=None,
+        original_models=original_models,
+        mxq_dir=mxq_dir,
+        vision_core_mode=vision_core_mode,
+        text_core_mode=text_core_mode,
+    )
+
+
+def _capture_build_pipeline_kwargs(
+    monkeypatch,
+    args: argparse.Namespace,
+    *,
+    core_mode: str | None,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def _fake_pipeline(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model_kwargs=kwargs.get("model_kwargs", {}))
+
+    monkeypatch.setattr(vlm_bench, "hf_pipeline", _fake_pipeline)
+    vlm_bench._build_pipeline(
+        args,
+        "mobilint/Qwen2-VL-2B",
+        None,
+        None,
+        core_mode,
+    )
+    return captured
+
+
+def test_build_pipeline_original_models_drops_subconfig_core_modes(monkeypatch) -> None:
+    """Verify --original-models without --mxq-dir strips vision/text overrides from model_kwargs."""
+    args = _make_vlm_pipeline_args(
+        original_models=True,
+        mxq_dir=None,
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )
+    captured = _capture_build_pipeline_kwargs(monkeypatch, args, core_mode=None)
+    model_kwargs = captured.get("model_kwargs", {})
+    assert "vision_core_mode" not in model_kwargs
+    assert "text_core_mode" not in model_kwargs
+    assert "vision_target_cores" not in model_kwargs
+    assert "vision_target_clusters" not in model_kwargs
+    assert "text_target_cores" not in model_kwargs
+    assert "text_target_clusters" not in model_kwargs
+
+
+def test_build_pipeline_original_models_with_mxq_dir_keeps_subconfig_core_modes(monkeypatch, tmp_path) -> None:
+    """Verify --original-models WITH --mxq-dir still applies vision/text overrides."""
+    args = _make_vlm_pipeline_args(
+        original_models=True,
+        mxq_dir=str(tmp_path),
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )
+    captured = _capture_build_pipeline_kwargs(monkeypatch, args, core_mode="single")
+    model_kwargs = captured.get("model_kwargs", {})
+    assert model_kwargs["vision_core_mode"] == "global8"
+    assert model_kwargs["text_core_mode"] == "global4"
+
+
+def test_build_pipeline_non_original_keeps_subconfig_core_modes(monkeypatch) -> None:
+    """Verify overrides still reach model_kwargs when --original-models is not set."""
+    args = _make_vlm_pipeline_args(
+        original_models=False,
+        mxq_dir=None,
+        vision_core_mode="global8",
+        text_core_mode="global4",
+    )
+    captured = _capture_build_pipeline_kwargs(monkeypatch, args, core_mode="single")
+    model_kwargs = captured.get("model_kwargs", {})
+    assert model_kwargs["vision_core_mode"] == "global8"
+    assert model_kwargs["text_core_mode"] == "global4"


### PR DESCRIPTION
## Summary
- Fix silently dropped NPU kwargs in `MobilintEagle3ConfigMixin` by adding missing `base_/draft_/fc_` `dev_no` and `max_batch_size` setters so those kwargs actually reach the NPU backend
- Fix `AttributeError` in Qwen2VL/Qwen3VL/Blip/AyaVision composite configs by stripping `text_*`/`vision_*` NPU kwargs before delegating to upstream `__init__`, then re-applying them after sub-configs exist
- Add a shared base→subconfig core-mode propagator wired through the TPS CLI (`--vision-*`, `--text-*`), VLM benchmark (`--vision-core-mode`, `--text-core-mode`), and ASR benchmark (`--encoder-core-mode`, `--decoder-core-mode`); a lone `--core-mode` fans out to every composite subconfig, while per-subconfig overrides win for their prefix

## Test plan
- [x] `pytest tests/transformers/test_subconfig_core_mode_propagate.py` — 19/19 passed
- [x] Run TPS CLI with `--core-mode` only, and with mixed `--vision-core-mode` / `--text-core-mode` overrides — verified on `mobilint/Qwen2-VL-2B-Instruct` (NPU); `--core-mode global4` fans out to both subconfigs; `--core-mode single --vision-core-mode global4` yields `vision=global4` / `text=single`
- [x] Run VLM benchmark with `--vision-core-mode` / `--text-core-mode` — verified on `mobilint/Qwen2-VL-2B-Instruct` (NPU); log lines confirm both subconfigs get `core_mode=global4` on base fan-out, and `vision=global4` / `text=single` on mixed override
- [x] Run ASR benchmark with `--encoder-core-mode` / `--decoder-core-mode` — verified on `mobilint/whisper-small` (NPU); both encoder/decoder get `core_mode=global4` on base fan-out, and `encoder=single` / `decoder=global4` on mixed override
- [x] Load a Qwen2VL/Qwen3VL/Blip/AyaVision config with `text_*`/`vision_*` NPU kwargs and verify no `AttributeError` — all 4 configs propagate `core_mode`/`dev_no`/`max_batch_size` to text_config/vision_config
- [x] Load a MobilintEagle3 config with `base_dev_no` / `draft_dev_no` / `fc_dev_no` / `*_max_batch_size` and confirm the kwargs reach the NPU backend — all 6 kwargs verified via `__init__`, `from_dict`, and `to_dict`→`from_dict` roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)