### PR TITLE
fix: TPS 측정 구간 전체 트레이스 수집

### DIFF
--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -138,6 +138,10 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     stop_tracker_safe as _stop_tracker_safe_common,
 )
+from mblt_model_zoo.hf_transformers.utils.benchmark_utils import (
+    start_qbruntime_trace,
+    stop_qbruntime_trace,
+)
 
 _ASR_BENCHMARK_SCHEMA_VERSION = 1
 
@@ -156,6 +160,16 @@ class ASRBenchmarkTarget:
 
 def _safe_filename(model_id: str) -> str:
     return _safe_filename_common(model_id, replace_slash_only=True)
+
+
+def _trace_path_for_target(args: argparse.Namespace, *, base: str, benchmark_type: str) -> str | None:
+    """Return a per-target qbruntime trace path when trace collection is enabled."""
+    trace_dir = getattr(args, "trace_dir", None)
+    if not trace_dir:
+        return None
+    trace_root = Path(trace_dir).expanduser().resolve()
+    trace_root.mkdir(parents=True, exist_ok=True)
+    return str(trace_root / f"{_safe_filename(base)}_{benchmark_type}_trace.json")
 
 
 def _flag_present(raw_argv: Sequence[str], flag: str) -> bool:
@@ -437,6 +451,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output-dir",
         default=str(Path(__file__).resolve().parent / "results" / "automatic_speech_recognition"),
         help="output directory",
+    )
+    parser.add_argument(
+        "--trace-dir",
+        default=None,
+        help="directory for per-target qbruntime trace JSON files covering measured runs only",
     )
     parser.add_argument(
         "--save-samples",
@@ -860,6 +879,7 @@ def _measure_target(
     *,
     native_language: str | None = None,
     max_measured_samples: int | None = None,
+    trace_path: str | None = None,
 ) -> tuple[list[SampleTiming], dict[str, float | None], dict[str, list[dict[str, float]]]]:
     tracker = _build_device_tracker_common(target_args, pipe)
     _print_device_status_common(target_args, tracker)
@@ -868,18 +888,22 @@ def _measure_target(
         if tracker is not None:
             tracker.start()
         total = int(max_measured_samples) if max_measured_samples is not None else None
-        with tqdm(total=total, desc="ASR samples", leave=False, unit="sample") as progress_bar:
-            for sample in samples:
-                if max_measured_samples is not None and len(timings) >= int(max_measured_samples):
-                    break
-                if _should_skip_whisper_long_form_sample(model_id, sample):
-                    print(
-                        "Skipping sample (>30s Whisper limit): "
-                        f"model={model_id} sample_id={sample['id']} duration_s={_sample_audio_duration_s(sample):.2f}"
-                    )
-                    continue
-                timings.append(_run_one_sample(pipe, sample, generate_kwargs, native_language=native_language))
-                progress_bar.update(1)
+        trace_handle = start_qbruntime_trace(trace_path)
+        try:
+            with tqdm(total=total, desc="ASR samples", leave=False, unit="sample") as progress_bar:
+                for sample in samples:
+                    if max_measured_samples is not None and len(timings) >= int(max_measured_samples):
+                        break
+                    if _should_skip_whisper_long_form_sample(model_id, sample):
+                        print(
+                            "Skipping sample (>30s Whisper limit): "
+                            f"model={model_id} sample_id={sample['id']} duration_s={_sample_audio_duration_s(sample):.2f}"
+                        )
+                        continue
+                    timings.append(_run_one_sample(pipe, sample, generate_kwargs, native_language=native_language))
+                    progress_bar.update(1)
+        finally:
+            stop_qbruntime_trace(trace_handle)
     finally:
         _stop_tracker_safe_common(tracker)
     device_metric = _extract_device_metric_common(tracker) if tracker is not None else {}
@@ -1129,6 +1153,7 @@ def main(argv: list[str] | None = None) -> int:
                 generate_kwargs,
                 native_language=native_language,
                 max_measured_samples=args.num_samples,
+                trace_path=_trace_path_for_target(args, base=mode_base, benchmark_type="measure"),
             )
             if not timings:
                 reason = "No measured samples remained after warmup/skip filtering."

--- a/benchmark/transformers/benchmark_image_text_to_text_models.py
+++ b/benchmark/transformers/benchmark_image_text_to_text_models.py
@@ -109,6 +109,8 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_utils import (
     SweepData,
     VLMTPSMeasurer,
     npu_latency_pct,
+    start_qbruntime_trace,
+    stop_qbruntime_trace,
 )
 
 _VLM_WARMUP_PREFILL = 128
@@ -157,6 +159,16 @@ class VLMBenchmarkTarget:
 
 def _safe_filename(text: str) -> str:
     return _safe_filename_common(text, replace_slash_only=True)
+
+
+def _trace_path_for_target(args: argparse.Namespace, *, base: str, benchmark_type: str) -> str | None:
+    """Return a per-target qbruntime trace path when trace collection is enabled."""
+    trace_dir = getattr(args, "trace_dir", None)
+    if not trace_dir:
+        return None
+    trace_root = Path(trace_dir).expanduser().resolve()
+    trace_root.mkdir(parents=True, exist_ok=True)
+    return str(trace_root / f"{_safe_filename(base)}_{benchmark_type}_trace.json")
 
 
 def _mean(values: list[float]) -> float:
@@ -457,7 +469,9 @@ def _revision_exists(model_id: str, revision: str) -> bool | None:
     return _revision_exists_shared(model_id, revision)
 
 
-def _run_model(args: argparse.Namespace, label: str, pipeline: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+def _run_model(
+    args: argparse.Namespace, label: str, base: str, pipeline: Any
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     measurer = VLMTPSMeasurer(pipeline)
     tracker = _build_device_tracker(args, pipeline)
     _print_device_status(args, tracker)
@@ -507,157 +521,161 @@ def _run_model(args: argparse.Namespace, label: str, pipeline: Any) -> tuple[dic
             progress_prefix=f"{label} warmup {warmup_idx + 1}/{args.warmup}",
         )
 
-    for resolution in args.image_resolutions:
-        runs = []
-        power_vals: list[float] = []
-        p99_power_vals: list[float] = []
-        util_vals: list[float] = []
-        p99_util_vals: list[float] = []
-        temp_vals: list[float] = []
-        p99_temp_vals: list[float] = []
-        mem_mb_vals: list[float] = []
-        p99_mem_mb_vals: list[float] = []
-        mem_pct_vals: list[float] = []
-        p99_mem_pct_vals: list[float] = []
-        energy_vals: list[float] = []
-        img_per_j_vals: list[float] = []
-        j_per_img_vals: list[float] = []
-        device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
-        for _ in tqdm(
-            range(args.repeat),
-            desc=f"{label} vision@{resolution} runs",
-            leave=False,
-        ):
-            if tracker is not None:
-                tracker.start()
-            try:
-                run = measurer.measure_vision(
-                    image_resolution=resolution,
-                    repeat=1,
-                    prompt=args.prompt,
-                    batch_size=args.batch_size,
-                    show_progress=False,
-                )[0]
-            finally:
-                _stop_tracker_safe(tracker)
-            runs.append(run)
-            if tracker is not None:
-                metric = _extract_device_metric(tracker)
-                device_time_series = _extract_device_time_series(tracker)
-                device_time_series_runs.append(device_time_series)
-                avg_power = metric.get("avg_power_w")
-                p99_power = metric.get("p99_power_w")
-                avg_util = metric.get("avg_utilization_pct")
-                p99_util = metric.get("p99_utilization_pct")
-                avg_temp = metric.get("avg_temperature_c")
-                p99_temp = metric.get("p99_temperature_c")
-                avg_mem = metric.get("avg_memory_used_mb")
-                p99_mem = metric.get("p99_memory_used_mb")
-                avg_mem_pct = metric.get("avg_memory_used_pct")
-                p99_mem_pct = metric.get("p99_memory_used_pct")
-                if avg_power is not None:
-                    power_vals.append(float(avg_power))
-                energy = _energy_from_device_time_series(device_time_series)
-                if energy is not None:
-                    energy_vals.append(energy)
-                    j_per_img = _safe_div(energy, float(args.batch_size))
-                    if j_per_img is not None:
-                        j_per_img_vals.append(j_per_img)
-                    tpj = _safe_div(float(args.batch_size), energy)
-                    if tpj is not None:
-                        img_per_j_vals.append(tpj)
-                if p99_power is not None:
-                    p99_power_vals.append(float(p99_power))
-                if avg_util is not None:
-                    util_vals.append(float(avg_util))
-                if p99_util is not None:
-                    p99_util_vals.append(float(p99_util))
-                if avg_temp is not None:
-                    temp_vals.append(float(avg_temp))
-                if p99_temp is not None:
-                    p99_temp_vals.append(float(p99_temp))
-                if avg_mem is not None:
-                    mem_mb_vals.append(float(avg_mem))
-                if p99_mem is not None:
-                    p99_mem_mb_vals.append(float(p99_mem))
-                if avg_mem_pct is not None:
-                    mem_pct_vals.append(float(avg_mem_pct))
-                if p99_mem_pct is not None:
-                    p99_mem_pct_vals.append(float(p99_mem_pct))
-        encode_ms = [float(lat * 1000.0) for lat, _ in runs]
-        fps = [float(v) for _, v in runs]
-        all_vision_encode_ms.extend(encode_ms)
-        all_vision_fps.extend(fps)
-        all_vision_avg_power_w.extend(power_vals)
-        all_vision_p99_power_w.extend(p99_power_vals)
-        all_vision_avg_utilization_pct.extend(util_vals)
-        all_vision_p99_utilization_pct.extend(p99_util_vals)
-        all_vision_avg_temperature_c.extend(temp_vals)
-        all_vision_p99_temperature_c.extend(p99_temp_vals)
-        all_vision_avg_memory_used_mb.extend(mem_mb_vals)
-        all_vision_p99_memory_used_mb.extend(p99_mem_mb_vals)
-        all_vision_avg_memory_used_pct.extend(mem_pct_vals)
-        all_vision_p99_memory_used_pct.extend(p99_mem_pct_vals)
-        all_vision_total_energy_j.extend(energy_vals)
-        all_vision_img_per_j.extend(img_per_j_vals)
-        all_vision_j_per_img.extend(j_per_img_vals)
-        vision_results.append(
-            {
-                "image_resolution": resolution,
-                "runs": runs,
-                "summary": {
-                    "vision_encode_ms": _summary(encode_ms),
-                    "vision_fps": _summary(fps),
-                    "avg_power_w": _summary(power_vals),
-                    "p99_power_w": _summary(p99_power_vals),
-                    "avg_utilization_pct": _summary(util_vals),
-                    "p99_utilization_pct": _summary(p99_util_vals),
-                    "avg_temperature_c": _summary(temp_vals),
-                    "p99_temperature_c": _summary(p99_temp_vals),
-                    "avg_memory_used_mb": _summary(mem_mb_vals),
-                    "p99_memory_used_mb": _summary(p99_mem_mb_vals),
-                    "avg_memory_used_pct": _summary(mem_pct_vals),
-                    "p99_memory_used_pct": _summary(p99_mem_pct_vals),
-                    "total_energy_j": _summary(energy_vals),
-                    "vision_img_per_j": _summary(img_per_j_vals),
-                    "vision_j_per_img": _summary(j_per_img_vals),
-                },
-                "device_time_series_runs": device_time_series_runs,
-            }
-        )
-        for idx, (lat, vfps) in enumerate(runs, start=1):
-            csv_rows.append(
+    trace_handle = start_qbruntime_trace(_trace_path_for_target(args, base=base, benchmark_type="sweep_vision"))
+    try:
+        for resolution in args.image_resolutions:
+            runs = []
+            power_vals: list[float] = []
+            p99_power_vals: list[float] = []
+            util_vals: list[float] = []
+            p99_util_vals: list[float] = []
+            temp_vals: list[float] = []
+            p99_temp_vals: list[float] = []
+            mem_mb_vals: list[float] = []
+            p99_mem_mb_vals: list[float] = []
+            mem_pct_vals: list[float] = []
+            p99_mem_pct_vals: list[float] = []
+            energy_vals: list[float] = []
+            img_per_j_vals: list[float] = []
+            j_per_img_vals: list[float] = []
+            device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
+            for _ in tqdm(
+                range(args.repeat),
+                desc=f"{label} vision@{resolution} runs",
+                leave=False,
+            ):
+                if tracker is not None:
+                    tracker.start()
+                try:
+                    run = measurer.measure_vision(
+                        image_resolution=resolution,
+                        repeat=1,
+                        prompt=args.prompt,
+                        batch_size=args.batch_size,
+                        show_progress=False,
+                    )[0]
+                finally:
+                    _stop_tracker_safe(tracker)
+                runs.append(run)
+                if tracker is not None:
+                    metric = _extract_device_metric(tracker)
+                    device_time_series = _extract_device_time_series(tracker)
+                    device_time_series_runs.append(device_time_series)
+                    avg_power = metric.get("avg_power_w")
+                    p99_power = metric.get("p99_power_w")
+                    avg_util = metric.get("avg_utilization_pct")
+                    p99_util = metric.get("p99_utilization_pct")
+                    avg_temp = metric.get("avg_temperature_c")
+                    p99_temp = metric.get("p99_temperature_c")
+                    avg_mem = metric.get("avg_memory_used_mb")
+                    p99_mem = metric.get("p99_memory_used_mb")
+                    avg_mem_pct = metric.get("avg_memory_used_pct")
+                    p99_mem_pct = metric.get("p99_memory_used_pct")
+                    if avg_power is not None:
+                        power_vals.append(float(avg_power))
+                    energy = _energy_from_device_time_series(device_time_series)
+                    if energy is not None:
+                        energy_vals.append(energy)
+                        j_per_img = _safe_div(energy, float(args.batch_size))
+                        if j_per_img is not None:
+                            j_per_img_vals.append(j_per_img)
+                        tpj = _safe_div(float(args.batch_size), energy)
+                        if tpj is not None:
+                            img_per_j_vals.append(tpj)
+                    if p99_power is not None:
+                        p99_power_vals.append(float(p99_power))
+                    if avg_util is not None:
+                        util_vals.append(float(avg_util))
+                    if p99_util is not None:
+                        p99_util_vals.append(float(p99_util))
+                    if avg_temp is not None:
+                        temp_vals.append(float(avg_temp))
+                    if p99_temp is not None:
+                        p99_temp_vals.append(float(p99_temp))
+                    if avg_mem is not None:
+                        mem_mb_vals.append(float(avg_mem))
+                    if p99_mem is not None:
+                        p99_mem_mb_vals.append(float(p99_mem))
+                    if avg_mem_pct is not None:
+                        mem_pct_vals.append(float(avg_mem_pct))
+                    if p99_mem_pct is not None:
+                        p99_mem_pct_vals.append(float(p99_mem_pct))
+            encode_ms = [float(lat * 1000.0) for lat, _ in runs]
+            fps = [float(v) for _, v in runs]
+            all_vision_encode_ms.extend(encode_ms)
+            all_vision_fps.extend(fps)
+            all_vision_avg_power_w.extend(power_vals)
+            all_vision_p99_power_w.extend(p99_power_vals)
+            all_vision_avg_utilization_pct.extend(util_vals)
+            all_vision_p99_utilization_pct.extend(p99_util_vals)
+            all_vision_avg_temperature_c.extend(temp_vals)
+            all_vision_p99_temperature_c.extend(p99_temp_vals)
+            all_vision_avg_memory_used_mb.extend(mem_mb_vals)
+            all_vision_p99_memory_used_mb.extend(p99_mem_mb_vals)
+            all_vision_avg_memory_used_pct.extend(mem_pct_vals)
+            all_vision_p99_memory_used_pct.extend(p99_mem_pct_vals)
+            all_vision_total_energy_j.extend(energy_vals)
+            all_vision_img_per_j.extend(img_per_j_vals)
+            all_vision_j_per_img.extend(j_per_img_vals)
+            vision_results.append(
                 {
-                    "type": "vision",
                     "image_resolution": resolution,
-                    "repeat_index": idx,
-                    "vision_encode_ms": lat * 1000.0,
-                    "vision_fps": vfps,
-                    "llm_prefill_tps": None,
-                    "llm_decode_tps": None,
-                    "llm_ttft_ms": None,
-                    "llm_prefill_npu_latency_pct": None,
-                    "llm_decode_npu_latency_pct": None,
-                    "avg_power_w": power_vals[idx - 1] if idx - 1 < len(power_vals) else None,
-                    "p99_power_w": p99_power_vals[idx - 1] if idx - 1 < len(p99_power_vals) else None,
-                    "avg_utilization_pct": util_vals[idx - 1] if idx - 1 < len(util_vals) else None,
-                    "p99_utilization_pct": p99_util_vals[idx - 1] if idx - 1 < len(p99_util_vals) else None,
-                    "avg_temperature_c": temp_vals[idx - 1] if idx - 1 < len(temp_vals) else None,
-                    "p99_temperature_c": p99_temp_vals[idx - 1] if idx - 1 < len(p99_temp_vals) else None,
-                    "avg_memory_used_mb": mem_mb_vals[idx - 1] if idx - 1 < len(mem_mb_vals) else None,
-                    "p99_memory_used_mb": p99_mem_mb_vals[idx - 1] if idx - 1 < len(p99_mem_mb_vals) else None,
-                    "avg_memory_used_pct": mem_pct_vals[idx - 1] if idx - 1 < len(mem_pct_vals) else None,
-                    "p99_memory_used_pct": p99_mem_pct_vals[idx - 1] if idx - 1 < len(p99_mem_pct_vals) else None,
-                    "total_energy_j": energy_vals[idx - 1] if idx - 1 < len(energy_vals) else None,
-                    "prefill_tps_per_w": None,
-                    "decode_tps_per_w": None,
-                    "prefill_j_per_tok": None,
-                    "decode_j_per_tok": None,
-                    "vision_img_per_j": img_per_j_vals[idx - 1] if idx - 1 < len(img_per_j_vals) else None,
-                    "vision_j_per_img": j_per_img_vals[idx - 1] if idx - 1 < len(j_per_img_vals) else None,
+                    "runs": runs,
+                    "summary": {
+                        "vision_encode_ms": _summary(encode_ms),
+                        "vision_fps": _summary(fps),
+                        "avg_power_w": _summary(power_vals),
+                        "p99_power_w": _summary(p99_power_vals),
+                        "avg_utilization_pct": _summary(util_vals),
+                        "p99_utilization_pct": _summary(p99_util_vals),
+                        "avg_temperature_c": _summary(temp_vals),
+                        "p99_temperature_c": _summary(p99_temp_vals),
+                        "avg_memory_used_mb": _summary(mem_mb_vals),
+                        "p99_memory_used_mb": _summary(p99_mem_mb_vals),
+                        "avg_memory_used_pct": _summary(mem_pct_vals),
+                        "p99_memory_used_pct": _summary(p99_mem_pct_vals),
+                        "total_energy_j": _summary(energy_vals),
+                        "vision_img_per_j": _summary(img_per_j_vals),
+                        "vision_j_per_img": _summary(j_per_img_vals),
+                    },
+                    "device_time_series_runs": device_time_series_runs,
                 }
             )
+            for idx, (lat, vfps) in enumerate(runs, start=1):
+                csv_rows.append(
+                    {
+                        "type": "vision",
+                        "image_resolution": resolution,
+                        "repeat_index": idx,
+                        "vision_encode_ms": lat * 1000.0,
+                        "vision_fps": vfps,
+                        "llm_prefill_tps": None,
+                        "llm_decode_tps": None,
+                        "llm_ttft_ms": None,
+                        "llm_prefill_npu_latency_pct": None,
+                        "llm_decode_npu_latency_pct": None,
+                        "avg_power_w": power_vals[idx - 1] if idx - 1 < len(power_vals) else None,
+                        "p99_power_w": p99_power_vals[idx - 1] if idx - 1 < len(p99_power_vals) else None,
+                        "avg_utilization_pct": util_vals[idx - 1] if idx - 1 < len(util_vals) else None,
+                        "p99_utilization_pct": p99_util_vals[idx - 1] if idx - 1 < len(p99_util_vals) else None,
+                        "avg_temperature_c": temp_vals[idx - 1] if idx - 1 < len(temp_vals) else None,
+                        "p99_temperature_c": p99_temp_vals[idx - 1] if idx - 1 < len(p99_temp_vals) else None,
+                        "avg_memory_used_mb": mem_mb_vals[idx - 1] if idx - 1 < len(mem_mb_vals) else None,
+                        "p99_memory_used_mb": p99_mem_mb_vals[idx - 1] if idx - 1 < len(p99_mem_mb_vals) else None,
+                        "avg_memory_used_pct": mem_pct_vals[idx - 1] if idx - 1 < len(mem_pct_vals) else None,
+                        "p99_memory_used_pct": p99_mem_pct_vals[idx - 1] if idx - 1 < len(p99_mem_pct_vals) else None,
+                        "total_energy_j": energy_vals[idx - 1] if idx - 1 < len(energy_vals) else None,
+                        "prefill_tps_per_w": None,
+                        "decode_tps_per_w": None,
+                        "prefill_j_per_tok": None,
+                        "decode_j_per_tok": None,
+                        "vision_img_per_j": img_per_j_vals[idx - 1] if idx - 1 < len(img_per_j_vals) else None,
+                        "vision_j_per_img": j_per_img_vals[idx - 1] if idx - 1 < len(j_per_img_vals) else None,
+                    }
+                )
 
+    finally:
+        stop_qbruntime_trace(trace_handle)
     llm_runs = []
     llm_avg_power_w: list[float] = []
     llm_p99_power_w: list[float] = []
@@ -678,134 +696,142 @@ def _run_model(args: argparse.Namespace, label: str, pipeline: Any) -> tuple[dic
     llm_prefill_j_per_tok: list[float] = []
     llm_decode_j_per_tok: list[float] = []
     llm_device_time_series_runs: list[dict[str, dict[str, list[dict[str, float]]]]] = []
-    for repeat_idx in tqdm(
-        range(args.repeat),
-        desc=f"{label} llm@{llm_resolution} runs",
-        leave=False,
-    ):
-        llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
-        try:
-            run = measurer.measure_llm_full(
-                image_resolution=llm_resolution,
-                prompt=args.prompt,
-                prefill_range=args.prefill_range,
-                cache_lengths=args.cache_lengths,
-                decode_window=args.decode_window,
-                prefill_chunk_size=resolved_prefill_chunk_size,
-                batch_size=args.batch_size,
-                show_progress=True,
-                progress_prefix=f"{label} llm@{llm_resolution} run {repeat_idx + 1}/{args.repeat}",
-                on_prefill_start=(lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None,
-                on_prefill_end=(lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None,
-                on_decode_start=(lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None,
-                on_decode_end=(lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None,
-            )
-        finally:
-            _stop_tracker_safe(llm_tracker_prefill)
-            _stop_tracker_safe(llm_tracker_decode)
-        if llm_tracker_prefill is not None and llm_tracker_decode is not None:
-            prefill_metric = _extract_device_metric(llm_tracker_prefill)
-            decode_metric = _extract_device_metric(llm_tracker_decode)
-            prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
-            decode_time_series = _extract_device_time_series(llm_tracker_decode)
-            llm_device_time_series_runs.append({"prefill": prefill_time_series, "decode": decode_time_series})
-            prefill_duration = float(getattr(run, "prefill_phase_duration_s", 0.0) or 0.0)
-            decode_duration = float(getattr(run, "decode_phase_duration_s", 0.0) or 0.0)
-            run.avg_power_w = _weighted_two(
-                prefill_metric.get("avg_power_w"),
-                prefill_duration,
-                decode_metric.get("avg_power_w"),
-                decode_duration,
-            )
-            run.p99_power_w = max(
-                [v for v in (prefill_metric.get("p99_power_w"), decode_metric.get("p99_power_w")) if v is not None],
-                default=None,
-            )
-            run.avg_utilization_pct = _weighted_two(
-                prefill_metric.get("avg_utilization_pct"),
-                prefill_duration,
-                decode_metric.get("avg_utilization_pct"),
-                decode_duration,
-            )
-            run.p99_utilization_pct = max(
-                [
-                    v
-                    for v in (prefill_metric.get("p99_utilization_pct"), decode_metric.get("p99_utilization_pct"))
-                    if v is not None
-                ],
-                default=None,
-            )
-            run.avg_temperature_c = _weighted_two(
-                prefill_metric.get("avg_temperature_c"),
-                prefill_duration,
-                decode_metric.get("avg_temperature_c"),
-                decode_duration,
-            )
-            run.p99_temperature_c = max(
-                [
-                    v
-                    for v in (prefill_metric.get("p99_temperature_c"), decode_metric.get("p99_temperature_c"))
-                    if v is not None
-                ],
-                default=None,
-            )
-            run.avg_memory_used_mb = _weighted_two(
-                prefill_metric.get("avg_memory_used_mb"),
-                prefill_duration,
-                decode_metric.get("avg_memory_used_mb"),
-                decode_duration,
-            )
-            run.p99_memory_used_mb = max(
-                [
-                    v
-                    for v in (prefill_metric.get("p99_memory_used_mb"), decode_metric.get("p99_memory_used_mb"))
-                    if v is not None
-                ],
-                default=None,
-            )
-            run.avg_memory_used_pct = _weighted_two(
-                prefill_metric.get("avg_memory_used_pct"),
-                prefill_duration,
-                decode_metric.get("avg_memory_used_pct"),
-                decode_duration,
-            )
-            run.p99_memory_used_pct = max(
-                [
-                    v
-                    for v in (prefill_metric.get("p99_memory_used_pct"), decode_metric.get("p99_memory_used_pct"))
-                    if v is not None
-                ],
-                default=None,
-            )
-            prefill_energy = _energy_from_device_time_series(prefill_time_series)
-            decode_energy = _energy_from_device_time_series(decode_time_series)
-            total_energy = _sum_required_energies(prefill_energy, decode_energy)
-            run.llm_prefill_energy_j = prefill_energy
-            run.llm_decode_energy_j = decode_energy
-            run.llm_total_energy_j = total_energy
-            run.total_energy_j = total_energy
-            if prefill_energy is not None:
-                llm_prefill_energy_j.append(prefill_energy)
-            if decode_energy is not None:
-                llm_decode_energy_j.append(decode_energy)
-            if total_energy is not None:
-                llm_total_energy_j.append(total_energy)
-                prefill_tokens = _sweep_prefill_token_count(run, args.batch_size)
-                decode_tokens = _sweep_decode_token_count(
-                    run,
+    trace_handle = start_qbruntime_trace(_trace_path_for_target(args, base=base, benchmark_type="sweep_llm"))
+    try:
+        for repeat_idx in tqdm(
+            range(args.repeat),
+            desc=f"{label} llm@{llm_resolution} runs",
+            leave=False,
+        ):
+            llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
+            try:
+                run = measurer.measure_llm_full(
+                    image_resolution=llm_resolution,
+                    prompt=args.prompt,
+                    prefill_range=args.prefill_range,
+                    cache_lengths=args.cache_lengths,
                     decode_window=args.decode_window,
+                    prefill_chunk_size=resolved_prefill_chunk_size,
                     batch_size=args.batch_size,
+                    show_progress=True,
+                    progress_prefix=f"{label} llm@{llm_resolution} run {repeat_idx + 1}/{args.repeat}",
+                    on_prefill_start=(lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None,
+                    on_prefill_end=(lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None,
+                    on_decode_start=(lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None,
+                    on_decode_end=(lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None,
                 )
-                total_tokens = prefill_tokens + decode_tokens
-                run.prefill_tps_per_w = _safe_div(float(prefill_tokens), prefill_energy)
-                run.decode_tps_per_w = _safe_div(float(decode_tokens), decode_energy)
-                run.prefill_j_per_token = (
-                    _safe_div(prefill_energy, float(prefill_tokens)) if prefill_tokens > 0 else None
+            finally:
+                _stop_tracker_safe(llm_tracker_prefill)
+                _stop_tracker_safe(llm_tracker_decode)
+            if llm_tracker_prefill is not None and llm_tracker_decode is not None:
+                prefill_metric = _extract_device_metric(llm_tracker_prefill)
+                decode_metric = _extract_device_metric(llm_tracker_decode)
+                prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
+                decode_time_series = _extract_device_time_series(llm_tracker_decode)
+                llm_device_time_series_runs.append({"prefill": prefill_time_series, "decode": decode_time_series})
+                prefill_duration = float(getattr(run, "prefill_phase_duration_s", 0.0) or 0.0)
+                decode_duration = float(getattr(run, "decode_phase_duration_s", 0.0) or 0.0)
+                run.avg_power_w = _weighted_two(
+                    prefill_metric.get("avg_power_w"),
+                    prefill_duration,
+                    decode_metric.get("avg_power_w"),
+                    decode_duration,
                 )
-                run.decode_j_per_token = _safe_div(decode_energy, float(decode_tokens)) if decode_tokens > 0 else None
-                run.total_tps_per_w = _safe_div(float(total_tokens), total_energy)
-                run.total_j_per_token = _safe_div(total_energy, float(total_tokens)) if total_tokens > 0 else None
-        llm_runs.append(run)
+                run.p99_power_w = max(
+                    [v for v in (prefill_metric.get("p99_power_w"), decode_metric.get("p99_power_w")) if v is not None],
+                    default=None,
+                )
+                run.avg_utilization_pct = _weighted_two(
+                    prefill_metric.get("avg_utilization_pct"),
+                    prefill_duration,
+                    decode_metric.get("avg_utilization_pct"),
+                    decode_duration,
+                )
+                run.p99_utilization_pct = max(
+                    [
+                        v
+                        for v in (prefill_metric.get("p99_utilization_pct"), decode_metric.get("p99_utilization_pct"))
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                run.avg_temperature_c = _weighted_two(
+                    prefill_metric.get("avg_temperature_c"),
+                    prefill_duration,
+                    decode_metric.get("avg_temperature_c"),
+                    decode_duration,
+                )
+                run.p99_temperature_c = max(
+                    [
+                        v
+                        for v in (prefill_metric.get("p99_temperature_c"), decode_metric.get("p99_temperature_c"))
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                run.avg_memory_used_mb = _weighted_two(
+                    prefill_metric.get("avg_memory_used_mb"),
+                    prefill_duration,
+                    decode_metric.get("avg_memory_used_mb"),
+                    decode_duration,
+                )
+                run.p99_memory_used_mb = max(
+                    [
+                        v
+                        for v in (prefill_metric.get("p99_memory_used_mb"), decode_metric.get("p99_memory_used_mb"))
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                run.avg_memory_used_pct = _weighted_two(
+                    prefill_metric.get("avg_memory_used_pct"),
+                    prefill_duration,
+                    decode_metric.get("avg_memory_used_pct"),
+                    decode_duration,
+                )
+                run.p99_memory_used_pct = max(
+                    [
+                        v
+                        for v in (prefill_metric.get("p99_memory_used_pct"), decode_metric.get("p99_memory_used_pct"))
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                prefill_energy = _energy_from_device_time_series(prefill_time_series)
+                decode_energy = _energy_from_device_time_series(decode_time_series)
+                total_energy = _sum_required_energies(prefill_energy, decode_energy)
+                run.llm_prefill_energy_j = prefill_energy
+                run.llm_decode_energy_j = decode_energy
+                run.llm_total_energy_j = total_energy
+                run.total_energy_j = total_energy
+                if prefill_energy is not None:
+                    llm_prefill_energy_j.append(prefill_energy)
+                if decode_energy is not None:
+                    llm_decode_energy_j.append(decode_energy)
+                if total_energy is not None:
+                    llm_total_energy_j.append(total_energy)
+                    prefill_tokens = _sweep_prefill_token_count(run, args.batch_size)
+                    decode_tokens = _sweep_decode_token_count(
+                        run,
+                        decode_window=args.decode_window,
+                        batch_size=args.batch_size,
+                    )
+                    total_tokens = prefill_tokens + decode_tokens
+                    run.prefill_tps_per_w = _safe_div(float(prefill_tokens), prefill_energy)
+                    run.decode_tps_per_w = _safe_div(float(decode_tokens), decode_energy)
+                    run.prefill_j_per_token = (
+                        _safe_div(prefill_energy, float(prefill_tokens)) if prefill_tokens > 0 else None
+                    )
+                    run.decode_j_per_token = (
+                        _safe_div(decode_energy, float(decode_tokens)) if decode_tokens > 0 else None
+                    )
+                    run.total_tps_per_w = _safe_div(float(total_tokens), total_energy)
+                    run.total_j_per_token = (
+                        _safe_div(total_energy, float(total_tokens)) if total_tokens > 0 else None
+                    )
+            llm_runs.append(run)
+    finally:
+        stop_qbruntime_trace(trace_handle)
     llm_prefill = [float(r.prefill_sweep.tps_values[-1]) for r in llm_runs if r.prefill_sweep.tps_values]
     llm_decode = [float(r.decode_sweep.tps_values[-1]) for r in llm_runs if r.decode_sweep.tps_values]
     llm_ttft_values_ms = [
@@ -1403,6 +1429,11 @@ def _add_common_benchmark_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="output directory (default: benchmark/transformers/results/image_text_to_text)",
     )
+    parser.add_argument(
+        "--trace-dir",
+        default=None,
+        help="directory for per-target qbruntime trace JSON files covering measured runs only",
+    )
 
 
 def _add_measure_args(parser: argparse.ArgumentParser) -> None:
@@ -1708,7 +1739,7 @@ def _run_sweep(args: argparse.Namespace) -> int:
             target_args.batch_mode = batch_mode
             target_args.prefill_range = prefill_range
             target_args.cache_lengths = cache_lengths
-            payload, rows = _run_model(target_args, label, pipeline)
+            payload, rows = _run_model(target_args, label, base, pipeline)
             payload.update(_vlm_subconfig_core_mode_payload_fields(target_args, core_mode))
             _write_json(json_path, payload)
             _write_csv(csv_path, rows)
@@ -2101,132 +2132,136 @@ def _run_measure(args: argparse.Namespace) -> int:
             vlm_total_energy_j: list[float] = []
             llm_prefill_tps_per_w: list[float] = []
             llm_decode_tps_per_w: list[float] = []
-            for repeat_idx in tqdm(range(args.repeat), desc=f"{label} measured runs", leave=False):
-                current_vision_energy: float | None = None
-                if tracker is not None:
-                    tracker.start()
-                try:
-                    vision_latency_per_image, vision_fps = measurer.measure_vision(
-                        args.image_resolution,
-                        repeat=1,
-                        prompt=args.prompt,
-                        batch_size=batch_size,
-                        show_progress=False,
-                    )[0]
-                finally:
-                    _stop_tracker_safe(tracker)
-
-                vision_device_time_series: dict[str, list[dict[str, float]]] = {}
-                if tracker is not None:
-                    metric = _extract_device_metric(tracker)
-                    vision_device_time_series = _extract_device_time_series(tracker)
-                    power = metric.get("avg_power_w")
-                    temperature = metric.get("avg_temperature_c")
-                    utilization = metric.get("avg_utilization_pct")
-                    memory_used = metric.get("avg_memory_used_mb")
-                    if temperature is not None:
-                        avg_temperature_c.append(float(temperature))
-                    if utilization is not None:
-                        avg_utilization_pct.append(float(utilization))
-                    if memory_used is not None:
-                        avg_memory_used_mb.append(float(memory_used))
-                    if power is not None:
-                        avg_power_w.append(float(power))
-                    energy = _energy_from_device_time_series(vision_device_time_series)
-                    if energy is not None:
-                        current_vision_energy = energy
-                        vision_energy_j.append(energy)
-
-                llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(target_args, pipeline)
-                try:
-                    llm_result = measurer.measure_llm_full(
-                        image_resolution=args.image_resolution,
-                        prompt=args.prompt,
-                        prefill_range=(args.prefill, args.prefill, args.prefill),
-                        cache_lengths=[args.prefill],
-                        decode_window=args.decode,
-                        prefill_chunk_size=resolved_prefill_chunk_size,
-                        batch_size=batch_size,
-                        show_progress=True,
-                        progress_prefix=f"{label} run {repeat_idx + 1}/{args.repeat}",
-                        on_prefill_start=(
-                            (lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None
-                        ),
-                        on_prefill_end=(
-                            (lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None
-                        ),
-                        on_decode_start=(
-                            (lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None
-                        ),
-                        on_decode_end=(
-                            (lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None
-                        ),
-                    )
-                finally:
-                    _stop_tracker_safe(llm_tracker_prefill)
-                    _stop_tracker_safe(llm_tracker_decode)
-
-                llm_device_time_series: dict[str, dict[str, list[dict[str, float]]]] = {}
-                if llm_tracker_prefill is not None and llm_tracker_decode is not None:
-                    prefill_metric = _extract_device_metric(llm_tracker_prefill)
-                    decode_metric = _extract_device_metric(llm_tracker_decode)
-                    prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
-                    decode_time_series = _extract_device_time_series(llm_tracker_decode)
-                    llm_device_time_series = {"prefill": prefill_time_series, "decode": decode_time_series}
-                    prefill_duration = float(getattr(llm_result, "prefill_phase_duration_s", 0.0) or 0.0)
-                    decode_duration = float(getattr(llm_result, "decode_phase_duration_s", 0.0) or 0.0)
-                    llm_result.avg_power_w = _weighted_two(
-                        prefill_metric.get("avg_power_w"),
-                        prefill_duration,
-                        decode_metric.get("avg_power_w"),
-                        decode_duration,
-                    )
-                    prefill_energy = _energy_from_device_time_series(prefill_time_series)
-                    decode_energy = _energy_from_device_time_series(decode_time_series)
-                    llm_energy = _sum_required_energies(prefill_energy, decode_energy)
-                    llm_result.llm_prefill_energy_j = prefill_energy
-                    llm_result.llm_decode_energy_j = decode_energy
-                    llm_result.llm_total_energy_j = llm_energy
-                    true_total_energy = _sum_required_energies(
-                        current_vision_energy,
-                        llm_energy,
-                    )
-                    llm_result.total_energy_j = true_total_energy
-                    if prefill_energy is not None:
-                        llm_prefill_energy_j.append(prefill_energy)
-                    if decode_energy is not None:
-                        llm_decode_energy_j.append(decode_energy)
-                    if llm_energy is not None:
-                        llm_total_energy_j.append(llm_energy)
-                        prefill_tokens = _sweep_prefill_token_count(llm_result, batch_size)
-                        decode_tokens = _sweep_decode_token_count(
-                            llm_result,
-                            decode_window=args.decode,
+            trace_handle = start_qbruntime_trace(_trace_path_for_target(args, base=base, benchmark_type="measure"))
+            try:
+                for repeat_idx in tqdm(range(args.repeat), desc=f"{label} measured runs", leave=False):
+                    current_vision_energy: float | None = None
+                    if tracker is not None:
+                        tracker.start()
+                    try:
+                        vision_latency_per_image, vision_fps = measurer.measure_vision(
+                            args.image_resolution,
+                            repeat=1,
+                            prompt=args.prompt,
                             batch_size=batch_size,
-                        )
-                        total_tokens = prefill_tokens + decode_tokens
-                        llm_result.prefill_tps_per_w = _safe_div(float(prefill_tokens), prefill_energy)
-                        llm_result.decode_tps_per_w = _safe_div(float(decode_tokens), decode_energy)
-                        llm_result.prefill_j_per_token = (
-                            _safe_div(prefill_energy, float(prefill_tokens)) if prefill_tokens > 0 else None
-                        )
-                        llm_result.decode_j_per_token = (
-                            _safe_div(decode_energy, float(decode_tokens)) if decode_tokens > 0 else None
-                        )
-                        llm_result.total_tps_per_w = _safe_div(float(total_tokens), llm_energy)
-                        llm_result.total_j_per_token = (
-                            _safe_div(llm_energy, float(total_tokens)) if total_tokens > 0 else None
-                        )
-                        if llm_result.prefill_tps_per_w is not None:
-                            llm_prefill_tps_per_w.append(float(llm_result.prefill_tps_per_w))
-                        if llm_result.decode_tps_per_w is not None:
-                            llm_decode_tps_per_w.append(float(llm_result.decode_tps_per_w))
-                    if true_total_energy is not None:
-                        vlm_total_energy_j.append(true_total_energy)
+                            show_progress=False,
+                        )[0]
+                    finally:
+                        _stop_tracker_safe(tracker)
 
-                vision_runs.append({"vision_encode_latency": vision_latency_per_image, "vision_fps": vision_fps})
-                llm_runs.append(_vlm_llm_run_payload(llm_result))
-                device_time_series_runs.append({"vision": vision_device_time_series, "llm": llm_device_time_series})
+                    vision_device_time_series: dict[str, list[dict[str, float]]] = {}
+                    if tracker is not None:
+                        metric = _extract_device_metric(tracker)
+                        vision_device_time_series = _extract_device_time_series(tracker)
+                        power = metric.get("avg_power_w")
+                        temperature = metric.get("avg_temperature_c")
+                        utilization = metric.get("avg_utilization_pct")
+                        memory_used = metric.get("avg_memory_used_mb")
+                        if temperature is not None:
+                            avg_temperature_c.append(float(temperature))
+                        if utilization is not None:
+                            avg_utilization_pct.append(float(utilization))
+                        if memory_used is not None:
+                            avg_memory_used_mb.append(float(memory_used))
+                        if power is not None:
+                            avg_power_w.append(float(power))
+                        energy = _energy_from_device_time_series(vision_device_time_series)
+                        if energy is not None:
+                            current_vision_energy = energy
+                            vision_energy_j.append(energy)
+
+                    llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(target_args, pipeline)
+                    try:
+                        llm_result = measurer.measure_llm_full(
+                            image_resolution=args.image_resolution,
+                            prompt=args.prompt,
+                            prefill_range=(args.prefill, args.prefill, args.prefill),
+                            cache_lengths=[args.prefill],
+                            decode_window=args.decode,
+                            prefill_chunk_size=resolved_prefill_chunk_size,
+                            batch_size=batch_size,
+                            show_progress=True,
+                            progress_prefix=f"{label} run {repeat_idx + 1}/{args.repeat}",
+                            on_prefill_start=(
+                                (lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None
+                            ),
+                            on_prefill_end=(
+                                (lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None
+                            ),
+                            on_decode_start=(
+                                (lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None
+                            ),
+                            on_decode_end=(
+                                (lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None
+                            ),
+                        )
+                    finally:
+                        _stop_tracker_safe(llm_tracker_prefill)
+                        _stop_tracker_safe(llm_tracker_decode)
+
+                    llm_device_time_series: dict[str, dict[str, list[dict[str, float]]]] = {}
+                    if llm_tracker_prefill is not None and llm_tracker_decode is not None:
+                        prefill_metric = _extract_device_metric(llm_tracker_prefill)
+                        decode_metric = _extract_device_metric(llm_tracker_decode)
+                        prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
+                        decode_time_series = _extract_device_time_series(llm_tracker_decode)
+                        llm_device_time_series = {"prefill": prefill_time_series, "decode": decode_time_series}
+                        prefill_duration = float(getattr(llm_result, "prefill_phase_duration_s", 0.0) or 0.0)
+                        decode_duration = float(getattr(llm_result, "decode_phase_duration_s", 0.0) or 0.0)
+                        llm_result.avg_power_w = _weighted_two(
+                            prefill_metric.get("avg_power_w"),
+                            prefill_duration,
+                            decode_metric.get("avg_power_w"),
+                            decode_duration,
+                        )
+                        prefill_energy = _energy_from_device_time_series(prefill_time_series)
+                        decode_energy = _energy_from_device_time_series(decode_time_series)
+                        llm_energy = _sum_required_energies(prefill_energy, decode_energy)
+                        llm_result.llm_prefill_energy_j = prefill_energy
+                        llm_result.llm_decode_energy_j = decode_energy
+                        llm_result.llm_total_energy_j = llm_energy
+                        true_total_energy = _sum_required_energies(
+                            current_vision_energy,
+                            llm_energy,
+                        )
+                        llm_result.total_energy_j = true_total_energy
+                        if prefill_energy is not None:
+                            llm_prefill_energy_j.append(prefill_energy)
+                        if decode_energy is not None:
+                            llm_decode_energy_j.append(decode_energy)
+                        if llm_energy is not None:
+                            llm_total_energy_j.append(llm_energy)
+                            prefill_tokens = _sweep_prefill_token_count(llm_result, batch_size)
+                            decode_tokens = _sweep_decode_token_count(
+                                llm_result,
+                                decode_window=args.decode,
+                                batch_size=batch_size,
+                            )
+                            total_tokens = prefill_tokens + decode_tokens
+                            llm_result.prefill_tps_per_w = _safe_div(float(prefill_tokens), prefill_energy)
+                            llm_result.decode_tps_per_w = _safe_div(float(decode_tokens), decode_energy)
+                            llm_result.prefill_j_per_token = (
+                                _safe_div(prefill_energy, float(prefill_tokens)) if prefill_tokens > 0 else None
+                            )
+                            llm_result.decode_j_per_token = (
+                                _safe_div(decode_energy, float(decode_tokens)) if decode_tokens > 0 else None
+                            )
+                            llm_result.total_tps_per_w = _safe_div(float(total_tokens), llm_energy)
+                            llm_result.total_j_per_token = (
+                                _safe_div(llm_energy, float(total_tokens)) if total_tokens > 0 else None
+                            )
+                            if llm_result.prefill_tps_per_w is not None:
+                                llm_prefill_tps_per_w.append(float(llm_result.prefill_tps_per_w))
+                            if llm_result.decode_tps_per_w is not None:
+                                llm_decode_tps_per_w.append(float(llm_result.decode_tps_per_w))
+                        if true_total_energy is not None:
+                            vlm_total_energy_j.append(true_total_energy)
+
+                    vision_runs.append({"vision_encode_latency": vision_latency_per_image, "vision_fps": vision_fps})
+                    llm_runs.append(_vlm_llm_run_payload(llm_result))
+                    device_time_series_runs.append({"vision": vision_device_time_series, "llm": llm_device_time_series})
+            finally:
+                stop_qbruntime_trace(trace_handle)
             llm_prefill = [
                 float(r["prefill_sweep"]["tps_values"][-1]) for r in llm_runs if r["prefill_sweep"]["tps_values"]
             ]

--- a/benchmark/transformers/benchmark_text_generation_models.py
+++ b/benchmark/transformers/benchmark_text_generation_models.py
@@ -105,6 +105,8 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_utils import (
     SweepData,
     TPSMeasurer,
     npu_latency_pct,
+    start_qbruntime_trace,
+    stop_qbruntime_trace,
 )
 
 _BATCH_MODE_BATCH = "batch"
@@ -137,6 +139,16 @@ def _format_exception(exc: BaseException) -> str:
     if message:
         return f"{type(exc).__name__}: {message}"
     return f"{type(exc).__name__}: {exc!r}"
+
+
+def _trace_path_for_target(args: argparse.Namespace, *, base: str, benchmark_type: str) -> str | None:
+    """Return a per-target qbruntime trace path when trace collection is enabled."""
+    trace_dir = getattr(args, "trace_dir", None)
+    if not trace_dir:
+        return None
+    trace_root = Path(trace_dir).expanduser().resolve()
+    trace_root.mkdir(parents=True, exist_ok=True)
+    return str(trace_root / f"{_safe_filename(base)}_{benchmark_type}_trace.json")
 
 
 def _print_exception(message: str, exc: BaseException, *, debug_errors: bool) -> None:
@@ -975,6 +987,11 @@ def _add_common_benchmark_args(parser: argparse.ArgumentParser) -> None:
         help="output directory (default: benchmark/transformers/results/text_generation)",
     )
     parser.add_argument(
+        "--trace-dir",
+        default=None,
+        help="directory for per-target qbruntime trace JSON files covering measured runs only",
+    )
+    parser.add_argument(
         "--debug-errors",
         action="store_true",
         help="print full tracebacks for per-target benchmark failures",
@@ -1367,26 +1384,37 @@ def _run_sweep(args: argparse.Namespace) -> int:
                     progress_desc=f"{label} warmup generate {i + 1}/{args.warmup}",
                 )
             run_results: list[BenchmarkResult] = []
-            for repeat_idx in tqdm(range(args.repeat), desc=f"{label} measured runs", leave=False):
-                try:
-                    run_results.append(
-                        measurer.measure_full(
-                            prefill_range=prefill_range,
-                            cache_lengths=cache_lengths,
-                            decode_window=args.decode_window,
-                            batch_size=batch_size,
-                            prefill_chunk_size=resolved_prefill_chunk_size,
-                            show_progress=True,
-                            progress_prefix=f"{label} run {repeat_idx + 1}/{args.repeat}",
-                            on_prefill_start=(lambda: tracker_prefill.start()) if tracker_prefill is not None else None,
-                            on_prefill_end=(lambda: tracker_prefill.stop()) if tracker_prefill is not None else None,
-                            on_decode_start=(lambda: tracker_decode.start()) if tracker_decode is not None else None,
-                            on_decode_end=(lambda: tracker_decode.stop()) if tracker_decode is not None else None,
+            trace_handle = start_qbruntime_trace(_trace_path_for_target(args, base=base, benchmark_type="sweep"))
+            try:
+                for repeat_idx in tqdm(range(args.repeat), desc=f"{label} measured runs", leave=False):
+                    try:
+                        run_results.append(
+                            measurer.measure_full(
+                                prefill_range=prefill_range,
+                                cache_lengths=cache_lengths,
+                                decode_window=args.decode_window,
+                                batch_size=batch_size,
+                                prefill_chunk_size=resolved_prefill_chunk_size,
+                                trace_path=None,
+                                show_progress=True,
+                                progress_prefix=f"{label} run {repeat_idx + 1}/{args.repeat}",
+                                on_prefill_start=(
+                                    (lambda: tracker_prefill.start()) if tracker_prefill is not None else None
+                                ),
+                                on_prefill_end=(
+                                    (lambda: tracker_prefill.stop()) if tracker_prefill is not None else None
+                                ),
+                                on_decode_start=(
+                                    (lambda: tracker_decode.start()) if tracker_decode is not None else None
+                                ),
+                                on_decode_end=((lambda: tracker_decode.stop()) if tracker_decode is not None else None),
+                            )
                         )
-                    )
-                finally:
-                    _stop_tracker_safe(tracker_prefill)
-                    _stop_tracker_safe(tracker_decode)
+                    finally:
+                        _stop_tracker_safe(tracker_prefill)
+                        _stop_tracker_safe(tracker_decode)
+            finally:
+                stop_qbruntime_trace(trace_handle)
             result = _aggregate_benchmark_results(run_results)
         except Exception as e:
             if _is_cuda_oom_error(e):
@@ -1917,97 +1945,94 @@ def _run_measure(args: argparse.Namespace) -> int:
                 )
             runs: list[dict[str, Any]] = []
             device_time_series_runs: list[dict[str, Any]] = []
-            for repeat_idx in tqdm(range(args.repeat), desc=f"{label} measured runs", leave=False):
-                tracker_prefill, tracker_decode = _build_phase_trackers(target_args, pipeline)
-                try:
-                    run = measurer.measure(
-                        num_prefill=args.prefill,
-                        num_decode=args.decode,
-                        batch_size=batch_size,
-                        prefill_chunk_size=resolved_prefill_chunk_size,
-                        show_progress=True,
-                        progress_desc=f"{label} run {repeat_idx + 1}/{args.repeat}",
-                        on_prefill_start=(
-                            (lambda: tracker_prefill.start()) if tracker_prefill is not None else None
-                        ),
-                        on_prefill_end=(
-                            (lambda: tracker_prefill.stop()) if tracker_prefill is not None else None
-                        ),
-                        on_decode_start=(
-                            (lambda: tracker_decode.start()) if tracker_decode is not None else None
-                        ),
-                        on_decode_end=(
-                            (lambda: tracker_decode.stop()) if tracker_decode is not None else None
-                        ),
-                    )
-                finally:
-                    _stop_tracker_safe(tracker_prefill)
-                    _stop_tracker_safe(tracker_decode)
-                row = asdict(run)
-                if tracker_prefill is not None and tracker_decode is not None:
-                    prefill_metric = _extract_device_metric(tracker_prefill)
-                    decode_metric = _extract_device_metric(tracker_decode)
-                    device_time_series = {
-                        "prefill": _extract_device_time_series(tracker_prefill),
-                        "decode": _extract_device_time_series(tracker_decode),
-                    }
-                    prefill_energy = _energy_from_device_time_series(device_time_series["prefill"])
-                    decode_energy = _energy_from_device_time_series(device_time_series["decode"])
-                    row["avg_power_w"] = _weighted_two(
-                        prefill_metric.get("avg_power_w"),
-                        run.prefill_latency,
-                        decode_metric.get("avg_power_w"),
-                        run.decode_duration,
-                    )
-                    row["p99_power_w"] = max(
-                        [
-                            v
-                            for v in (prefill_metric.get("p99_power_w"), decode_metric.get("p99_power_w"))
-                            if v is not None
-                        ],
-                        default=None,
-                    )
-                    row["avg_utilization_pct"] = _weighted_two(
-                        prefill_metric.get("avg_utilization_pct"),
-                        run.prefill_latency,
-                        decode_metric.get("avg_utilization_pct"),
-                        run.decode_duration,
-                    )
-                    row["avg_memory_used_mb"] = _weighted_two(
-                        prefill_metric.get("avg_memory_used_mb"),
-                        run.prefill_latency,
-                        decode_metric.get("avg_memory_used_mb"),
-                        run.decode_duration,
-                    )
-                    row["total_energy_j"] = (
-                        prefill_energy + decode_energy
-                        if prefill_energy is not None and decode_energy is not None
-                        else None
-                    )
-                    row["prefill_tps_per_w"] = (
-                        _safe_div(float(args.prefill) * float(batch_size), prefill_energy)
-                        if prefill_energy is not None
-                        else None
-                    )
-                    row["decode_tps_per_w"] = (
-                        _safe_div(float(args.decode) * float(batch_size), decode_energy)
-                        if decode_energy is not None
-                        else None
-                    )
-                    row["prefill_j_per_token"] = (
-                        _safe_div(1.0, float(row["prefill_tps_per_w"]))
-                        if isinstance(row.get("prefill_tps_per_w"), (int, float))
-                        else None
-                    )
-                    row["decode_j_per_token"] = (
-                        _safe_div(1.0, float(row["decode_tps_per_w"]))
-                        if isinstance(row.get("decode_tps_per_w"), (int, float))
-                        else None
-                    )
-                    device_time_series_runs.append(
-                        device_time_series
-                    )
-                runs.append(row)
+            trace_handle = start_qbruntime_trace(_trace_path_for_target(args, base=base, benchmark_type="measure"))
+            try:
+                for repeat_idx in tqdm(range(args.repeat), desc=f"{label} measured runs", leave=False):
+                    tracker_prefill, tracker_decode = _build_phase_trackers(target_args, pipeline)
+                    try:
+                        run = measurer.measure(
+                            num_prefill=args.prefill,
+                            num_decode=args.decode,
+                            batch_size=batch_size,
+                            prefill_chunk_size=resolved_prefill_chunk_size,
+                            trace_path=None,
+                            show_progress=True,
+                            progress_desc=f"{label} run {repeat_idx + 1}/{args.repeat}",
+                            on_prefill_start=(
+                                (lambda: tracker_prefill.start()) if tracker_prefill is not None else None
+                            ),
+                            on_prefill_end=((lambda: tracker_prefill.stop()) if tracker_prefill is not None else None),
+                            on_decode_start=((lambda: tracker_decode.start()) if tracker_decode is not None else None),
+                            on_decode_end=((lambda: tracker_decode.stop()) if tracker_decode is not None else None),
+                        )
+                    finally:
+                        _stop_tracker_safe(tracker_prefill)
+                        _stop_tracker_safe(tracker_decode)
+                    row = asdict(run)
+                    if tracker_prefill is not None and tracker_decode is not None:
+                        prefill_metric = _extract_device_metric(tracker_prefill)
+                        decode_metric = _extract_device_metric(tracker_decode)
+                        device_time_series = {
+                            "prefill": _extract_device_time_series(tracker_prefill),
+                            "decode": _extract_device_time_series(tracker_decode),
+                        }
+                        prefill_energy = _energy_from_device_time_series(device_time_series["prefill"])
+                        decode_energy = _energy_from_device_time_series(device_time_series["decode"])
+                        row["avg_power_w"] = _weighted_two(
+                            prefill_metric.get("avg_power_w"),
+                            run.prefill_latency,
+                            decode_metric.get("avg_power_w"),
+                            run.decode_duration,
+                        )
+                        row["p99_power_w"] = max(
+                            [
+                                v
+                                for v in (prefill_metric.get("p99_power_w"), decode_metric.get("p99_power_w"))
+                                if v is not None
+                            ],
+                            default=None,
+                        )
+                        row["avg_utilization_pct"] = _weighted_two(
+                            prefill_metric.get("avg_utilization_pct"),
+                            run.prefill_latency,
+                            decode_metric.get("avg_utilization_pct"),
+                            run.decode_duration,
+                        )
+                        row["avg_memory_used_mb"] = _weighted_two(
+                            prefill_metric.get("avg_memory_used_mb"),
+                            run.prefill_latency,
+                            decode_metric.get("avg_memory_used_mb"),
+                            run.decode_duration,
+                        )
+                        row["total_energy_j"] = (
+                            prefill_energy + decode_energy
+                            if prefill_energy is not None and decode_energy is not None
+                            else None
+                        )
+                        row["prefill_tps_per_w"] = (
+                            _safe_div(float(args.prefill) * float(batch_size), prefill_energy)
+                            if prefill_energy is not None
+                            else None
+                        )
+                        row["decode_tps_per_w"] = (
+                            _safe_div(float(args.decode) * float(batch_size), decode_energy)
+                            if decode_energy is not None
+                            else None
+                        )
+                        row["prefill_j_per_token"] = (
+                            _safe_div(1.0, float(row["prefill_tps_per_w"]))
+                            if isinstance(row.get("prefill_tps_per_w"), (int, float))
+                            else None
+                        )
+                        row["decode_j_per_token"] = (
+                            _safe_div(1.0, float(row["decode_tps_per_w"]))
+                            if isinstance(row.get("decode_tps_per_w"), (int, float))
+                            else None
+                        )
+                        device_time_series_runs.append(device_time_series)
+                    runs.append(row)
+            finally:
+                stop_qbruntime_trace(trace_handle)
             payload = {
                 "model": label,
                 "benchmark_type": "measure",

--- a/mblt_model_zoo/cli/tps.py
+++ b/mblt_model_zoo/cli/tps.py
@@ -9,6 +9,7 @@ import random
 import sys
 import warnings
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence, Tuple, Union
 
 import torch
@@ -65,6 +66,31 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
 
 _SWEEP_WARMUP_PREFILL = 128
 _SWEEP_WARMUP_DECODE = 32
+_DEFAULT_TPS_TASK = "text-generation"
+_VLM_TASK_FALLBACK = "image-text-to-text"
+_VLM_MODEL_TYPE_MARKERS = (
+    "_vl",
+    "-vl",
+    "vlm",
+    "vision2seq",
+    "blip",
+    "aya_vision",
+)
+
+
+class _TaskAction(argparse.Action):
+    """Argparse action that records whether ``--task`` was explicitly supplied."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,
+    ) -> None:
+        del parser, option_string
+        setattr(namespace, self.dest, values)
+        setattr(namespace, "task_explicit", True)
 
 
 @dataclass(frozen=True)
@@ -230,6 +256,71 @@ def _parse_target_clusters(spec: Union[str, None]) -> Union[list[int], None]:
 def _is_vlm_task(task: str) -> bool:
     """Return whether a transformers pipeline task should use VLM TPS measurement."""
     return task in {"image-text-to-text", "image-to-text"}
+
+
+def _is_vlm_config(config: Any) -> bool:
+    """Return whether a Transformers config appears to describe a VLM model."""
+    if getattr(config, "vision_config", None) is not None and getattr(config, "text_config", None) is not None:
+        return True
+
+    model_type = str(getattr(config, "model_type", "") or "").lower()
+    if any(marker in model_type for marker in _VLM_MODEL_TYPE_MARKERS):
+        return True
+
+    architectures = getattr(config, "architectures", None)
+    if isinstance(architectures, (list, tuple)):
+        return any(any(marker in str(item).lower() for marker in _VLM_MODEL_TYPE_MARKERS) for item in architectures)
+
+    return False
+
+
+def _auto_detect_vlm_task(args: argparse.Namespace) -> str | None:
+    """Detect a VLM task from model config when the user did not explicitly pass ``--task``."""
+    try:
+        from transformers import AutoConfig
+    except Exception as exc:
+        warnings.warn(
+            f"Could not import transformers to auto-detect TPS task; keeping task={args.task!r}: {exc}",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+
+    config_kwargs: dict[str, Any] = {"trust_remote_code": args.trust_remote_code}
+    if args.revision:
+        config_kwargs["revision"] = args.revision
+    try:
+        config = AutoConfig.from_pretrained(args.model, **config_kwargs)
+    except Exception as exc:
+        warnings.warn(
+            f"Could not inspect model config to auto-detect TPS task; keeping task={args.task!r}: {exc}",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+
+    if not _is_vlm_config(config):
+        return None
+    return _VLM_TASK_FALLBACK
+
+
+def _normalize_task_defaults(args: argparse.Namespace) -> None:
+    """Infer the TPS pipeline task for VLM models unless the user supplied ``--task`` explicitly."""
+    if getattr(args, "task_explicit", False):
+        return
+    if getattr(args, "task", None) != _DEFAULT_TPS_TASK:
+        return
+
+    detected_task = _auto_detect_vlm_task(args)
+    if detected_task is None or detected_task == args.task:
+        return
+
+    print(
+        f"[tps] auto-detected VLM model; using task={detected_task}. "
+        f"Pass --task {_DEFAULT_TPS_TASK} to force text-only measurement.",
+        file=sys.stderr,
+    )
+    args.task = detected_task
 
 
 def _apply_vlm_core_mode_model_kwargs(
@@ -732,6 +823,14 @@ def _start_qbruntime_trace(trace_path: str | None):
     return start_qbruntime_trace(trace_path)
 
 
+def _phase_trace_path(trace_path: str | None, phase: str) -> str | None:
+    """Return a phase-specific trace path derived from a user-provided path."""
+    if not trace_path:
+        return None
+    path = Path(trace_path)
+    return str(path.with_name(f"{path.stem}.{phase}{path.suffix}"))
+
+
 def _stop_qbruntime_trace(handle) -> None:
     """Stop qbruntime event tracing for a CLI measured section."""
     from mblt_model_zoo.hf_transformers.utils.benchmark_utils import stop_qbruntime_trace
@@ -1190,6 +1289,7 @@ def _vlm_llm_aggregate_payload(result: Any) -> dict[str, Any]:
 
 def _cmd_measure(args: argparse.Namespace) -> int:
     """Dispatch a single TPS measurement to the text or VLM measurement path."""
+    _normalize_task_defaults(args)
     if _is_vlm_task(args.task):
         return _run_vlm_measure(args)
     return _run_text_measure(args)
@@ -1604,28 +1704,60 @@ def _run_vlm_measure(args: argparse.Namespace) -> int:
     tracker = _build_device_tracker(args, pipeline)
     _print_device_status(args, tracker)
 
-    for i in tqdm(range(args.warmup), desc="warmup runs", leave=False):
-        _measure_fixed_vlm_run(show_progress=False)
+    for _ in tqdm(range(args.warmup), desc="vision warmup runs", leave=False):
+        measurer.measure_vision(
+            image_resolution=args.image_resolution,
+            repeat=1,
+            prompt=args.prompt,
+            batch_size=batch_size,
+            show_progress=False,
+        )
 
-    runs = []
-    device_metrics = []
-    device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
-    trace_handle = _start_qbruntime_trace(getattr(args, "trace", None))
+    vision_trace_path = _phase_trace_path(getattr(args, "trace", None), "vision")
+    llm_trace_path = _phase_trace_path(getattr(args, "trace", None), "llm")
+    vision_runs = []
+    vision_device_metrics: list[dict[str, Optional[float]]] = []
+    vision_device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
+
+    trace_handle = _start_qbruntime_trace(vision_trace_path)
     try:
-        for _ in tqdm(range(args.repeat), desc="measure runs", leave=False):
+        for _ in tqdm(range(args.repeat), desc="vision measure runs", leave=False):
             if tracker is not None:
                 tracker.start()
             try:
-                vision_latency, vision_fps = measurer.measure_vision(
-                    image_resolution=args.image_resolution,
-                    repeat=1,
-                    prompt=args.prompt,
-                    batch_size=batch_size,
-                    show_progress=False,
-                )[0]
+                vision_runs.append(
+                    measurer.measure_vision(
+                        image_resolution=args.image_resolution,
+                        repeat=1,
+                        prompt=args.prompt,
+                        batch_size=batch_size,
+                        show_progress=False,
+                    )[0]
+                )
             finally:
                 _stop_tracker_safe(tracker)
-            llm_result = None
+            if tracker is not None:
+                vision_device_metrics.append(_extract_device_metric(tracker))
+                vision_device_time_series_runs.append(_extract_device_time_series(tracker))
+    finally:
+        _stop_qbruntime_trace(trace_handle)
+
+    for _ in tqdm(range(args.warmup), desc="llm warmup runs", leave=False):
+        measurer.measure_llm_full(
+            image_resolution=args.image_resolution,
+            prompt=args.prompt,
+            prefill_range=(args.prefill, args.prefill, args.prefill),
+            cache_lengths=[args.prefill],
+            decode_window=args.decode,
+            prefill_chunk_size=args.prefill_chunk_size,
+            show_progress=False,
+            batch_size=batch_size,
+        )
+
+    llm_results = []
+    trace_handle = _start_qbruntime_trace(llm_trace_path)
+    try:
+        for _ in tqdm(range(args.repeat), desc="llm measure runs", leave=False):
             llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
             try:
                 llm_result = measurer.measure_llm_full(
@@ -1645,42 +1777,49 @@ def _run_vlm_measure(args: argparse.Namespace) -> int:
             finally:
                 _stop_tracker_safe(llm_tracker_prefill)
                 _stop_tracker_safe(llm_tracker_decode)
-            run = VLMSingleMeasurement(
-                image_resolution=args.image_resolution,
-                vision_encode_latency=vision_latency,
-                vision_fps=vision_fps,
-                llm=_single_llm_measurement(llm_result),
-            )
+            llm_measurement = _single_llm_measurement(llm_result)
             if llm_tracker_prefill is not None and llm_tracker_decode is not None:
                 prefill_metric = _extract_device_metric(llm_tracker_prefill)
                 decode_metric = _extract_device_metric(llm_tracker_decode)
                 prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
                 decode_time_series = _extract_device_time_series(llm_tracker_decode)
                 _enrich_single_run_device(
-                    run=run.llm,
+                    run=llm_measurement,
                     prefill_metric=prefill_metric,
                     decode_metric=decode_metric,
                     batch_size=batch_size,
                     prefill_time_series=prefill_time_series,
                     decode_time_series=decode_time_series,
                 )
-            runs.append(run)
-            if tracker is not None:
-                metric = _extract_device_metric(tracker)
-                device_time_series = _extract_device_time_series(tracker)
-                vision_energy = _energy_from_device_time_series(device_time_series)
-                llm_prefill_energy = getattr(run.llm, "prefill_energy_j", None)
-                llm_decode_energy = getattr(run.llm, "decode_energy_j", None)
-                llm_energy = getattr(run.llm, "total_energy_j", None)
-                metric["vision_energy_j"] = vision_energy
-                metric["llm_prefill_energy_j"] = llm_prefill_energy
-                metric["llm_decode_energy_j"] = llm_decode_energy
-                metric["llm_total_energy_j"] = llm_energy
-                metric["total_energy_j"] = _sum_required_energies(vision_energy, llm_energy)
-                device_metrics.append(metric)
-                device_time_series_runs.append(device_time_series)
+            llm_results.append(llm_measurement)
     finally:
         _stop_qbruntime_trace(trace_handle)
+
+    runs = []
+    device_metrics = []
+    device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
+    for idx, ((vision_latency, vision_fps), llm_measurement) in enumerate(zip(vision_runs, llm_results)):
+        run = VLMSingleMeasurement(
+            image_resolution=args.image_resolution,
+            vision_encode_latency=vision_latency,
+            vision_fps=vision_fps,
+            llm=llm_measurement,
+        )
+        runs.append(run)
+        if idx < len(vision_device_metrics) and idx < len(vision_device_time_series_runs):
+            metric = vision_device_metrics[idx]
+            device_time_series = vision_device_time_series_runs[idx]
+            vision_energy = _energy_from_device_time_series(device_time_series)
+            llm_prefill_energy = getattr(run.llm, "prefill_energy_j", None)
+            llm_decode_energy = getattr(run.llm, "decode_energy_j", None)
+            llm_energy = getattr(run.llm, "total_energy_j", None)
+            metric["vision_energy_j"] = vision_energy
+            metric["llm_prefill_energy_j"] = llm_prefill_energy
+            metric["llm_decode_energy_j"] = llm_decode_energy
+            metric["llm_total_energy_j"] = llm_energy
+            metric["total_energy_j"] = _sum_required_energies(vision_energy, llm_energy)
+            device_metrics.append(metric)
+            device_time_series_runs.append(device_time_series)
 
     vision_ms = [r.vision_encode_latency * 1000.0 for r in runs]
     vision_fps = [r.vision_fps for r in runs]
@@ -1799,6 +1938,7 @@ def _run_vlm_measure(args: argparse.Namespace) -> int:
 
 def _cmd_sweep(args: argparse.Namespace) -> int:
     """Dispatch a TPS sweep to the text or VLM measurement path."""
+    _normalize_task_defaults(args)
     if _is_vlm_task(args.task):
         return _run_vlm_sweep(args)
     return _run_text_sweep(args)
@@ -2344,18 +2484,10 @@ def _run_vlm_sweep(args: argparse.Namespace) -> int:
             )
 
     llm_resolution = args.llm_resolution if args.llm_resolution is not None else args.image_resolutions[0]
-    for _ in range(args.warmup):
-        measurer.measure_llm_full(
-            image_resolution=llm_resolution,
-            prompt=args.prompt,
-            prefill_range=args.prefill_range,
-            cache_lengths=args.cache_lengths,
-            decode_window=args.decode_window,
-            show_progress=False,
-            batch_size=batch_size,
-        )
+    vision_trace_path = _phase_trace_path(getattr(args, "trace", None), "vision")
+    llm_trace_path = _phase_trace_path(getattr(args, "trace", None), "llm")
 
-    trace_handle = _start_qbruntime_trace(getattr(args, "trace", None))
+    trace_handle = _start_qbruntime_trace(vision_trace_path)
     try:
         for resolution in args.image_resolutions:
             vision_runs = []
@@ -2542,8 +2674,24 @@ def _run_vlm_sweep(args: argparse.Namespace) -> int:
                 }
             )
 
-        llm_runs = []
-        llm_device_time_series_runs: list[dict[str, dict[str, list[dict[str, float]]]]] = []
+    finally:
+        _stop_qbruntime_trace(trace_handle)
+
+    for _ in range(args.warmup):
+        measurer.measure_llm_full(
+            image_resolution=llm_resolution,
+            prompt=args.prompt,
+            prefill_range=args.prefill_range,
+            cache_lengths=args.cache_lengths,
+            decode_window=args.decode_window,
+            show_progress=False,
+            batch_size=batch_size,
+        )
+
+    llm_runs = []
+    llm_device_time_series_runs: list[dict[str, dict[str, list[dict[str, float]]]]] = []
+    trace_handle = _start_qbruntime_trace(llm_trace_path)
+    try:
         for _ in tqdm(range(args.repeat), desc=f"llm@{llm_resolution}", leave=False):
             llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
             try:
@@ -2844,7 +2992,13 @@ def add_tps_parser(
     tps_sub = parser.add_subparsers(dest="tps_cmd", required=True)
 
     def add_common(p: argparse.ArgumentParser) -> None:
-        p.add_argument("--task", default="text-generation", help="transformers pipeline task")
+        p.set_defaults(task_explicit=False)
+        p.add_argument(
+            "--task",
+            action=_TaskAction,
+            default=_DEFAULT_TPS_TASK,
+            help="transformers pipeline task",
+        )
         p.add_argument(
             "--model",
             required=True,

--- a/mblt_model_zoo/cli/tps.py
+++ b/mblt_model_zoo/cli/tps.py
@@ -725,6 +725,20 @@ def _write_csv(path: str, rows: Sequence[dict[str, Any]]) -> None:
             writer.writerow({k: ("" if row.get(k) is None else row.get(k)) for k in fieldnames})
 
 
+def _start_qbruntime_trace(trace_path: str | None):
+    """Start qbruntime event tracing for a CLI measured section."""
+    from mblt_model_zoo.hf_transformers.utils.benchmark_utils import start_qbruntime_trace
+
+    return start_qbruntime_trace(trace_path)
+
+
+def _stop_qbruntime_trace(handle) -> None:
+    """Stop qbruntime event tracing for a CLI measured section."""
+    from mblt_model_zoo.hf_transformers.utils.benchmark_utils import stop_qbruntime_trace
+
+    stop_qbruntime_trace(handle)
+
+
 def _percentile(values: Sequence[float], q: float) -> float:
     if not values:
         return 0.0
@@ -1238,48 +1252,52 @@ def _run_text_measure(args: argparse.Namespace) -> int:
         )
     runs = []
     run_phase_device_time_series: list[dict[str, dict[str, list[dict[str, float]]]]] = []
-    for i in tqdm(range(args.repeat), desc="measure runs", leave=False):
-        prefill_metric: dict[str, Optional[float]] = {}
-        decode_metric: dict[str, Optional[float]] = {}
-        tracker_prefill, tracker_decode = _build_phase_trackers(args, pipeline)
-        try:
-            run = measurer.measure(
-                num_prefill=measure_num_prefill,
-                num_decode=args.decode,
-                input_ids=measure_input_ids,
-                prefill_chunk_size=args.prefill_chunk_size,
-                trace_path=args.trace if i == 0 else None,
-                show_progress=True,
-                progress_desc=f"measure generate {i + 1}/{args.repeat}",
-                on_prefill_start=((lambda: tracker_prefill.start()) if tracker_prefill is not None else None),
-                on_prefill_end=((lambda: tracker_prefill.stop()) if tracker_prefill is not None else None),
-                on_decode_start=((lambda: tracker_decode.start()) if tracker_decode is not None else None),
-                on_decode_end=((lambda: tracker_decode.stop()) if tracker_decode is not None else None),
-                batch_size=batch_size,
-            )
-        finally:
-            _stop_tracker_safe(tracker_prefill)
-            _stop_tracker_safe(tracker_decode)
-        if tracker_prefill is not None and tracker_decode is not None:
-            prefill_metric = _extract_device_metric(tracker_prefill)
-            decode_metric = _extract_device_metric(tracker_decode)
-            prefill_time_series = _extract_device_time_series(tracker_prefill)
-            decode_time_series = _extract_device_time_series(tracker_decode)
-            run_phase_device_time_series.append(
-                {
-                    "prefill": prefill_time_series,
-                    "decode": decode_time_series,
-                }
-            )
-            _enrich_single_run_device(
-                run=run,
-                prefill_metric=prefill_metric,
-                decode_metric=decode_metric,
-                batch_size=batch_size,
-                prefill_time_series=prefill_time_series,
-                decode_time_series=decode_time_series,
-            )
-        runs.append(run)
+    trace_handle = _start_qbruntime_trace(getattr(args, "trace", None))
+    try:
+        for i in tqdm(range(args.repeat), desc="measure runs", leave=False):
+            prefill_metric: dict[str, Optional[float]] = {}
+            decode_metric: dict[str, Optional[float]] = {}
+            tracker_prefill, tracker_decode = _build_phase_trackers(args, pipeline)
+            try:
+                run = measurer.measure(
+                    num_prefill=measure_num_prefill,
+                    num_decode=args.decode,
+                    input_ids=measure_input_ids,
+                    prefill_chunk_size=args.prefill_chunk_size,
+                    trace_path=None,
+                    show_progress=True,
+                    progress_desc=f"measure generate {i + 1}/{args.repeat}",
+                    on_prefill_start=((lambda: tracker_prefill.start()) if tracker_prefill is not None else None),
+                    on_prefill_end=((lambda: tracker_prefill.stop()) if tracker_prefill is not None else None),
+                    on_decode_start=((lambda: tracker_decode.start()) if tracker_decode is not None else None),
+                    on_decode_end=((lambda: tracker_decode.stop()) if tracker_decode is not None else None),
+                    batch_size=batch_size,
+                )
+            finally:
+                _stop_tracker_safe(tracker_prefill)
+                _stop_tracker_safe(tracker_decode)
+            if tracker_prefill is not None and tracker_decode is not None:
+                prefill_metric = _extract_device_metric(tracker_prefill)
+                decode_metric = _extract_device_metric(tracker_decode)
+                prefill_time_series = _extract_device_time_series(tracker_prefill)
+                decode_time_series = _extract_device_time_series(tracker_decode)
+                run_phase_device_time_series.append(
+                    {
+                        "prefill": prefill_time_series,
+                        "decode": decode_time_series,
+                    }
+                )
+                _enrich_single_run_device(
+                    run=run,
+                    prefill_metric=prefill_metric,
+                    decode_metric=decode_metric,
+                    batch_size=batch_size,
+                    prefill_time_series=prefill_time_series,
+                    decode_time_series=decode_time_series,
+                )
+            runs.append(run)
+    finally:
+        _stop_qbruntime_trace(trace_handle)
 
     prefill_tps = [r.prefill_tps for r in runs]
     decode_tps = [r.decode_tps for r in runs]
@@ -1592,73 +1610,77 @@ def _run_vlm_measure(args: argparse.Namespace) -> int:
     runs = []
     device_metrics = []
     device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
-    for _ in tqdm(range(args.repeat), desc="measure runs", leave=False):
-        if tracker is not None:
-            tracker.start()
-        try:
-            vision_latency, vision_fps = measurer.measure_vision(
+    trace_handle = _start_qbruntime_trace(getattr(args, "trace", None))
+    try:
+        for _ in tqdm(range(args.repeat), desc="measure runs", leave=False):
+            if tracker is not None:
+                tracker.start()
+            try:
+                vision_latency, vision_fps = measurer.measure_vision(
+                    image_resolution=args.image_resolution,
+                    repeat=1,
+                    prompt=args.prompt,
+                    batch_size=batch_size,
+                    show_progress=False,
+                )[0]
+            finally:
+                _stop_tracker_safe(tracker)
+            llm_result = None
+            llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
+            try:
+                llm_result = measurer.measure_llm_full(
+                    image_resolution=args.image_resolution,
+                    prompt=args.prompt,
+                    prefill_range=(args.prefill, args.prefill, args.prefill),
+                    cache_lengths=[args.prefill],
+                    decode_window=args.decode,
+                    prefill_chunk_size=args.prefill_chunk_size,
+                    show_progress=False,
+                    batch_size=batch_size,
+                    on_prefill_start=(lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None,
+                    on_prefill_end=(lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None,
+                    on_decode_start=(lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None,
+                    on_decode_end=(lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None,
+                )
+            finally:
+                _stop_tracker_safe(llm_tracker_prefill)
+                _stop_tracker_safe(llm_tracker_decode)
+            run = VLMSingleMeasurement(
                 image_resolution=args.image_resolution,
-                repeat=1,
-                prompt=args.prompt,
-                batch_size=batch_size,
-                show_progress=False,
-            )[0]
-        finally:
-            _stop_tracker_safe(tracker)
-        llm_result = None
-        llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
-        try:
-            llm_result = measurer.measure_llm_full(
-                image_resolution=args.image_resolution,
-                prompt=args.prompt,
-                prefill_range=(args.prefill, args.prefill, args.prefill),
-                cache_lengths=[args.prefill],
-                decode_window=args.decode,
-                prefill_chunk_size=args.prefill_chunk_size,
-                show_progress=False,
-                batch_size=batch_size,
-                on_prefill_start=(lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None,
-                on_prefill_end=(lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None,
-                on_decode_start=(lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None,
-                on_decode_end=(lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None,
+                vision_encode_latency=vision_latency,
+                vision_fps=vision_fps,
+                llm=_single_llm_measurement(llm_result),
             )
-        finally:
-            _stop_tracker_safe(llm_tracker_prefill)
-            _stop_tracker_safe(llm_tracker_decode)
-        run = VLMSingleMeasurement(
-            image_resolution=args.image_resolution,
-            vision_encode_latency=vision_latency,
-            vision_fps=vision_fps,
-            llm=_single_llm_measurement(llm_result),
-        )
-        if llm_tracker_prefill is not None and llm_tracker_decode is not None:
-            prefill_metric = _extract_device_metric(llm_tracker_prefill)
-            decode_metric = _extract_device_metric(llm_tracker_decode)
-            prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
-            decode_time_series = _extract_device_time_series(llm_tracker_decode)
-            _enrich_single_run_device(
-                run=run.llm,
-                prefill_metric=prefill_metric,
-                decode_metric=decode_metric,
-                batch_size=batch_size,
-                prefill_time_series=prefill_time_series,
-                decode_time_series=decode_time_series,
-            )
-        runs.append(run)
-        if tracker is not None:
-            metric = _extract_device_metric(tracker)
-            device_time_series = _extract_device_time_series(tracker)
-            vision_energy = _energy_from_device_time_series(device_time_series)
-            llm_prefill_energy = getattr(run.llm, "prefill_energy_j", None)
-            llm_decode_energy = getattr(run.llm, "decode_energy_j", None)
-            llm_energy = getattr(run.llm, "total_energy_j", None)
-            metric["vision_energy_j"] = vision_energy
-            metric["llm_prefill_energy_j"] = llm_prefill_energy
-            metric["llm_decode_energy_j"] = llm_decode_energy
-            metric["llm_total_energy_j"] = llm_energy
-            metric["total_energy_j"] = _sum_required_energies(vision_energy, llm_energy)
-            device_metrics.append(metric)
-            device_time_series_runs.append(device_time_series)
+            if llm_tracker_prefill is not None and llm_tracker_decode is not None:
+                prefill_metric = _extract_device_metric(llm_tracker_prefill)
+                decode_metric = _extract_device_metric(llm_tracker_decode)
+                prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
+                decode_time_series = _extract_device_time_series(llm_tracker_decode)
+                _enrich_single_run_device(
+                    run=run.llm,
+                    prefill_metric=prefill_metric,
+                    decode_metric=decode_metric,
+                    batch_size=batch_size,
+                    prefill_time_series=prefill_time_series,
+                    decode_time_series=decode_time_series,
+                )
+            runs.append(run)
+            if tracker is not None:
+                metric = _extract_device_metric(tracker)
+                device_time_series = _extract_device_time_series(tracker)
+                vision_energy = _energy_from_device_time_series(device_time_series)
+                llm_prefill_energy = getattr(run.llm, "prefill_energy_j", None)
+                llm_decode_energy = getattr(run.llm, "decode_energy_j", None)
+                llm_energy = getattr(run.llm, "total_energy_j", None)
+                metric["vision_energy_j"] = vision_energy
+                metric["llm_prefill_energy_j"] = llm_prefill_energy
+                metric["llm_decode_energy_j"] = llm_decode_energy
+                metric["llm_total_energy_j"] = llm_energy
+                metric["total_energy_j"] = _sum_required_energies(vision_energy, llm_energy)
+                device_metrics.append(metric)
+                device_time_series_runs.append(device_time_series)
+    finally:
+        _stop_qbruntime_trace(trace_handle)
 
     vision_ms = [r.vision_encode_latency * 1000.0 for r in runs]
     vision_fps = [r.vision_fps for r in runs]
@@ -1856,196 +1878,200 @@ def _run_text_sweep(args: argparse.Namespace) -> int:
     run_decode_p99_mem_used_pct: list[float] = []
     run_phase_device: list[dict[str, dict[str, Optional[float]]]] = []
     run_phase_device_time_series: list[dict[str, dict[str, list[dict[str, float]]]]] = []
-    for i in tqdm(range(args.repeat), desc="sweep runs", leave=False):
-        prefill_metric: dict[str, Optional[float]] = {}
-        decode_metric: dict[str, Optional[float]] = {}
-        tracker_prefill, tracker_decode = _build_phase_trackers(args, pipeline)
-        try:
-            runs.append(
-                measurer.measure_full(
-                    prefill_range=args.prefill_range,
-                    cache_lengths=args.cache_lengths,
-                    decode_window=args.decode_window,
-                    prefill_chunk_size=args.prefill_chunk_size,
-                    trace_path=args.trace if i == 0 else None,
-                    show_progress=True,
-                    progress_prefix=f"run {i + 1}/{args.repeat}",
-                    on_prefill_start=(lambda: tracker_prefill.start()) if tracker_prefill is not None else None,
-                    on_prefill_end=(lambda: tracker_prefill.stop()) if tracker_prefill is not None else None,
-                    on_decode_start=(lambda: tracker_decode.start()) if tracker_decode is not None else None,
-                    on_decode_end=(lambda: tracker_decode.stop()) if tracker_decode is not None else None,
-                    batch_size=batch_size,
+    trace_handle = _start_qbruntime_trace(getattr(args, "trace", None))
+    try:
+        for i in tqdm(range(args.repeat), desc="sweep runs", leave=False):
+            prefill_metric: dict[str, Optional[float]] = {}
+            decode_metric: dict[str, Optional[float]] = {}
+            tracker_prefill, tracker_decode = _build_phase_trackers(args, pipeline)
+            try:
+                runs.append(
+                    measurer.measure_full(
+                        prefill_range=args.prefill_range,
+                        cache_lengths=args.cache_lengths,
+                        decode_window=args.decode_window,
+                        prefill_chunk_size=args.prefill_chunk_size,
+                        trace_path=None,
+                        show_progress=True,
+                        progress_prefix=f"run {i + 1}/{args.repeat}",
+                        on_prefill_start=(lambda: tracker_prefill.start()) if tracker_prefill is not None else None,
+                        on_prefill_end=(lambda: tracker_prefill.stop()) if tracker_prefill is not None else None,
+                        on_decode_start=(lambda: tracker_decode.start()) if tracker_decode is not None else None,
+                        on_decode_end=(lambda: tracker_decode.stop()) if tracker_decode is not None else None,
+                        batch_size=batch_size,
+                    )
                 )
-            )
-        finally:
-            _stop_tracker_safe(tracker_prefill)
-            _stop_tracker_safe(tracker_decode)
-        if tracker_prefill is not None and tracker_decode is not None:
-            prefill_metric = _extract_device_metric(tracker_prefill)
-            decode_metric = _extract_device_metric(tracker_decode)
-            run_phase_device.append({"prefill": prefill_metric, "decode": decode_metric})
-            prefill_time_series = _extract_device_time_series(tracker_prefill)
-            decode_time_series = _extract_device_time_series(tracker_decode)
-            run_phase_device_time_series.append(
-                {
-                    "prefill": prefill_time_series,
-                    "decode": decode_time_series,
-                }
-            )
-            _enrich_single_run_device(
-                run=runs[-1],
-                prefill_metric=prefill_metric,
-                decode_metric=decode_metric,
-                batch_size=batch_size,
-                prefill_time_series=prefill_time_series,
-                decode_time_series=decode_time_series,
-                decode_window=args.decode_window,
-            )
-            prefill_dur = float(getattr(runs[-1], "prefill_phase_duration_s", 0.0) or 0.0)
-            decode_dur = float(getattr(runs[-1], "decode_phase_duration_s", 0.0) or 0.0)
-            avg_power = _weighted_two(
-                prefill_metric.get("avg_power_w"),
-                prefill_dur,
-                decode_metric.get("avg_power_w"),
-                decode_dur,
-            )
-            if avg_power is not None:
-                run_avg_power.append(avg_power)
-            prefill_energy = _energy_from_device_time_series(prefill_time_series)
-            decode_energy = _energy_from_device_time_series(decode_time_series)
-            total_energy = _sum_required_energies(prefill_energy, decode_energy)
-            if total_energy is not None:
-                run_total_energy.append(total_energy)
-            p99_power = max(
-                [v for v in (prefill_metric.get("p99_power_w"), decode_metric.get("p99_power_w")) if v is not None],
-                default=None,
-            )
-            if p99_power is not None:
-                run_p99_power.append(float(p99_power))
-            avg_util = _weighted_two(
-                prefill_metric.get("avg_utilization_pct"),
-                prefill_dur,
-                decode_metric.get("avg_utilization_pct"),
-                decode_dur,
-            )
-            if avg_util is not None:
-                run_avg_utilization.append(float(avg_util))
-            p99_util = max(
-                [
-                    v
-                    for v in (
-                        prefill_metric.get("p99_utilization_pct"),
-                        decode_metric.get("p99_utilization_pct"),
-                    )
-                    if v is not None
-                ],
-                default=None,
-            )
-            if p99_util is not None:
-                run_p99_utilization.append(float(p99_util))
-            avg_temp = _weighted_two(
-                prefill_metric.get("avg_temperature_c"),
-                prefill_dur,
-                decode_metric.get("avg_temperature_c"),
-                decode_dur,
-            )
-            if avg_temp is not None:
-                run_avg_temperature.append(float(avg_temp))
-            p99_temp = max(
-                [
-                    v
-                    for v in (
-                        prefill_metric.get("p99_temperature_c"),
-                        decode_metric.get("p99_temperature_c"),
-                    )
-                    if v is not None
-                ],
-                default=None,
-            )
-            if p99_temp is not None:
-                run_p99_temperature.append(float(p99_temp))
-            avg_mem_used_mb = _weighted_two(
-                prefill_metric.get("avg_memory_used_mb"),
-                prefill_dur,
-                decode_metric.get("avg_memory_used_mb"),
-                decode_dur,
-            )
-            if avg_mem_used_mb is not None:
-                run_avg_memory_used_mb.append(float(avg_mem_used_mb))
-            p99_mem_used_mb = max(
-                [
-                    v
-                    for v in (
-                        prefill_metric.get("p99_memory_used_mb"),
-                        decode_metric.get("p99_memory_used_mb"),
-                    )
-                    if v is not None
-                ],
-                default=None,
-            )
-            if p99_mem_used_mb is not None:
-                run_p99_memory_used_mb.append(float(p99_mem_used_mb))
-            total_memory_mb = max(
-                [
-                    v
-                    for v in (prefill_metric.get("total_memory_mb"), decode_metric.get("total_memory_mb"))
-                    if v is not None
-                ],
-                default=None,
-            )
-            if total_memory_mb is not None:
-                run_total_memory_mb.append(float(total_memory_mb))
-            avg_mem_used_pct = _weighted_two(
-                prefill_metric.get("avg_memory_used_pct"),
-                prefill_dur,
-                decode_metric.get("avg_memory_used_pct"),
-                decode_dur,
-            )
-            if avg_mem_used_pct is not None:
-                run_avg_memory_used_pct.append(float(avg_mem_used_pct))
-            p99_mem_used_pct = max(
-                [
-                    v
-                    for v in (
-                        prefill_metric.get("p99_memory_used_pct"),
-                        decode_metric.get("p99_memory_used_pct"),
-                    )
-                    if v is not None
-                ],
-                default=None,
-            )
-            if p99_mem_used_pct is not None:
-                run_p99_memory_used_pct.append(float(p99_mem_used_pct))
-            for dst, key in (
-                (run_prefill_avg_power, "avg_power_w"),
-                (run_prefill_p99_power, "p99_power_w"),
-                (run_prefill_avg_util, "avg_utilization_pct"),
-                (run_prefill_p99_util, "p99_utilization_pct"),
-                (run_prefill_avg_temp, "avg_temperature_c"),
-                (run_prefill_p99_temp, "p99_temperature_c"),
-                (run_prefill_avg_mem_used_mb, "avg_memory_used_mb"),
-                (run_prefill_p99_mem_used_mb, "p99_memory_used_mb"),
-                (run_prefill_avg_mem_used_pct, "avg_memory_used_pct"),
-                (run_prefill_p99_mem_used_pct, "p99_memory_used_pct"),
-            ):
-                v = prefill_metric.get(key)
-                if isinstance(v, (int, float)):
-                    dst.append(float(v))
-            for dst, key in (
-                (run_decode_avg_power, "avg_power_w"),
-                (run_decode_p99_power, "p99_power_w"),
-                (run_decode_avg_util, "avg_utilization_pct"),
-                (run_decode_p99_util, "p99_utilization_pct"),
-                (run_decode_avg_temp, "avg_temperature_c"),
-                (run_decode_p99_temp, "p99_temperature_c"),
-                (run_decode_avg_mem_used_mb, "avg_memory_used_mb"),
-                (run_decode_p99_mem_used_mb, "p99_memory_used_mb"),
-                (run_decode_avg_mem_used_pct, "avg_memory_used_pct"),
-                (run_decode_p99_mem_used_pct, "p99_memory_used_pct"),
-            ):
-                v = decode_metric.get(key)
-                if isinstance(v, (int, float)):
-                    dst.append(float(v))
+            finally:
+                _stop_tracker_safe(tracker_prefill)
+                _stop_tracker_safe(tracker_decode)
+            if tracker_prefill is not None and tracker_decode is not None:
+                prefill_metric = _extract_device_metric(tracker_prefill)
+                decode_metric = _extract_device_metric(tracker_decode)
+                run_phase_device.append({"prefill": prefill_metric, "decode": decode_metric})
+                prefill_time_series = _extract_device_time_series(tracker_prefill)
+                decode_time_series = _extract_device_time_series(tracker_decode)
+                run_phase_device_time_series.append(
+                    {
+                        "prefill": prefill_time_series,
+                        "decode": decode_time_series,
+                    }
+                )
+                _enrich_single_run_device(
+                    run=runs[-1],
+                    prefill_metric=prefill_metric,
+                    decode_metric=decode_metric,
+                    batch_size=batch_size,
+                    prefill_time_series=prefill_time_series,
+                    decode_time_series=decode_time_series,
+                    decode_window=args.decode_window,
+                )
+                prefill_dur = float(getattr(runs[-1], "prefill_phase_duration_s", 0.0) or 0.0)
+                decode_dur = float(getattr(runs[-1], "decode_phase_duration_s", 0.0) or 0.0)
+                avg_power = _weighted_two(
+                    prefill_metric.get("avg_power_w"),
+                    prefill_dur,
+                    decode_metric.get("avg_power_w"),
+                    decode_dur,
+                )
+                if avg_power is not None:
+                    run_avg_power.append(avg_power)
+                prefill_energy = _energy_from_device_time_series(prefill_time_series)
+                decode_energy = _energy_from_device_time_series(decode_time_series)
+                total_energy = _sum_required_energies(prefill_energy, decode_energy)
+                if total_energy is not None:
+                    run_total_energy.append(total_energy)
+                p99_power = max(
+                    [v for v in (prefill_metric.get("p99_power_w"), decode_metric.get("p99_power_w")) if v is not None],
+                    default=None,
+                )
+                if p99_power is not None:
+                    run_p99_power.append(float(p99_power))
+                avg_util = _weighted_two(
+                    prefill_metric.get("avg_utilization_pct"),
+                    prefill_dur,
+                    decode_metric.get("avg_utilization_pct"),
+                    decode_dur,
+                )
+                if avg_util is not None:
+                    run_avg_utilization.append(float(avg_util))
+                p99_util = max(
+                    [
+                        v
+                        for v in (
+                            prefill_metric.get("p99_utilization_pct"),
+                            decode_metric.get("p99_utilization_pct"),
+                        )
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                if p99_util is not None:
+                    run_p99_utilization.append(float(p99_util))
+                avg_temp = _weighted_two(
+                    prefill_metric.get("avg_temperature_c"),
+                    prefill_dur,
+                    decode_metric.get("avg_temperature_c"),
+                    decode_dur,
+                )
+                if avg_temp is not None:
+                    run_avg_temperature.append(float(avg_temp))
+                p99_temp = max(
+                    [
+                        v
+                        for v in (
+                            prefill_metric.get("p99_temperature_c"),
+                            decode_metric.get("p99_temperature_c"),
+                        )
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                if p99_temp is not None:
+                    run_p99_temperature.append(float(p99_temp))
+                avg_mem_used_mb = _weighted_two(
+                    prefill_metric.get("avg_memory_used_mb"),
+                    prefill_dur,
+                    decode_metric.get("avg_memory_used_mb"),
+                    decode_dur,
+                )
+                if avg_mem_used_mb is not None:
+                    run_avg_memory_used_mb.append(float(avg_mem_used_mb))
+                p99_mem_used_mb = max(
+                    [
+                        v
+                        for v in (
+                            prefill_metric.get("p99_memory_used_mb"),
+                            decode_metric.get("p99_memory_used_mb"),
+                        )
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                if p99_mem_used_mb is not None:
+                    run_p99_memory_used_mb.append(float(p99_mem_used_mb))
+                total_memory_mb = max(
+                    [
+                        v
+                        for v in (prefill_metric.get("total_memory_mb"), decode_metric.get("total_memory_mb"))
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                if total_memory_mb is not None:
+                    run_total_memory_mb.append(float(total_memory_mb))
+                avg_mem_used_pct = _weighted_two(
+                    prefill_metric.get("avg_memory_used_pct"),
+                    prefill_dur,
+                    decode_metric.get("avg_memory_used_pct"),
+                    decode_dur,
+                )
+                if avg_mem_used_pct is not None:
+                    run_avg_memory_used_pct.append(float(avg_mem_used_pct))
+                p99_mem_used_pct = max(
+                    [
+                        v
+                        for v in (
+                            prefill_metric.get("p99_memory_used_pct"),
+                            decode_metric.get("p99_memory_used_pct"),
+                        )
+                        if v is not None
+                    ],
+                    default=None,
+                )
+                if p99_mem_used_pct is not None:
+                    run_p99_memory_used_pct.append(float(p99_mem_used_pct))
+                for dst, key in (
+                    (run_prefill_avg_power, "avg_power_w"),
+                    (run_prefill_p99_power, "p99_power_w"),
+                    (run_prefill_avg_util, "avg_utilization_pct"),
+                    (run_prefill_p99_util, "p99_utilization_pct"),
+                    (run_prefill_avg_temp, "avg_temperature_c"),
+                    (run_prefill_p99_temp, "p99_temperature_c"),
+                    (run_prefill_avg_mem_used_mb, "avg_memory_used_mb"),
+                    (run_prefill_p99_mem_used_mb, "p99_memory_used_mb"),
+                    (run_prefill_avg_mem_used_pct, "avg_memory_used_pct"),
+                    (run_prefill_p99_mem_used_pct, "p99_memory_used_pct"),
+                ):
+                    v = prefill_metric.get(key)
+                    if isinstance(v, (int, float)):
+                        dst.append(float(v))
+                for dst, key in (
+                    (run_decode_avg_power, "avg_power_w"),
+                    (run_decode_p99_power, "p99_power_w"),
+                    (run_decode_avg_util, "avg_utilization_pct"),
+                    (run_decode_p99_util, "p99_utilization_pct"),
+                    (run_decode_avg_temp, "avg_temperature_c"),
+                    (run_decode_p99_temp, "p99_temperature_c"),
+                    (run_decode_avg_mem_used_mb, "avg_memory_used_mb"),
+                    (run_decode_p99_mem_used_mb, "p99_memory_used_mb"),
+                    (run_decode_avg_mem_used_pct, "avg_memory_used_pct"),
+                    (run_decode_p99_mem_used_pct, "p99_memory_used_pct"),
+                ):
+                    v = decode_metric.get(key)
+                    if isinstance(v, (int, float)):
+                        dst.append(float(v))
+    finally:
+        _stop_qbruntime_trace(trace_handle)
 
     result = _aggregate_sweep_results(runs)
     _attach_aggregate_sweep_device(result, runs, batch_size=batch_size, decode_window=args.decode_window)
@@ -2306,6 +2332,7 @@ def _run_vlm_sweep(args: argparse.Namespace) -> int:
     resolution_payloads = []
     vision_energy_by_resolution: dict[int, list[float]] = {}
     csv_rows: list[dict[str, Any]] = []
+
     for resolution in args.image_resolutions:
         for _ in range(args.warmup):
             measurer.measure_vision(
@@ -2315,189 +2342,6 @@ def _run_vlm_sweep(args: argparse.Namespace) -> int:
                 show_progress=False,
                 batch_size=batch_size,
             )
-        vision_runs = []
-        vision_power_avg = []
-        vision_power_p99 = []
-        vision_util_avg = []
-        vision_util_p99 = []
-        vision_temp_avg = []
-        vision_temp_p99 = []
-        vision_mem_used_avg_mb = []
-        vision_mem_used_p99_mb = []
-        vision_mem_total_mb = []
-        vision_mem_used_pct_avg = []
-        vision_mem_used_pct_p99 = []
-        vision_energy_j = []
-        vision_img_per_j = []
-        vision_j_per_img = []
-        vision_device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
-        for _ in tqdm(range(args.repeat), desc=f"vision@{resolution}", leave=False):
-            if tracker is not None:
-                tracker.start()
-            try:
-                single = measurer.measure_vision(
-                    image_resolution=resolution,
-                    repeat=1,
-                    prompt=args.prompt,
-                    show_progress=False,
-                    batch_size=batch_size,
-                )[0]
-            finally:
-                _stop_tracker_safe(tracker)
-            vision_runs.append(single)
-            if tracker is not None:
-                metric = _extract_device_metric(tracker)
-                device_time_series = _extract_device_time_series(tracker)
-                vision_device_time_series_runs.append(device_time_series)
-                avg_power = metric.get("avg_power_w")
-                p99_power = metric.get("p99_power_w")
-                avg_utilization = metric.get("avg_utilization_pct")
-                p99_utilization = metric.get("p99_utilization_pct")
-                avg_temperature = metric.get("avg_temperature_c")
-                p99_temperature = metric.get("p99_temperature_c")
-                avg_memory_used_mb = metric.get("avg_memory_used_mb")
-                p99_memory_used_mb = metric.get("p99_memory_used_mb")
-                total_memory_mb = metric.get("total_memory_mb")
-                avg_memory_used_pct = metric.get("avg_memory_used_pct")
-                p99_memory_used_pct = metric.get("p99_memory_used_pct")
-                if avg_power is not None:
-                    avg_power_f = float(avg_power)
-                    vision_power_avg.append(avg_power_f)
-                energy = _energy_from_device_time_series(device_time_series)
-                if energy is not None:
-                    vision_energy_j.append(energy)
-                    vision_img_per_j.append(1.0 / energy if energy > 0 else 0.0)
-                    vision_j_per_img.append(energy)
-                if p99_power is not None:
-                    vision_power_p99.append(float(p99_power))
-                if avg_utilization is not None:
-                    vision_util_avg.append(float(avg_utilization))
-                if p99_utilization is not None:
-                    vision_util_p99.append(float(p99_utilization))
-                if avg_temperature is not None:
-                    vision_temp_avg.append(float(avg_temperature))
-                if p99_temperature is not None:
-                    vision_temp_p99.append(float(p99_temperature))
-                if avg_memory_used_mb is not None:
-                    vision_mem_used_avg_mb.append(float(avg_memory_used_mb))
-                if p99_memory_used_mb is not None:
-                    vision_mem_used_p99_mb.append(float(p99_memory_used_mb))
-                if total_memory_mb is not None:
-                    vision_mem_total_mb.append(float(total_memory_mb))
-                if avg_memory_used_pct is not None:
-                    vision_mem_used_pct_avg.append(float(avg_memory_used_pct))
-                if p99_memory_used_pct is not None:
-                    vision_mem_used_pct_p99.append(float(p99_memory_used_pct))
-
-        vision_ms = [lat * 1000.0 for lat, _ in vision_runs]
-        vision_fps = [fps for _, fps in vision_runs]
-        vision_energy_by_resolution[resolution] = list(vision_energy_j)
-
-        print(f"\nresolution={resolution} warmup={args.warmup} runs={args.repeat} batch_size={batch_size}")
-        _print_summary_header()
-        _print_summary("vision_encode", vision_ms, "ms")
-        _print_summary("vision_fps", vision_fps, "fps")
-        if args.device_metrics:
-            _print_summary("vision_avg_power", vision_power_avg, "W")
-            _print_summary("vision_p99_power", vision_power_p99, "W")
-            _print_summary("vision_avg_util", vision_util_avg, "%")
-            _print_summary("vision_p99_util", vision_util_p99, "%")
-            _print_summary("vision_avg_temp", vision_temp_avg, "C")
-            _print_summary("vision_p99_temp", vision_temp_p99, "C")
-            _print_summary("vision_avg_mem_used", vision_mem_used_avg_mb, "MB")
-            _print_summary("vision_p99_mem_used", vision_mem_used_p99_mb, "MB")
-            _print_summary("vision_total_mem", vision_mem_total_mb, "MB")
-            _print_summary("vision_avg_mem_used_pct", vision_mem_used_pct_avg, "%")
-            _print_summary("vision_p99_mem_used_pct", vision_mem_used_pct_p99, "%")
-            _print_summary("vision_energy", vision_energy_j, "J")
-            _print_summary("vision_img_per_j", vision_img_per_j, "img/J")
-            _print_summary("vision_j_per_img", vision_j_per_img, "J/img")
-            if not vision_power_avg:
-                print("[device] warning: no vision device samples were collected for this resolution")
-        _print_summary_footer()
-
-        for idx, (latency, fps) in enumerate(vision_runs, start=1):
-            csv_rows.append(
-                {
-                    "type": "vision",
-                    "batch_size": batch_size,
-                    "image_resolution": resolution,
-                    "repeat_index": idx,
-                    "vision_encode_ms": latency * 1000.0,
-                    "vision_fps": fps,
-                    "llm_prefill_tokens": None,
-                    "llm_decode_tokens": None,
-                    "llm_prefill_tps": None,
-                    "llm_decode_tps": None,
-                    "llm_ttft_ms": None,
-                    "llm_decode_ms": None,
-                    "llm_total_ms": None,
-                    "llm_prefill_npu_latency_pct": None,
-                    "llm_decode_npu_latency_pct": None,
-                    "avg_power_w": vision_power_avg[idx - 1] if idx - 1 < len(vision_power_avg) else None,
-                    "p99_power_w": vision_power_p99[idx - 1] if idx - 1 < len(vision_power_p99) else None,
-                    "avg_utilization_pct": vision_util_avg[idx - 1] if idx - 1 < len(vision_util_avg) else None,
-                    "p99_utilization_pct": vision_util_p99[idx - 1] if idx - 1 < len(vision_util_p99) else None,
-                    "avg_temperature_c": vision_temp_avg[idx - 1] if idx - 1 < len(vision_temp_avg) else None,
-                    "p99_temperature_c": vision_temp_p99[idx - 1] if idx - 1 < len(vision_temp_p99) else None,
-                    "avg_memory_used_mb": vision_mem_used_avg_mb[idx - 1]
-                    if idx - 1 < len(vision_mem_used_avg_mb)
-                    else None,
-                    "p99_memory_used_mb": vision_mem_used_p99_mb[idx - 1]
-                    if idx - 1 < len(vision_mem_used_p99_mb)
-                    else None,
-                    "total_memory_mb": vision_mem_total_mb[idx - 1] if idx - 1 < len(vision_mem_total_mb) else None,
-                    "avg_memory_used_pct": vision_mem_used_pct_avg[idx - 1]
-                    if idx - 1 < len(vision_mem_used_pct_avg)
-                    else None,
-                    "p99_memory_used_pct": vision_mem_used_pct_p99[idx - 1]
-                    if idx - 1 < len(vision_mem_used_pct_p99)
-                    else None,
-                    "vision_energy_j": vision_energy_j[idx - 1] if idx - 1 < len(vision_energy_j) else None,
-                    "total_energy_j": vision_energy_j[idx - 1] if idx - 1 < len(vision_energy_j) else None,
-                    "prefill_tps_per_w": None,
-                    "decode_tps_per_w": None,
-                    "prefill_j_per_tok": None,
-                    "decode_j_per_tok": None,
-                    "vision_img_per_j": vision_img_per_j[idx - 1] if idx - 1 < len(vision_img_per_j) else None,
-                    "vision_j_per_img": vision_j_per_img[idx - 1] if idx - 1 < len(vision_j_per_img) else None,
-                }
-            )
-
-        resolution_payloads.append(
-            {
-                "image_resolution": resolution,
-                "repeat": args.repeat,
-                "batch_size": batch_size,
-                "runs": [
-                    {
-                        "vision_encode_latency": latency,
-                        "vision_fps": fps,
-                    }
-                    for latency, fps in vision_runs
-                ],
-                "summary": {
-                    "vision_encode_ms": _summary(vision_ms),
-                    "vision_fps": _summary(vision_fps),
-                    "avg_power_w": _summary(vision_power_avg),
-                    "p99_power_w": _summary(vision_power_p99),
-                    "avg_utilization_pct": _summary(vision_util_avg),
-                    "p99_utilization_pct": _summary(vision_util_p99),
-                    "avg_temperature_c": _summary(vision_temp_avg),
-                    "p99_temperature_c": _summary(vision_temp_p99),
-                    "avg_memory_used_mb": _summary(vision_mem_used_avg_mb),
-                    "p99_memory_used_mb": _summary(vision_mem_used_p99_mb),
-                    "total_memory_mb": _summary(vision_mem_total_mb),
-                    "avg_memory_used_pct": _summary(vision_mem_used_pct_avg),
-                    "p99_memory_used_pct": _summary(vision_mem_used_pct_p99),
-                    "vision_energy_j": _summary(vision_energy_j),
-                    "energy_j": _summary(vision_energy_j),
-                    "vision_img_per_j": _summary(vision_img_per_j),
-                    "vision_j_per_img": _summary(vision_j_per_img),
-                },
-                "device_time_series_runs": vision_device_time_series_runs,
-            }
-        )
 
     llm_resolution = args.llm_resolution if args.llm_resolution is not None else args.image_resolutions[0]
     for _ in range(args.warmup):
@@ -2510,45 +2354,235 @@ def _run_vlm_sweep(args: argparse.Namespace) -> int:
             show_progress=False,
             batch_size=batch_size,
         )
-    llm_runs = []
-    llm_device_time_series_runs: list[dict[str, dict[str, list[dict[str, float]]]]] = []
-    for _ in tqdm(range(args.repeat), desc=f"llm@{llm_resolution}", leave=False):
-        llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
-        try:
-            run = measurer.measure_llm_full(
-                image_resolution=llm_resolution,
-                prompt=args.prompt,
-                prefill_range=args.prefill_range,
-                cache_lengths=args.cache_lengths,
-                decode_window=args.decode_window,
-                show_progress=False,
-                batch_size=batch_size,
-                on_prefill_start=(lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None,
-                on_prefill_end=(lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None,
-                on_decode_start=(lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None,
-                on_decode_end=(lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None,
+
+    trace_handle = _start_qbruntime_trace(getattr(args, "trace", None))
+    try:
+        for resolution in args.image_resolutions:
+            vision_runs = []
+            vision_power_avg = []
+            vision_power_p99 = []
+            vision_util_avg = []
+            vision_util_p99 = []
+            vision_temp_avg = []
+            vision_temp_p99 = []
+            vision_mem_used_avg_mb = []
+            vision_mem_used_p99_mb = []
+            vision_mem_total_mb = []
+            vision_mem_used_pct_avg = []
+            vision_mem_used_pct_p99 = []
+            vision_energy_j = []
+            vision_img_per_j = []
+            vision_j_per_img = []
+            vision_device_time_series_runs: list[dict[str, list[dict[str, float]]]] = []
+            for _ in tqdm(range(args.repeat), desc=f"vision@{resolution}", leave=False):
+                if tracker is not None:
+                    tracker.start()
+                try:
+                    single = measurer.measure_vision(
+                        image_resolution=resolution,
+                        repeat=1,
+                        prompt=args.prompt,
+                        show_progress=False,
+                        batch_size=batch_size,
+                    )[0]
+                finally:
+                    _stop_tracker_safe(tracker)
+                vision_runs.append(single)
+                if tracker is not None:
+                    metric = _extract_device_metric(tracker)
+                    device_time_series = _extract_device_time_series(tracker)
+                    vision_device_time_series_runs.append(device_time_series)
+                    avg_power = metric.get("avg_power_w")
+                    p99_power = metric.get("p99_power_w")
+                    avg_utilization = metric.get("avg_utilization_pct")
+                    p99_utilization = metric.get("p99_utilization_pct")
+                    avg_temperature = metric.get("avg_temperature_c")
+                    p99_temperature = metric.get("p99_temperature_c")
+                    avg_memory_used_mb = metric.get("avg_memory_used_mb")
+                    p99_memory_used_mb = metric.get("p99_memory_used_mb")
+                    total_memory_mb = metric.get("total_memory_mb")
+                    avg_memory_used_pct = metric.get("avg_memory_used_pct")
+                    p99_memory_used_pct = metric.get("p99_memory_used_pct")
+                    if avg_power is not None:
+                        avg_power_f = float(avg_power)
+                        vision_power_avg.append(avg_power_f)
+                    energy = _energy_from_device_time_series(device_time_series)
+                    if energy is not None:
+                        vision_energy_j.append(energy)
+                        vision_img_per_j.append(1.0 / energy if energy > 0 else 0.0)
+                        vision_j_per_img.append(energy)
+                    if p99_power is not None:
+                        vision_power_p99.append(float(p99_power))
+                    if avg_utilization is not None:
+                        vision_util_avg.append(float(avg_utilization))
+                    if p99_utilization is not None:
+                        vision_util_p99.append(float(p99_utilization))
+                    if avg_temperature is not None:
+                        vision_temp_avg.append(float(avg_temperature))
+                    if p99_temperature is not None:
+                        vision_temp_p99.append(float(p99_temperature))
+                    if avg_memory_used_mb is not None:
+                        vision_mem_used_avg_mb.append(float(avg_memory_used_mb))
+                    if p99_memory_used_mb is not None:
+                        vision_mem_used_p99_mb.append(float(p99_memory_used_mb))
+                    if total_memory_mb is not None:
+                        vision_mem_total_mb.append(float(total_memory_mb))
+                    if avg_memory_used_pct is not None:
+                        vision_mem_used_pct_avg.append(float(avg_memory_used_pct))
+                    if p99_memory_used_pct is not None:
+                        vision_mem_used_pct_p99.append(float(p99_memory_used_pct))
+
+            vision_ms = [lat * 1000.0 for lat, _ in vision_runs]
+            vision_fps = [fps for _, fps in vision_runs]
+            vision_energy_by_resolution[resolution] = list(vision_energy_j)
+
+            print(f"\nresolution={resolution} warmup={args.warmup} runs={args.repeat} batch_size={batch_size}")
+            _print_summary_header()
+            _print_summary("vision_encode", vision_ms, "ms")
+            _print_summary("vision_fps", vision_fps, "fps")
+            if args.device_metrics:
+                _print_summary("vision_avg_power", vision_power_avg, "W")
+                _print_summary("vision_p99_power", vision_power_p99, "W")
+                _print_summary("vision_avg_util", vision_util_avg, "%")
+                _print_summary("vision_p99_util", vision_util_p99, "%")
+                _print_summary("vision_avg_temp", vision_temp_avg, "C")
+                _print_summary("vision_p99_temp", vision_temp_p99, "C")
+                _print_summary("vision_avg_mem_used", vision_mem_used_avg_mb, "MB")
+                _print_summary("vision_p99_mem_used", vision_mem_used_p99_mb, "MB")
+                _print_summary("vision_total_mem", vision_mem_total_mb, "MB")
+                _print_summary("vision_avg_mem_used_pct", vision_mem_used_pct_avg, "%")
+                _print_summary("vision_p99_mem_used_pct", vision_mem_used_pct_p99, "%")
+                _print_summary("vision_energy", vision_energy_j, "J")
+                _print_summary("vision_img_per_j", vision_img_per_j, "img/J")
+                _print_summary("vision_j_per_img", vision_j_per_img, "J/img")
+                if not vision_power_avg:
+                    print("[device] warning: no vision device samples were collected for this resolution")
+            _print_summary_footer()
+
+            for idx, (latency, fps) in enumerate(vision_runs, start=1):
+                csv_rows.append(
+                    {
+                        "type": "vision",
+                        "batch_size": batch_size,
+                        "image_resolution": resolution,
+                        "repeat_index": idx,
+                        "vision_encode_ms": latency * 1000.0,
+                        "vision_fps": fps,
+                        "llm_prefill_tokens": None,
+                        "llm_decode_tokens": None,
+                        "llm_prefill_tps": None,
+                        "llm_decode_tps": None,
+                        "llm_ttft_ms": None,
+                        "llm_decode_ms": None,
+                        "llm_total_ms": None,
+                        "llm_prefill_npu_latency_pct": None,
+                        "llm_decode_npu_latency_pct": None,
+                        "avg_power_w": vision_power_avg[idx - 1] if idx - 1 < len(vision_power_avg) else None,
+                        "p99_power_w": vision_power_p99[idx - 1] if idx - 1 < len(vision_power_p99) else None,
+                        "avg_utilization_pct": vision_util_avg[idx - 1] if idx - 1 < len(vision_util_avg) else None,
+                        "p99_utilization_pct": vision_util_p99[idx - 1] if idx - 1 < len(vision_util_p99) else None,
+                        "avg_temperature_c": vision_temp_avg[idx - 1] if idx - 1 < len(vision_temp_avg) else None,
+                        "p99_temperature_c": vision_temp_p99[idx - 1] if idx - 1 < len(vision_temp_p99) else None,
+                        "avg_memory_used_mb": vision_mem_used_avg_mb[idx - 1]
+                        if idx - 1 < len(vision_mem_used_avg_mb)
+                        else None,
+                        "p99_memory_used_mb": vision_mem_used_p99_mb[idx - 1]
+                        if idx - 1 < len(vision_mem_used_p99_mb)
+                        else None,
+                        "total_memory_mb": vision_mem_total_mb[idx - 1] if idx - 1 < len(vision_mem_total_mb) else None,
+                        "avg_memory_used_pct": vision_mem_used_pct_avg[idx - 1]
+                        if idx - 1 < len(vision_mem_used_pct_avg)
+                        else None,
+                        "p99_memory_used_pct": vision_mem_used_pct_p99[idx - 1]
+                        if idx - 1 < len(vision_mem_used_pct_p99)
+                        else None,
+                        "vision_energy_j": vision_energy_j[idx - 1] if idx - 1 < len(vision_energy_j) else None,
+                        "total_energy_j": vision_energy_j[idx - 1] if idx - 1 < len(vision_energy_j) else None,
+                        "prefill_tps_per_w": None,
+                        "decode_tps_per_w": None,
+                        "prefill_j_per_tok": None,
+                        "decode_j_per_tok": None,
+                        "vision_img_per_j": vision_img_per_j[idx - 1] if idx - 1 < len(vision_img_per_j) else None,
+                        "vision_j_per_img": vision_j_per_img[idx - 1] if idx - 1 < len(vision_j_per_img) else None,
+                    }
+                )
+
+            resolution_payloads.append(
+                {
+                    "image_resolution": resolution,
+                    "repeat": args.repeat,
+                    "batch_size": batch_size,
+                    "runs": [
+                        {
+                            "vision_encode_latency": latency,
+                            "vision_fps": fps,
+                        }
+                        for latency, fps in vision_runs
+                    ],
+                    "summary": {
+                        "vision_encode_ms": _summary(vision_ms),
+                        "vision_fps": _summary(vision_fps),
+                        "avg_power_w": _summary(vision_power_avg),
+                        "p99_power_w": _summary(vision_power_p99),
+                        "avg_utilization_pct": _summary(vision_util_avg),
+                        "p99_utilization_pct": _summary(vision_util_p99),
+                        "avg_temperature_c": _summary(vision_temp_avg),
+                        "p99_temperature_c": _summary(vision_temp_p99),
+                        "avg_memory_used_mb": _summary(vision_mem_used_avg_mb),
+                        "p99_memory_used_mb": _summary(vision_mem_used_p99_mb),
+                        "total_memory_mb": _summary(vision_mem_total_mb),
+                        "avg_memory_used_pct": _summary(vision_mem_used_pct_avg),
+                        "p99_memory_used_pct": _summary(vision_mem_used_pct_p99),
+                        "vision_energy_j": _summary(vision_energy_j),
+                        "energy_j": _summary(vision_energy_j),
+                        "vision_img_per_j": _summary(vision_img_per_j),
+                        "vision_j_per_img": _summary(vision_j_per_img),
+                    },
+                    "device_time_series_runs": vision_device_time_series_runs,
+                }
             )
-        finally:
-            _stop_tracker_safe(llm_tracker_prefill)
-            _stop_tracker_safe(llm_tracker_decode)
-        if llm_tracker_prefill is not None and llm_tracker_decode is not None and (
-            run.prefill_sweep.x_values or run.decode_sweep.x_values
-        ):
-            prefill_metric = _extract_device_metric(llm_tracker_prefill)
-            decode_metric = _extract_device_metric(llm_tracker_decode)
-            prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
-            decode_time_series = _extract_device_time_series(llm_tracker_decode)
-            llm_device_time_series_runs.append({"prefill": prefill_time_series, "decode": decode_time_series})
-            _enrich_single_run_device(
-                run=run,
-                prefill_metric=prefill_metric,
-                decode_metric=decode_metric,
-                batch_size=batch_size,
-                prefill_time_series=prefill_time_series,
-                decode_time_series=decode_time_series,
-                decode_window=args.decode_window,
-            )
-        llm_runs.append(run)
+
+        llm_runs = []
+        llm_device_time_series_runs: list[dict[str, dict[str, list[dict[str, float]]]]] = []
+        for _ in tqdm(range(args.repeat), desc=f"llm@{llm_resolution}", leave=False):
+            llm_tracker_prefill, llm_tracker_decode = _build_phase_trackers(args, pipeline)
+            try:
+                run = measurer.measure_llm_full(
+                    image_resolution=llm_resolution,
+                    prompt=args.prompt,
+                    prefill_range=args.prefill_range,
+                    cache_lengths=args.cache_lengths,
+                    decode_window=args.decode_window,
+                    show_progress=False,
+                    batch_size=batch_size,
+                    on_prefill_start=(lambda: llm_tracker_prefill.start()) if llm_tracker_prefill is not None else None,
+                    on_prefill_end=(lambda: llm_tracker_prefill.stop()) if llm_tracker_prefill is not None else None,
+                    on_decode_start=(lambda: llm_tracker_decode.start()) if llm_tracker_decode is not None else None,
+                    on_decode_end=(lambda: llm_tracker_decode.stop()) if llm_tracker_decode is not None else None,
+                )
+            finally:
+                _stop_tracker_safe(llm_tracker_prefill)
+                _stop_tracker_safe(llm_tracker_decode)
+            if llm_tracker_prefill is not None and llm_tracker_decode is not None and (
+                run.prefill_sweep.x_values or run.decode_sweep.x_values
+            ):
+                prefill_metric = _extract_device_metric(llm_tracker_prefill)
+                decode_metric = _extract_device_metric(llm_tracker_decode)
+                prefill_time_series = _extract_device_time_series(llm_tracker_prefill)
+                decode_time_series = _extract_device_time_series(llm_tracker_decode)
+                llm_device_time_series_runs.append({"prefill": prefill_time_series, "decode": decode_time_series})
+                _enrich_single_run_device(
+                    run=run,
+                    prefill_metric=prefill_metric,
+                    decode_metric=decode_metric,
+                    batch_size=batch_size,
+                    prefill_time_series=prefill_time_series,
+                    decode_time_series=decode_time_series,
+                    decode_window=args.decode_window,
+                )
+            llm_runs.append(run)
+    finally:
+        _stop_qbruntime_trace(trace_handle)
 
     llm_result = _aggregate_sweep_results(llm_runs)
     llm_prefill_tps = [r.prefill_sweep.tps_values[-1] for r in llm_runs if r.prefill_sweep.tps_values]
@@ -2923,7 +2957,7 @@ def add_tps_parser(
         p.add_argument(
             "--trace",
             default=None,
-            help="write qbruntime trace to the given JSON path (first run only)",
+            help="write qbruntime event trace JSON for measured runs to the given path",
         )
         p.add_argument(
             "--prefill-chunk-size",

--- a/mblt_model_zoo/hf_transformers/utils/benchmark_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/benchmark_utils.py
@@ -13,6 +13,45 @@ from .cache_utils import MobilintCache
 
 _NS_PER_SECOND = 1_000_000_000
 _SAMPLING_GENERATION_FLAGS = ("temperature", "top_p", "top_k")
+_ACTIVE_QBRUNTIME_TRACE_HANDLE = None
+
+
+class _NestedQbruntimeTraceHandle:
+    """Marker for nested trace requests that must not stop the active trace."""
+
+    pass
+
+
+def start_qbruntime_trace(trace_path: str | None):
+    """Start qbruntime event tracing when a destination path is provided."""
+    global _ACTIVE_QBRUNTIME_TRACE_HANDLE
+
+    if not trace_path:
+        return None
+    if _ACTIVE_QBRUNTIME_TRACE_HANDLE is not None:
+        return _NestedQbruntimeTraceHandle()
+    try:
+        import qbruntime  # type: ignore
+    except Exception as e:
+        raise RuntimeError("Tracing requires qbruntime to be available.") from e
+    qbruntime.start_tracing_events(trace_path)
+    _ACTIVE_QBRUNTIME_TRACE_HANDLE = qbruntime
+    return qbruntime
+
+
+def stop_qbruntime_trace(handle) -> None:
+    """Stop a qbruntime event trace previously started by ``start_qbruntime_trace``."""
+    global _ACTIVE_QBRUNTIME_TRACE_HANDLE
+
+    if handle is None:
+        return
+    if isinstance(handle, _NestedQbruntimeTraceHandle):
+        return
+    try:
+        handle.stop_tracing_events()
+    finally:
+        if handle is _ACTIVE_QBRUNTIME_TRACE_HANDLE:
+            _ACTIVE_QBRUNTIME_TRACE_HANDLE = None
 
 
 class _GenerationPhaseCallbacks:
@@ -797,20 +836,11 @@ class TPSMeasurer:
 
     @staticmethod
     def _start_trace(trace_path: Union[str, None]):
-        if not trace_path:
-            return None
-        try:
-            import qbruntime  # type: ignore
-        except Exception as e:
-            raise RuntimeError("Tracing requires qbruntime to be available.") from e
-        qbruntime.start_tracing_events(trace_path)
-        return qbruntime
+        return start_qbruntime_trace(trace_path)
 
     @staticmethod
     def _stop_trace(handle):
-        if handle is None:
-            return
-        handle.stop_tracing_events()
+        stop_qbruntime_trace(handle)
 
     def _measure_batch_generate(
         self,

--- a/tests/transformers/cli_tps/test_runtime_and_metrics.py
+++ b/tests/transformers/cli_tps/test_runtime_and_metrics.py
@@ -2539,3 +2539,269 @@ def test_cli_tps_positive_int_enforced(argv: list[str]):
     with pytest.raises(SystemExit) as excinfo:
         parser.parse_args(argv)
     assert excinfo.value.code == 2
+
+
+def _trace_scope_args(**overrides):
+    """Build a minimal TPS CLI namespace for trace-scope tests."""
+    defaults = dict(
+        task="text-generation",
+        model="dummy",
+        tokenizer=None,
+        device="cpu",
+        trust_remote_code=True,
+        dtype=None,
+        device_map=None,
+        revision=None,
+        embedding_weight=None,
+        base_embedding_path=None,
+        draft_embedding_path=None,
+        base_mxq_path=None,
+        draft_mxq_path=None,
+        fc_mxq_path=None,
+        base_core_mode=None,
+        draft_core_mode=None,
+        fc_core_mode=None,
+        base_target_cores=None,
+        draft_target_cores=None,
+        fc_target_cores=None,
+        base_target_clusters=None,
+        draft_target_clusters=None,
+        fc_target_clusters=None,
+        mxq_path=None,
+        core_mode=None,
+        target_cores=None,
+        target_clusters=None,
+        batch_size=1,
+        warmup=1,
+        repeat=2,
+        prefill=8,
+        decode=2,
+        prefill_range=(8, 8, 1),
+        cache_lengths=[4],
+        decode_window=2,
+        prefill_chunk_size=None,
+        trace="trace.json",
+        device_metrics=False,
+        json=None,
+        csv=None,
+        plot=None,
+        device_backend="none",
+        input_mode="random",
+        prompt_text=None,
+        prompt_file=None,
+        prompt_file_strategy="first",
+        prompt_file_seed=0,
+        image_resolution=224,
+        image_resolutions=[224],
+        llm_resolution=224,
+        prompt="Describe.",
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _trace_single(num_prefill: int = 8, num_decode: int = 2) -> SingleMeasurement:
+    """Return a deterministic single measurement."""
+    return SingleMeasurement(
+        num_prefill=num_prefill,
+        num_decode=num_decode,
+        prefill_latency=1.0,
+        prefill_tps=float(num_prefill),
+        decode_duration=1.0,
+        decode_tps=float(num_decode),
+        total_time=2.0,
+        avg_total_prefill_token_latency=1.0 / num_prefill,
+        avg_npu_prefill_token_latency=None,
+        avg_total_decode_token_latency=1.0 / num_decode,
+        avg_npu_decode_token_latency=None,
+    )
+
+
+def _trace_result(prefill: int = 8, decode: int = 4) -> BenchmarkResult:
+    """Return a deterministic benchmark result."""
+    result = BenchmarkResult()
+    result.prefill_sweep.x_values.append(prefill)
+    result.prefill_sweep.tps_values.append(float(prefill))
+    result.prefill_sweep.time_values.append(1.0)
+    result.prefill_sweep.avg_total_token_latency_values.append(1.0 / prefill)
+    result.prefill_sweep.avg_npu_token_latency_values.append(None)
+    result.decode_sweep.x_values.append(decode)
+    result.decode_sweep.tps_values.append(float(decode))
+    result.decode_sweep.time_values.append(1.0)
+    result.decode_sweep.avg_total_token_latency_values.append(1.0 / decode)
+    result.decode_sweep.avg_npu_token_latency_values.append(None)
+    return result
+
+
+def test_qbruntime_trace_ignores_nested_start_to_preserve_outer_file(monkeypatch):
+    """Nested qbruntime trace requests should not overwrite the active outer trace file."""
+    import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
+
+    calls: list[tuple[str, str | None]] = []
+    fake_qbruntime = SimpleNamespace(
+        start_tracing_events=lambda path: calls.append(("start", path)),
+        stop_tracing_events=lambda: calls.append(("stop", None)),
+    )
+
+    monkeypatch.setitem(sys.modules, "qbruntime", fake_qbruntime)
+    monkeypatch.setattr(benchmark_utils, "_ACTIVE_QBRUNTIME_TRACE_HANDLE", None)
+
+    outer_handle = benchmark_utils.start_qbruntime_trace("outer.json")
+    nested_handle = benchmark_utils.start_qbruntime_trace("nested.json")
+    benchmark_utils.stop_qbruntime_trace(nested_handle)
+    benchmark_utils.stop_qbruntime_trace(outer_handle)
+
+    assert calls == [("start", "outer.json"), ("stop", None)]
+    assert benchmark_utils._ACTIVE_QBRUNTIME_TRACE_HANDLE is None
+
+
+def test_run_text_measure_traces_all_measured_repeats(monkeypatch):
+    """Text measure should trace all measured repeats and exclude warmup."""
+    import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
+
+    events: list[str] = []
+    pipeline = SimpleNamespace(model=SimpleNamespace(config=_DummyConfig(max_batch_size=1)))
+
+    class _FakeTPSMeasurer:
+        def __init__(self, pipeline_arg) -> None:
+            assert pipeline_arg is pipeline
+
+        def measure(self, **kwargs) -> SingleMeasurement:
+            assert kwargs["trace_path"] is None
+            events.append(str(kwargs["progress_desc"]))
+            return _trace_single(kwargs["num_prefill"], kwargs["num_decode"])
+
+    monkeypatch.setattr(tps_cli, "_build_pipeline", lambda **kwargs: pipeline)
+    monkeypatch.setattr(tps_cli, "_build_phase_trackers", lambda args, pipeline: (None, None))
+    monkeypatch.setattr(tps_cli, "_print_device_status", lambda args, tracker: None)
+    monkeypatch.setattr(tps_cli, "_start_qbruntime_trace", lambda path: events.append(f"start:{path}") or object())
+    monkeypatch.setattr(tps_cli, "_stop_qbruntime_trace", lambda handle: events.append("stop"))
+    monkeypatch.setattr(benchmark_utils, "TPSMeasurer", _FakeTPSMeasurer)
+
+    assert tps_cli._run_text_measure(_trace_scope_args()) == 0
+    assert events.count("start:trace.json") == 1
+    assert events.count("stop") == 1
+    assert events == [
+        "warmup generate 1/1",
+        "start:trace.json",
+        "measure generate 1/2",
+        "measure generate 2/2",
+        "stop",
+    ]
+
+
+def test_run_text_sweep_traces_all_measured_repeats(monkeypatch):
+    """Text sweep should trace all measured repeats and exclude warmup."""
+    import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
+
+    events: list[str] = []
+    pipeline = SimpleNamespace(model=SimpleNamespace(config=_DummyConfig(max_batch_size=1)))
+
+    class _FakeTPSMeasurer:
+        def __init__(self, pipeline_arg) -> None:
+            assert pipeline_arg is pipeline
+
+        def measure(self, **kwargs) -> SingleMeasurement:
+            events.append(str(kwargs["progress_desc"]))
+            return _trace_single(kwargs["num_prefill"], kwargs["num_decode"])
+
+        def measure_full(self, **kwargs) -> BenchmarkResult:
+            assert kwargs["trace_path"] is None
+            events.append(str(kwargs["progress_prefix"]))
+            return _trace_result()
+
+        def plot_and_save(self, result, save_path) -> None:
+            del result, save_path
+
+    monkeypatch.setattr(tps_cli, "_build_pipeline", lambda **kwargs: pipeline)
+    monkeypatch.setattr(tps_cli, "_build_phase_trackers", lambda args, pipeline: (None, None))
+    monkeypatch.setattr(tps_cli, "_print_device_status", lambda args, tracker: None)
+    monkeypatch.setattr(tps_cli, "_start_qbruntime_trace", lambda path: events.append(f"start:{path}") or object())
+    monkeypatch.setattr(tps_cli, "_stop_qbruntime_trace", lambda handle: events.append("stop"))
+    monkeypatch.setattr(benchmark_utils, "TPSMeasurer", _FakeTPSMeasurer)
+
+    assert tps_cli._run_text_sweep(_trace_scope_args()) == 0
+    assert events.count("start:trace.json") == 1
+    assert events.count("stop") == 1
+    assert events == ["warmup generate 1/1", "start:trace.json", "run 1/2", "run 2/2", "stop"]
+
+
+def test_run_vlm_measure_traces_all_measured_repeats(monkeypatch):
+    """VLM measure should trace all measured vision and LLM repeats after warmup."""
+    import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
+
+    events: list[str] = []
+    pipeline = SimpleNamespace(model=SimpleNamespace(config=_DummyConfig(max_batch_size=1)))
+
+    class _FakeVLMTPSMeasurer:
+        def __init__(self, pipeline_arg) -> None:
+            assert pipeline_arg is pipeline
+
+        def measure_vision(self, **kwargs) -> list[tuple[float, float]]:
+            del kwargs
+            events.append("vision")
+            return [(1.0, 1.0)]
+
+        def measure_llm_full(self, **kwargs) -> BenchmarkResult:
+            del kwargs
+            events.append("llm")
+            return _trace_result(prefill=8, decode=8)
+
+    monkeypatch.setattr(tps_cli, "_build_pipeline", lambda **kwargs: pipeline)
+    monkeypatch.setattr(tps_cli, "_build_device_tracker", lambda args, pipeline: None)
+    monkeypatch.setattr(tps_cli, "_build_phase_trackers", lambda args, pipeline: (None, None))
+    monkeypatch.setattr(tps_cli, "_print_device_status", lambda args, tracker: None)
+    monkeypatch.setattr(tps_cli, "_start_qbruntime_trace", lambda path: events.append(f"start:{path}") or object())
+    monkeypatch.setattr(tps_cli, "_stop_qbruntime_trace", lambda handle: events.append("stop"))
+    monkeypatch.setattr(benchmark_utils, "VLMTPSMeasurer", _FakeVLMTPSMeasurer)
+
+    assert tps_cli._run_vlm_measure(_trace_scope_args(task="image-text-to-text")) == 0
+    assert events.count("start:trace.json") == 1
+    assert events.count("stop") == 1
+    assert events == ["vision", "llm", "start:trace.json", "vision", "llm", "vision", "llm", "stop"]
+
+
+def test_run_vlm_sweep_traces_all_measured_repeats(monkeypatch):
+    """VLM sweep should trace all measured vision and LLM runs after warmup."""
+    import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
+
+    events: list[str] = []
+    pipeline = SimpleNamespace(model=SimpleNamespace(config=_DummyConfig(max_batch_size=1)))
+
+    class _FakeVLMTPSMeasurer:
+        def __init__(self, pipeline_arg) -> None:
+            assert pipeline_arg is pipeline
+
+        def measure_vision(self, **kwargs) -> list[tuple[float, float]]:
+            events.append(f"vision:{kwargs['image_resolution']}")
+            return [(1.0, 1.0)]
+
+        def measure_llm_full(self, **kwargs) -> BenchmarkResult:
+            events.append(f"llm:{kwargs['image_resolution']}")
+            return _trace_result()
+
+    monkeypatch.setattr(tps_cli, "_build_pipeline", lambda **kwargs: pipeline)
+    monkeypatch.setattr(tps_cli, "_build_device_tracker", lambda args, pipeline: None)
+    monkeypatch.setattr(tps_cli, "_build_phase_trackers", lambda args, pipeline: (None, None))
+    monkeypatch.setattr(tps_cli, "_print_device_status", lambda args, tracker: None)
+    monkeypatch.setattr(tps_cli, "_start_qbruntime_trace", lambda path: events.append(f"start:{path}") or object())
+    monkeypatch.setattr(tps_cli, "_stop_qbruntime_trace", lambda handle: events.append("stop"))
+    monkeypatch.setattr(benchmark_utils, "VLMTPSMeasurer", _FakeVLMTPSMeasurer)
+
+    args = _trace_scope_args(task="image-text-to-text", image_resolutions=[224, 448], llm_resolution=224)
+    assert tps_cli._run_vlm_sweep(args) == 0
+    assert events.count("start:trace.json") == 1
+    assert events.count("stop") == 1
+    assert events == [
+        "vision:224",
+        "vision:448",
+        "llm:224",
+        "start:trace.json",
+        "vision:224",
+        "vision:224",
+        "vision:448",
+        "vision:448",
+        "llm:224",
+        "llm:224",
+        "stop",
+    ]

--- a/tests/transformers/cli_tps/test_runtime_and_metrics.py
+++ b/tests/transformers/cli_tps/test_runtime_and_metrics.py
@@ -2633,6 +2633,14 @@ def _trace_result(prefill: int = 8, decode: int = 4) -> BenchmarkResult:
     return result
 
 
+def test_phase_trace_path_preserves_cli_trace_shape() -> None:
+    """Phase trace paths should preserve the user-facing single --trace argument shape."""
+    assert tps_cli._phase_trace_path("trace.json", "vision") == "trace.vision.json"
+    assert tps_cli._phase_trace_path("outputs/trace.json", "llm").replace("\\", "/") == "outputs/trace.llm.json"
+    assert tps_cli._phase_trace_path("trace", "vision") == "trace.vision"
+    assert tps_cli._phase_trace_path(None, "vision") is None
+
+
 def test_qbruntime_trace_ignores_nested_start_to_preserve_outer_file(monkeypatch):
     """Nested qbruntime trace requests should not overwrite the active outer trace file."""
     import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
@@ -2727,7 +2735,7 @@ def test_run_text_sweep_traces_all_measured_repeats(monkeypatch):
 
 
 def test_run_vlm_measure_traces_all_measured_repeats(monkeypatch):
-    """VLM measure should trace all measured vision and LLM repeats after warmup."""
+    """VLM measure should trace measured vision and LLM phases separately after warmup."""
     import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
 
     events: list[str] = []
@@ -2756,13 +2764,25 @@ def test_run_vlm_measure_traces_all_measured_repeats(monkeypatch):
     monkeypatch.setattr(benchmark_utils, "VLMTPSMeasurer", _FakeVLMTPSMeasurer)
 
     assert tps_cli._run_vlm_measure(_trace_scope_args(task="image-text-to-text")) == 0
-    assert events.count("start:trace.json") == 1
-    assert events.count("stop") == 1
-    assert events == ["vision", "llm", "start:trace.json", "vision", "llm", "vision", "llm", "stop"]
+    assert events.count("start:trace.vision.json") == 1
+    assert events.count("start:trace.llm.json") == 1
+    assert events.count("stop") == 2
+    assert events == [
+        "vision",
+        "start:trace.vision.json",
+        "vision",
+        "vision",
+        "stop",
+        "llm",
+        "start:trace.llm.json",
+        "llm",
+        "llm",
+        "stop",
+    ]
 
 
 def test_run_vlm_sweep_traces_all_measured_repeats(monkeypatch):
-    """VLM sweep should trace all measured vision and LLM runs after warmup."""
+    """VLM sweep should trace measured vision and LLM phases separately after warmup."""
     import mblt_model_zoo.hf_transformers.utils.benchmark_utils as benchmark_utils
 
     events: list[str] = []
@@ -2790,17 +2810,20 @@ def test_run_vlm_sweep_traces_all_measured_repeats(monkeypatch):
 
     args = _trace_scope_args(task="image-text-to-text", image_resolutions=[224, 448], llm_resolution=224)
     assert tps_cli._run_vlm_sweep(args) == 0
-    assert events.count("start:trace.json") == 1
-    assert events.count("stop") == 1
+    assert events.count("start:trace.vision.json") == 1
+    assert events.count("start:trace.llm.json") == 1
+    assert events.count("stop") == 2
     assert events == [
         "vision:224",
         "vision:448",
+        "start:trace.vision.json",
+        "vision:224",
+        "vision:224",
+        "vision:448",
+        "vision:448",
+        "stop",
         "llm:224",
-        "start:trace.json",
-        "vision:224",
-        "vision:224",
-        "vision:448",
-        "vision:448",
+        "start:trace.llm.json",
         "llm:224",
         "llm:224",
         "stop",


### PR DESCRIPTION
## 개요
- TPS CLI의 qbruntime trace 시작/종료 범위를 측정 반복 전체로 확장했습니다.
- text/VLM measure 및 sweep 경로에서 warmup 이후 측정 구간만 trace되도록 정리했습니다.
- trace 범위가 모든 measured repeat에 적용되는지 검증하는 CLI TPS 테스트를 추가했습니다.

## 변경 사항
- `mblt_model_zoo/cli/tps.py`: CLI 레벨 trace lifecycle 헬퍼 추가 및 측정 루프 단위 trace 처리 개선
- `mblt_model_zoo/hf_transformers/utils/benchmark_utils.py`: qbruntime trace 시작/종료 유틸 보강
- `tests/transformers/cli_tps/test_runtime_and_metrics.py`: text/VLM measure·sweep trace 범위 회귀 테스트 추가

## 테스트
- 미실행: PR 생성 요청 범위 내에서 별도 테스트는 실행하지 않았습니다.
