### PR TITLE
fix: allow kanana llama config

### DIFF
--- a/mblt_model_zoo/hf_transformers/models/llama/configuration_llama.py
+++ b/mblt_model_zoo/hf_transformers/models/llama/configuration_llama.py
@@ -28,7 +28,26 @@ class MobilintLlamaConfig(MobilintConfigMixin, LlamaConfig):
         if head_dim is not None and head_dim <= 0:
             raise ValueError(f"head_dim must be positive, got {head_dim}.")
 
-    def __init__(self, **kwargs,):
+    def validate(self) -> None:
+        """Validate the config with Mobilint-specific architecture rules.
+
+        Upstream strict Llama configs generate a ``validate`` method that keeps
+        enforcing ``hidden_size % num_attention_heads == 0`` even after this
+        subclass restores Kanana's non-divisible hidden size. Defining the
+        validation entry point here keeps later ``config.validate()`` calls on
+        the Mobilint path.
+        """
+        for validator_name in (
+            "validate_output_attentions",
+            "validate_architecture",
+            "validate_token_ids",
+            "validate_layer_type",
+        ):
+            validator = getattr(self, validator_name, None)
+            if validator is not None:
+                validator()
+
+    def __init__(self, **kwargs):
         """Initialize the config while allowing non-square Mobilint query projections."""
         actual_hidden_size = kwargs.get("hidden_size")
         temporary_hidden_size = self._get_strict_compatible_hidden_size(
@@ -44,7 +63,7 @@ class MobilintLlamaConfig(MobilintConfigMixin, LlamaConfig):
 
         if temporary_hidden_size is not None:
             self.hidden_size = actual_hidden_size
-        
+
         self.tie_word_embeddings = False
 
 AutoConfig.register("mobilint-llama", MobilintLlamaConfig)

--- a/mblt_model_zoo/hf_transformers/models/llama/configuration_llama.py
+++ b/mblt_model_zoo/hf_transformers/models/llama/configuration_llama.py
@@ -7,8 +7,43 @@ from ...utils.configuration_utils import MobilintConfigMixin
 class MobilintLlamaConfig(MobilintConfigMixin, LlamaConfig):
     model_type = "mobilint-llama"
 
+    @staticmethod
+    def _get_strict_compatible_hidden_size(hidden_size: object, num_attention_heads: object) -> int | None:
+        """Return a temporary hidden size that satisfies upstream strict validation."""
+        if not isinstance(hidden_size, int) or not isinstance(num_attention_heads, int):
+            return None
+        if num_attention_heads <= 0 or hidden_size % num_attention_heads == 0:
+            return None
+        return num_attention_heads * max(1, hidden_size // num_attention_heads)
+
+    def validate_architecture(self) -> None:
+        """Validate Mobilint Llama architecture constraints.
+
+        Mobilint Llama artifacts may use non-square query projections, so
+        ``hidden_size`` is not required to be divisible by ``num_attention_heads``.
+        This overrides the upstream Llama validator while keeping lightweight
+        validation for explicitly configured attention head dimensions.
+        """
+        head_dim = getattr(self, "head_dim", None)
+        if head_dim is not None and head_dim <= 0:
+            raise ValueError(f"head_dim must be positive, got {head_dim}.")
+
     def __init__(self, **kwargs,):
+        """Initialize the config while allowing non-square Mobilint query projections."""
+        actual_hidden_size = kwargs.get("hidden_size")
+        temporary_hidden_size = self._get_strict_compatible_hidden_size(
+            actual_hidden_size,
+            kwargs.get("num_attention_heads"),
+        )
+
+        if temporary_hidden_size is not None:
+            kwargs = dict(kwargs)
+            kwargs["hidden_size"] = temporary_hidden_size
+
         super().__init__(**kwargs)
+
+        if temporary_hidden_size is not None:
+            self.hidden_size = actual_hidden_size
         
         self.tie_word_embeddings = False
 

--- a/tests/transformers/text_generation/test_llama_config.py
+++ b/tests/transformers/text_generation/test_llama_config.py
@@ -1,0 +1,41 @@
+"""Unit tests for Mobilint Llama configuration validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from mblt_model_zoo.hf_transformers.models.llama.configuration_llama import MobilintLlamaConfig
+
+
+def test_llama_config_validate_allows_kanana_non_divisible_hidden_size() -> None:
+    """Kanana configs should remain valid after restoring their real hidden size."""
+    config = MobilintLlamaConfig(
+        hidden_size=1792,
+        intermediate_size=4864,
+        num_hidden_layers=1,
+        num_attention_heads=24,
+        num_key_value_heads=4,
+        head_dim=128,
+    )
+
+    config.validate()
+
+    assert config.hidden_size == 1792
+    assert config.num_attention_heads == 24
+    assert config.head_dim == 128
+
+
+def test_llama_config_validate_rejects_non_positive_head_dim() -> None:
+    """Mobilint validation should still reject invalid explicit head dimensions."""
+    config = MobilintLlamaConfig(
+        hidden_size=1792,
+        intermediate_size=4864,
+        num_hidden_layers=1,
+        num_attention_heads=24,
+        num_key_value_heads=4,
+        head_dim=128,
+    )
+    config.head_dim = 0
+
+    with pytest.raises(ValueError, match="head_dim must be positive"):
+        config.validate()


### PR DESCRIPTION
## Summary

Kanana 1.5 2.1B uses a Mobilint Llama config whose query projection does not follow the upstream Llama assumption that `hidden_size` is divisible by `num_attention_heads`.

This PR allows `MobilintLlamaConfig` to load such non-square query projection configs while preserving the original config values used by Mobilint artifacts.

## Changes

- Add Mobilint-specific architecture validation for `MobilintLlamaConfig`.
- Bypass upstream strict Llama hidden-size divisibility validation only when needed.
- Restore the original `hidden_size` immediately after upstream config initialization.
- Keep existing divisible Llama configs on the normal initialization path.

## Why

Upstream `LlamaConfig` validates this invariant:


```python
hidden_size % num_attention_heads == 0
```

For `mobilint/kanana-1.5-2.1b-instruct-2505`, the config has:

```text
hidden_size = 1792
num_attention_heads = 24
```

That is invalid under upstream Llama's square-Q projection assumption, but it is valid for the Mobilint artifact because the Q matrix is not square. Without this patch, config loading fails before the TPS measurement can construct the pipeline.

## Validation

- `uv run pre-commit run --files mblt_model_zoo/hf_transformers/models/llama/configuration_llama.py`
- `mblt-model-zoo tps measure --model mobilint/kanana-1.5-2.1b-instruct-2505`

The Kanana TPS command now completes successfully and reports prefill/decode metrics.
