### PR TITLE
fix: normalize anchorless output layout

### DIFF
--- a/mblt_model_zoo/__init__.py
+++ b/mblt_model_zoo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 from . import utils, vision
 
 __all__ = ["utils", "vision"]

--- a/mblt_model_zoo/vision/utils/evaluation/eval_coco.py
+++ b/mblt_model_zoo/vision/utils/evaluation/eval_coco.py
@@ -163,7 +163,7 @@ def eval_coco(
         out_npu = model(input_npu)
         inference_time += time() - tic
 
-        nms_outs = model.postprocess(out_npu)
+        nms_outs = model.postprocess(out_npu, multi_label=True)
         infer_post_time += time() - tic
         results.extend(
             format_coco_results(

--- a/mblt_model_zoo/vision/utils/postprocess/base.py
+++ b/mblt_model_zoo/vision/utils/postprocess/base.py
@@ -147,6 +147,7 @@ class YOLOPostBase(PostBase):
         x: TensorLike | ListTensorLike,
         conf_thres: float | None = None,
         iou_thres: float | None = None,
+        multi_label: bool = False,
     ) -> list[Any]:
         """Executes YOLO postprocessing.
 
@@ -156,6 +157,8 @@ class YOLOPostBase(PostBase):
             x (TensorLike | ListTensorLike): Raw model outputs.
             conf_thres (float | None): Confidence threshold for detection.
             iou_thres (float | None): IoU threshold for NMS.
+            multi_label: Whether to emit one candidate for every class above the
+                confidence threshold. Validation uses this to match Ultralytics.
 
         Returns:
             list: List of detections per image.
@@ -173,7 +176,7 @@ class YOLOPostBase(PostBase):
 
         predictions, proto_outs = self._pre_process(checked_input)
 
-        nms_output = self.nms(predictions)
+        nms_output = self.nms_multilabel(predictions) if multi_label else self.nms(predictions)
 
         if proto_outs is not None:
             return self.masking(nms_output, proto_outs)
@@ -504,6 +507,17 @@ class YOLOPostBase(PostBase):
         Returns:
             Detections after NMS for each image in the batch.
         """
+
+    def nms_multilabel(self, x: Any) -> list[torch.Tensor]:
+        """Perform validation NMS with all above-threshold class candidates.
+
+        Args:
+            x: Decoded detections for each image.
+
+        Returns:
+            Detections after NMS for each image in the batch.
+        """
+        return self.nms(x)
 
     def masking(self, x: list[torch.Tensor], proto_outs: torch.Tensor | list[torch.Tensor]) -> list[list[torch.Tensor]]:
         """Apply prototype masks to detection results.

--- a/mblt_model_zoo/vision/utils/postprocess/common.py
+++ b/mblt_model_zoo/vision/utils/postprocess/common.py
@@ -871,15 +871,7 @@ def crop_mask(masks: torch.Tensor, boxes: torch.Tensor) -> torch.Tensor:
     """
     if boxes.device != masks.device:
         boxes = boxes.to(masks.device)
-    n, h, w = masks.shape
-    if n < 50 and not masks.is_cuda:
-        for i, (x1, y1, x2, y2) in enumerate(boxes.clamp(min=0).round().int()):
-            masks[i, :y1] = 0
-            masks[i, y2:] = 0
-            masks[i, :, :x1] = 0
-            masks[i, :, x2:] = 0
-        return masks
-
+    _, h, w = masks.shape
     x1, y1, x2, y2 = torch.chunk(boxes[:, :, None], 4, 1)
     rows = torch.arange(w, device=masks.device, dtype=x1.dtype)[None, None, :]
     cols = torch.arange(h, device=masks.device, dtype=x1.dtype)[None, :, None]

--- a/mblt_model_zoo/vision/utils/postprocess/yolo_anchorless_post.py
+++ b/mblt_model_zoo/vision/utils/postprocess/yolo_anchorless_post.py
@@ -4,6 +4,9 @@ YOLO anchorless postprocessing.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Literal
+
 import torch
 
 from .base import YOLOPostBase
@@ -20,6 +23,16 @@ from .common import (
     xywh2xyxy,
     yolo_multilabel_candidates,
 )
+
+AnchorlessOutputLayout = Literal["channels_first", "candidates_first"]
+
+
+@dataclass(frozen=True)
+class _AnchorlessNMSInput:
+    """Decoded anchorless detections together with their source layout."""
+
+    detections: torch.Tensor | list[torch.Tensor]
+    layout: AnchorlessOutputLayout
 
 
 class YOLOAnchorlessPost(YOLOPostBase):
@@ -117,6 +130,30 @@ class YOLOAnchorlessPost(YOLOPostBase):
         """
         return [self.process_box_cls(box_cls) for box_cls in x]
 
+    def _pre_process(
+        self,
+        x: list[torch.Tensor],
+    ) -> tuple[_AnchorlessNMSInput, torch.Tensor | None]:
+        """Decode detections while retaining whether the source was raw or converted.
+
+        Args:
+            x: Checked model output tensors.
+
+        Returns:
+            Layout-aware detections and an optional prototype output.
+        """
+        if len(x) == 1:
+            converted = self.conversion(x)
+            if not isinstance(converted, torch.Tensor):
+                raise TypeError("conversion should return a tensor for single-output YOLO postprocessing.")
+            detections = self.filter_conversion(converted)
+            return _AnchorlessNMSInput(detections, "candidates_first"), None
+        rearranged = self.rearrange(x)
+        if not isinstance(rearranged, torch.Tensor):
+            raise TypeError("rearrange should return a tensor for non-segmentation YOLO postprocessing.")
+        detections = self.decode(rearranged)
+        return _AnchorlessNMSInput(detections, "channels_first"), None
+
     def process_box_cls(self, box_cls: torch.Tensor) -> torch.Tensor:
         """Processes detection results for a single image.
 
@@ -188,52 +225,98 @@ class YOLOAnchorlessPost(YOLOPostBase):
 
         return [process_conversion(xi) for xi in x_list]
 
-    def _nms_single(self, xi: torch.Tensor, max_det: int, max_nms: int, max_wh: int) -> torch.Tensor:
+    def _nms_single(
+        self,
+        xi: torch.Tensor,
+        max_det: int,
+        max_nms: int,
+        max_wh: int,
+        multi_label: bool,
+    ) -> torch.Tensor:
         """Apply anchorless NMS to a single decoded image tensor."""
-        if xi.numel() == 0:
-            return torch.zeros((0, 6 + self.n_extra), dtype=torch.float32, device=self.device)
-        xi_t = xi.transpose(0, 1)
-        score = xi_t[:, 4 : 4 + self.nc]
-        extra = xi_t[:, 4 + self.nc :]
-        conf, cls_idx = score.max(dim=1)
-        filt = conf > self.conf_thres
-        if not torch.any(filt):
-            return torch.zeros((0, 6 + self.n_extra), dtype=torch.float32, device=self.device)
-        xi_t = xi_t[filt]
-        conf = conf[filt]
-        cls_idx = cls_idx[filt]
-        extra = extra[filt]
-        xi_out = torch.empty((xi_t.shape[0], 6 + self.n_extra), dtype=xi_t.dtype, device=xi_t.device)
-        xi_out[:, :4] = xi_t[:, :4]
-        xi_out[:, 4] = conf
-        xi_out[:, 5] = cls_idx.to(xi_t.dtype)
-        if self.n_extra > 0:
-            xi_out[:, 6:] = extra
-        xi_out = xi_out[torch.argsort(xi_out[:, 4], descending=True)[:max_nms]]
-        c = xi_out[:, 5:6] * max_wh
-        boxes, scores = xi_out[:, :4] + c, xi_out[:, 4]
-        i_idx = non_max_suppression(boxes, scores, self.iou_thres, max_det)
-        return xi_out[i_idx]
+        return self._nms_single_legacy_rows(
+            self._normalize_nms_input(xi, "channels_first"),
+            max_det=max_det,
+            max_nms=max_nms,
+            max_wh=max_wh,
+            multi_label=multi_label,
+        )
 
-    def _nms_single_legacy_rows(self, xi: torch.Tensor, max_det: int, max_nms: int, max_wh: int) -> torch.Tensor:
+    def _normalize_nms_input(
+        self,
+        xi: torch.Tensor,
+        layout: AnchorlessOutputLayout | None = None,
+    ) -> torch.Tensor:
+        """Normalize one decoded tensor to ``(candidates, channels)``.
+
+        Source provenance resolves square tensors. Shape inference remains available
+        for callers that pass decoded tensors directly, with raw channel-first
+        layout taking precedence when both dimensions match.
+
+        Args:
+            xi: One image's decoded detections.
+            layout: Known source layout, if available.
+
+        Returns:
+            Detections in canonical ``(candidates, channels)`` layout.
+
+        Raises:
+            ValueError: If the tensor shape conflicts with the expected channel count
+                or with the supplied source layout.
+        """
+        if xi.ndim != 2:
+            raise ValueError(f"Expected 2D decoded tensor, got shape {tuple(xi.shape)}.")
+
+        expected_dim = 4 + self.nc + self.n_extra
+        if layout == "channels_first":
+            if xi.shape[0] != expected_dim:
+                raise ValueError(
+                    f"Expected channel-first decoded tensor with {expected_dim} channels, got shape {tuple(xi.shape)}."
+                )
+            return xi.transpose(0, 1)
+        if layout == "candidates_first":
+            if xi.shape[1] != expected_dim:
+                raise ValueError(
+                    "Expected candidates-first decoded tensor "
+                    f"with {expected_dim} channels, got shape {tuple(xi.shape)}."
+                )
+            return xi
+
+        if xi.shape[0] == expected_dim:
+            return xi.transpose(0, 1)
+        if xi.shape[1] == expected_dim:
+            return xi
+        raise ValueError(f"Unsupported decoded tensor shape {tuple(xi.shape)}.")
+
+    def _nms_single_legacy_rows(
+        self,
+        xi: torch.Tensor,
+        max_det: int,
+        max_nms: int,
+        max_wh: int,
+        multi_label: bool,
+    ) -> torch.Tensor:
         """Apply anchorless NMS to a single decoded image in row-major ``(anchors, channels)`` form."""
         if xi.numel() == 0:
             return torch.zeros((0, 6 + self.n_extra), dtype=torch.float32, device=self.device)
-        box, score, extra = xi[:, :4], xi[:, 4 : 4 + self.nc], xi[:, 4 + self.nc :]
-        conf, cls_idx = score.max(dim=1)
-        filt = conf > self.conf_thres
-        if not torch.any(filt):
-            return torch.zeros((0, 6 + self.n_extra), dtype=torch.float32, device=self.device)
-        box = box[filt]
-        conf = conf[filt]
-        cls_idx = cls_idx[filt]
-        extra = extra[filt]
-        xi_out = torch.empty((box.shape[0], 6 + self.n_extra), dtype=xi.dtype, device=xi.device)
-        xi_out[:, :4] = box
-        xi_out[:, 4] = conf
-        xi_out[:, 5] = cls_idx.to(xi.dtype)
-        if self.n_extra > 0:
-            xi_out[:, 6:] = extra
+        if multi_label:
+            xi_out = yolo_multilabel_candidates(xi, self.nc, self.n_extra, self.conf_thres)
+        else:
+            box, score, extra = xi[:, :4], xi[:, 4 : 4 + self.nc], xi[:, 4 + self.nc :]
+            conf, cls_idx = score.max(dim=1)
+            filt = conf > self.conf_thres
+            if not torch.any(filt):
+                return torch.zeros((0, 6 + self.n_extra), dtype=torch.float32, device=self.device)
+            box = box[filt]
+            conf = conf[filt]
+            cls_idx = cls_idx[filt]
+            extra = extra[filt]
+            xi_out = torch.empty((box.shape[0], 6 + self.n_extra), dtype=xi.dtype, device=xi.device)
+            xi_out[:, :4] = box
+            xi_out[:, 4] = conf
+            xi_out[:, 5] = cls_idx.to(xi.dtype)
+            if self.n_extra > 0:
+                xi_out[:, 6:] = extra
         xi_out = xi_out[torch.argsort(xi_out[:, 4], descending=True)[:max_nms]]
         c = xi_out[:, 5:6] * max_wh
         boxes, scores = xi_out[:, :4] + c, xi_out[:, 4]
@@ -242,37 +325,50 @@ class YOLOAnchorlessPost(YOLOPostBase):
 
     def nms(
         self,
-        x: torch.Tensor | list[torch.Tensor],
+        x: _AnchorlessNMSInput | torch.Tensor | list[torch.Tensor],
         max_det: int = 300,
         max_nms: int = 30000,
         max_wh: int = 7680,
+        multi_label: bool = False,
     ) -> list[torch.Tensor]:
         """Performs Non-Maximum Suppression (NMS) on the decoded detections.
 
         Args:
-            x (list[torch.Tensor]): Decoded detections for each image.
+            x: Decoded detections for each image, optionally with source-layout
+                provenance.
             max_det (int, optional): Maximum number of detections to keep. Defaults to 300.
             max_nms (int, optional): Maximum number of candidates to consider for NMS.
                 Defaults to 30000.
             max_wh (int, optional): Maximum box width/height for offset calculation.
                 Defaults to 7680.
+            multi_label: Whether to retain every class candidate above threshold.
 
         Returns:
             list[torch.Tensor]: Post-NMS detections for each image.
         """
-        if isinstance(x, list):
-            output = []
-            for xi in x:
-                if xi.ndim != 2:
-                    raise ValueError(f"Expected 2D decoded tensor, got shape {tuple(xi.shape)}.")
-                if xi.shape[1] == 4 + self.nc + self.n_extra:
-                    output.append(self._nms_single_legacy_rows(xi, max_det=max_det, max_nms=max_nms, max_wh=max_wh))
-                elif xi.shape[0] == 4 + self.nc + self.n_extra:
-                    output.append(self._nms_single(xi, max_det=max_det, max_nms=max_nms, max_wh=max_wh))
-                else:
-                    raise ValueError(f"Unsupported decoded tensor shape {tuple(xi.shape)}.")
-            return output
-        return [self._nms_single(xi, max_det=max_det, max_nms=max_nms, max_wh=max_wh) for xi in x]
+        layout: AnchorlessOutputLayout | None = None
+        if isinstance(x, _AnchorlessNMSInput):
+            layout = x.layout
+            x = x.detections
+
+        tensors = x if isinstance(x, list) else list(x)
+        return [
+            self._nms_single_legacy_rows(
+                self._normalize_nms_input(xi, layout),
+                max_det=max_det,
+                max_nms=max_nms,
+                max_wh=max_wh,
+                multi_label=multi_label,
+            )
+            for xi in tensors
+        ]
+
+    def nms_multilabel(
+        self,
+        x: _AnchorlessNMSInput | torch.Tensor | list[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        """Perform Ultralytics-compatible multi-label NMS for validation."""
+        return self.nms(x, multi_label=True)
 
     def dfl(self, x: torch.Tensor) -> torch.Tensor:
         """Applies Distribution Focal Loss projection.
@@ -323,7 +419,7 @@ class YOLOAnchorlessSegPost(YOLOSegPostMixin, YOLOAnchorlessPost):
             return proto.permute(0, 3, 1, 2)
         raise ValueError(f"Unsupported proto tensor shape {tuple(proto.shape)} for non-e2e output.")
 
-    def _pre_process(self, x: list[torch.Tensor]) -> tuple[list[torch.Tensor], torch.Tensor]:
+    def _pre_process(self, x: list[torch.Tensor]) -> tuple[_AnchorlessNMSInput, torch.Tensor]:
         """Preprocesses intermediate inputs into (boxes, proto) format.
 
         Args:
@@ -334,9 +430,10 @@ class YOLOAnchorlessSegPost(YOLOSegPostMixin, YOLOAnchorlessPost):
         """
         if len(x) == 2:
             converted, proto_outs = self.conversion(x)
-            return self.filter_conversion(converted), proto_outs
+            detections = self.filter_conversion(converted)
+            return _AnchorlessNMSInput(detections, "candidates_first"), proto_outs
         rearranged, proto_outs = self.rearrange(x)
-        return self.decode(rearranged), proto_outs
+        return _AnchorlessNMSInput(self.decode(rearranged), "channels_first"), proto_outs
 
     def conversion(self, x: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Converts raw model output tensors into detections and prototypes.
@@ -488,7 +585,7 @@ class YOLOAnchorlessOBBPost(YOLOOBBPostMixin, YOLOAnchorlessPost):
         """Decode YOLOv8/YOLO11 raw angle logits to radians."""
         return (angle.sigmoid() - 0.25) * torch.pi
 
-    def _pre_process(self, x: list[torch.Tensor]) -> tuple[list[torch.Tensor], torch.Tensor | None]:
+    def _pre_process(self, x: list[torch.Tensor]) -> tuple[_AnchorlessNMSInput, torch.Tensor | None]:
         """Preprocess OBB inputs into row-major detections.
 
         Args:
@@ -498,8 +595,9 @@ class YOLOAnchorlessOBBPost(YOLOOBBPostMixin, YOLOAnchorlessPost):
             A tuple of detections and no prototype output.
         """
         if len(x) in {1, 3, 5}:
-            return self.filter_conversion(self.conversion(x)), None
-        return self.decode(self.rearrange(x)), None
+            detections = self.filter_conversion(self.conversion(x))
+            return _AnchorlessNMSInput(detections, "candidates_first"), None
+        return _AnchorlessNMSInput(self.decode(self.rearrange(x)), "channels_first"), None
 
     def conversion(self, x: list[torch.Tensor]) -> torch.Tensor:
         """Convert exported OBB outputs to one canonical tensor.
@@ -672,15 +770,36 @@ class YOLOAnchorlessOBBPost(YOLOOBBPostMixin, YOLOAnchorlessPost):
                 outputs.append(torch.zeros((0, expected_dim), dtype=xi.dtype, device=xi.device))
         return outputs
 
-    def _nms_single(self, xi: torch.Tensor, max_det: int, max_nms: int, max_wh: int) -> torch.Tensor:
+    def _nms_single(
+        self,
+        xi: torch.Tensor,
+        max_det: int,
+        max_nms: int,
+        max_wh: int,
+        multi_label: bool,
+    ) -> torch.Tensor:
         """Apply rotated NMS to a single decoded OBB image tensor."""
         if xi.numel() == 0:
             return torch.zeros((0, 7), dtype=torch.float32, device=self.device)
         xi_t = xi.transpose(0, 1)
-        return self._nms_single_legacy_rows(xi_t, max_det=max_det, max_nms=max_nms, max_wh=max_wh)
+        return self._nms_single_legacy_rows(
+            xi_t,
+            max_det=max_det,
+            max_nms=max_nms,
+            max_wh=max_wh,
+            multi_label=multi_label,
+        )
 
-    def _nms_single_legacy_rows(self, xi: torch.Tensor, max_det: int, max_nms: int, max_wh: int) -> torch.Tensor:
+    def _nms_single_legacy_rows(
+        self,
+        xi: torch.Tensor,
+        max_det: int,
+        max_nms: int,
+        max_wh: int,
+        multi_label: bool,
+    ) -> torch.Tensor:
         """Apply rotated NMS to row-major OBB detections."""
+        del multi_label
         if xi.numel() == 0:
             return torch.zeros((0, 7), dtype=torch.float32, device=self.device)
         xi_out = yolo_multilabel_candidates(xi, self.nc, self.n_extra, self.conf_thres)
@@ -691,3 +810,10 @@ class YOLOAnchorlessOBBPost(YOLOOBBPostMixin, YOLOAnchorlessPost):
         boxes = torch.cat([xi_out[:, :2] + c, xi_out[:, 2:4], xi_out[:, 6:7]], dim=-1)
         keep = rotated_nms(boxes, xi_out[:, 4], self.iou_thres)[:max_det]
         return xi_out[keep]
+
+    def nms_multilabel(
+        self,
+        x: _AnchorlessNMSInput | torch.Tensor | list[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        """Preserve existing OBB NMS behavior outside the COCO validation scope."""
+        return self.nms(x)

--- a/tests/vision/test_wrapper_download.py
+++ b/tests/vision/test_wrapper_download.py
@@ -22,6 +22,12 @@ from mblt_model_zoo.vision.utils.postprocess.common import (
     scale_coords,
     scale_masks,
 )
+from mblt_model_zoo.vision.utils.postprocess.yolo_anchorless_post import (
+    AnchorlessOutputLayout,
+    YOLOAnchorlessPosePost,
+    YOLOAnchorlessPost,
+    _AnchorlessNMSInput,
+)
 from mblt_model_zoo.vision.utils.results import Results
 from mblt_model_zoo.vision.utils.types import ListTensorLike
 from mblt_model_zoo.vision.wrapper import MBLT_Engine
@@ -491,16 +497,17 @@ def test_custom_coco_data_filters_visible_keypoints(tmp_path: Path) -> None:
     assert dataset.ids == [2]
 
 
-def test_crop_mask_matches_ultralytics_rounding() -> None:
-    """Crop mask boxes with Ultralytics-compatible rounded boundaries."""
+@pytest.mark.parametrize("mask_count", [1, 50])
+def test_crop_mask_matches_ultralytics_fractional_boundaries(mask_count: int) -> None:
+    """Use identical fractional crop semantics on both sides of the former CPU branch."""
 
-    masks = torch.ones((1, 5, 5), dtype=torch.float32)
-    boxes = torch.tensor([[1.2, 1.8, 3.6, 4.2]], dtype=torch.float32)
+    masks = torch.ones((mask_count, 5, 5), dtype=torch.float32)
+    boxes = torch.tensor([[1.2, 1.8, 3.6, 4.2]], dtype=torch.float32).repeat(mask_count, 1)
 
     cropped = crop_mask(masks, boxes)
 
-    expected = torch.zeros((1, 5, 5), dtype=torch.float32)
-    expected[0, 2:4, 1:4] = 1
+    expected = torch.zeros((mask_count, 5, 5), dtype=torch.float32)
+    expected[:, 2:5, 2:4] = 1
     assert torch.equal(cropped, expected)
 
 
@@ -718,8 +725,8 @@ def test_final_onnx_detections_normalize_singleton_and_channel_first() -> None:
     assert torch.equal(channel_first_result[0], final_output[0, :1])
 
 
-def test_anchorless_pose_nms_prefers_row_major_ambiguous_shape() -> None:
-    """Keep ONNX row-major pose tensors row-major when candidate count equals channel count."""
+def test_anchorless_pose_nms_uses_converted_provenance_for_ambiguous_shape() -> None:
+    """Keep converted row-major pose tensors row-major when both dimensions match."""
 
     pre_cfg = {
         "LetterBox": {
@@ -739,7 +746,7 @@ def test_anchorless_pose_nms_prefers_row_major_ambiguous_shape() -> None:
     row_major[:, :4] = torch.tensor([10.0, 10.0, 20.0, 20.0])
     row_major[:, 4] = torch.linspace(0.9, 0.1, 56)
 
-    result = postprocessor.nms([row_major])
+    result = postprocessor.nms(_AnchorlessNMSInput([row_major], "candidates_first"))
 
     assert len(result) == 1
     assert result[0].shape == (1, 57)
@@ -1546,8 +1553,8 @@ def test_anchor_segmentation_accepts_mxq_raw_heads() -> None:
     assert result[1][1].shape == (0, 640, 640)
 
 
-def test_anchorless_nms_keeps_best_class_per_box() -> None:
-    """Use one detection per box to match Ultralytics best-class NMS behavior."""
+def test_anchorless_prediction_nms_keeps_best_class_per_box() -> None:
+    """Keep ordinary prediction output limited to the best class per box."""
 
     pre_cfg = {
         "LetterBox": {
@@ -1562,7 +1569,7 @@ def test_anchorless_nms_keeps_best_class_per_box() -> None:
         "conf_thres": 0.25,
         "iou_thres": 0.7,
     }
-    postprocessor = cast(YOLOPostBase, build_postprocess(pre_cfg, post_cfg))
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
     decoded = torch.tensor(
         [
             [
@@ -1583,6 +1590,263 @@ def test_anchorless_nms_keeps_best_class_per_box() -> None:
     assert len(result) == 1
     assert result[0].shape == (2, 6)
     assert torch.equal(result[0][:, 5], torch.tensor([0.0, 1.0]))
+
+
+@pytest.mark.parametrize(
+    ("layout", "candidate_count"),
+    [
+        ("channels_first", 117),
+        ("candidates_first", 117),
+        ("channels_first", 116),
+        ("candidates_first", 116),
+    ],
+)
+def test_anchorless_nms_normalizes_known_layout_before_suppression(
+    layout: AnchorlessOutputLayout,
+    candidate_count: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use source provenance to normalize raw and converted segmentation outputs."""
+
+    pre_cfg = {"LetterBox": {"img_size": [640, 640]}}
+    post_cfg = {
+        "task": "instance_segmentation",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 80,
+        "n_extra": 32,
+        "conf_thres": 0.25,
+        "iou_thres": 0.7,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    canonical = torch.arange(candidate_count * 116, dtype=torch.float32).reshape(candidate_count, 116)
+    source = canonical.transpose(0, 1) if layout == "channels_first" else canonical
+    captured: list[torch.Tensor] = []
+
+    def capture_canonical(xi: torch.Tensor, **_: Any) -> torch.Tensor:
+        captured.append(xi)
+        return torch.empty((0, 38), dtype=torch.float32)
+
+    monkeypatch.setattr(postprocessor, "_nms_single_legacy_rows", capture_canonical)
+
+    postprocessor.nms(_AnchorlessNMSInput([source], layout))
+
+    assert captured[0].shape == (candidate_count, 116)
+    torch.testing.assert_close(captured[0], canonical)
+
+
+def test_anchorless_nms_shape_fallback_prefers_raw_layout_for_square_tensor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Treat an ambiguous provenance-free square tensor as channel-first."""
+
+    pre_cfg = {"LetterBox": {"img_size": [640, 640]}}
+    post_cfg = {
+        "task": "instance_segmentation",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 80,
+        "n_extra": 32,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    source = torch.arange(116 * 116, dtype=torch.float32).reshape(116, 116)
+    captured: list[torch.Tensor] = []
+
+    def capture_canonical(xi: torch.Tensor, **_: Any) -> torch.Tensor:
+        captured.append(xi)
+        return torch.empty((0, 38), dtype=torch.float32)
+
+    monkeypatch.setattr(postprocessor, "_nms_single_legacy_rows", capture_canonical)
+
+    postprocessor.nms([source])
+
+    torch.testing.assert_close(captured[0], source.transpose(0, 1))
+
+
+def test_anchorless_segmentation_preprocess_preserves_layout_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tag decoded MXQ heads as channel-first and converted outputs as candidates-first."""
+
+    pre_cfg = {"LetterBox": {"img_size": [640, 640]}}
+    post_cfg = {
+        "task": "instance_segmentation",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 80,
+        "n_extra": 32,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    decoded = torch.zeros((116, 116), dtype=torch.float32)
+    converted = decoded.transpose(0, 1).unsqueeze(0)
+    proto = torch.zeros((1, 160, 160, 32), dtype=torch.float32)
+    rearranged = torch.empty(0)
+
+    monkeypatch.setattr(postprocessor, "rearrange", lambda _: (rearranged, proto))
+    monkeypatch.setattr(postprocessor, "decode", lambda value: [decoded] if value is rearranged else [])
+    raw_predictions, raw_proto = postprocessor._pre_process([torch.empty(0)] * 3)
+
+    monkeypatch.setattr(postprocessor, "conversion", lambda _: (converted, proto))
+    monkeypatch.setattr(postprocessor, "filter_conversion", lambda _: [converted.squeeze(0)])
+    converted_predictions, converted_proto = postprocessor._pre_process([torch.empty(0)] * 2)
+
+    assert raw_predictions.layout == "channels_first"
+    assert isinstance(raw_predictions.detections, list)
+    assert raw_predictions.detections[0] is decoded
+    assert raw_proto is proto
+    assert converted_predictions.layout == "candidates_first"
+    assert isinstance(converted_predictions.detections, list)
+    torch.testing.assert_close(converted_predictions.detections[0], converted.squeeze(0))
+    assert converted_proto is proto
+
+
+def test_anchorless_nms_normalizes_detection_without_extra_channels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normalize raw detection output when no segmentation or pose extras exist."""
+
+    pre_cfg = {"LetterBox": {"img_size": [640, 640]}}
+    post_cfg = {
+        "task": "object_detection",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 80,
+        "conf_thres": 0.25,
+        "iou_thres": 0.7,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    source = torch.arange(84 * 91, dtype=torch.float32).reshape(84, 91)
+    captured: list[torch.Tensor] = []
+
+    def capture_canonical(xi: torch.Tensor, **_: Any) -> torch.Tensor:
+        captured.append(xi)
+        return torch.empty((0, 6), dtype=torch.float32)
+
+    monkeypatch.setattr(postprocessor, "_nms_single_legacy_rows", capture_canonical)
+
+    postprocessor.nms(_AnchorlessNMSInput([source], "channels_first"))
+
+    assert postprocessor.n_extra == 0
+    assert captured[0].shape == (91, 84)
+    torch.testing.assert_close(captured[0], source.transpose(0, 1))
+
+
+def test_anchorless_nonambiguous_layouts_keep_identical_nms_results() -> None:
+    """Keep existing suppression results after canonical layout normalization."""
+
+    pre_cfg = {"LetterBox": {"img_size": [640, 640]}}
+    post_cfg = {
+        "task": "instance_segmentation",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 80,
+        "n_extra": 32,
+        "conf_thres": 0.25,
+        "iou_thres": 0.7,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    canonical = torch.zeros((2, 116), dtype=torch.float32)
+    canonical[0, :4] = torch.tensor([10.0, 10.0, 20.0, 20.0])
+    canonical[1, :4] = torch.tensor([40.0, 40.0, 60.0, 60.0])
+    canonical[0, 4] = 0.9
+    canonical[1, 5] = 0.8
+    canonical[:, 84:] = torch.arange(64, dtype=torch.float32).reshape(2, 32)
+
+    raw_result = postprocessor.nms(_AnchorlessNMSInput([canonical.transpose(0, 1)], "channels_first"))
+    converted_result = postprocessor.nms(_AnchorlessNMSInput([canonical], "candidates_first"))
+
+    torch.testing.assert_close(raw_result[0], converted_result[0])
+
+
+def test_anchorless_validation_nms_keeps_multilabel_candidates() -> None:
+    """Retain all above-threshold classes when validation requests Ultralytics semantics."""
+
+    pre_cfg = {
+        "LetterBox": {
+            "img_size": [640, 640],
+        }
+    }
+    post_cfg = {
+        "task": "object_detection",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 3,
+        "conf_thres": 0.25,
+        "iou_thres": 0.7,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    decoded = torch.tensor(
+        [
+            [10.0, 10.0, 20.0, 20.0, 0.90, 0.80, 0.10],
+            [50.0, 50.0, 60.0, 60.0, 0.20, 0.85, 0.70],
+        ],
+        dtype=torch.float32,
+    )
+
+    result = postprocessor.nms([decoded], multi_label=True)
+
+    assert len(result) == 1
+    assert result[0].shape == (4, 6)
+    assert torch.equal(result[0][:, 5], torch.tensor([0.0, 1.0, 1.0, 2.0]))
+
+
+def test_anchorless_segmentation_validation_duplicates_mask_coefficients_per_class() -> None:
+    """Copy mask coefficients when validation expands a box into multiple class candidates."""
+
+    pre_cfg = {
+        "LetterBox": {
+            "img_size": [640, 640],
+        }
+    }
+    post_cfg = {
+        "task": "instance_segmentation",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 3,
+        "n_extra": 2,
+        "conf_thres": 0.25,
+        "iou_thres": 0.7,
+    }
+    postprocessor = cast(YOLOAnchorlessPost, build_postprocess(pre_cfg, post_cfg))
+    decoded = torch.tensor(
+        [[10.0, 10.0, 20.0, 20.0, 0.90, 0.80, 0.10, 0.25, -0.50]],
+        dtype=torch.float32,
+    )
+
+    result = postprocessor.nms([decoded], multi_label=True)
+
+    assert result[0].shape == (2, 8)
+    assert torch.equal(result[0][:, 5], torch.tensor([0.0, 1.0]))
+    assert torch.equal(result[0][:, 6:], decoded[:, 7:].repeat(2, 1))
+
+
+def test_anchorless_pose_single_and_batch_decode_are_equivalent() -> None:
+    """Keep batched pose decoding equivalent to the verified v1.5.1 per-image formula."""
+
+    torch.manual_seed(0)
+    pre_cfg = {
+        "LetterBox": {
+            "img_size": [64, 64],
+        }
+    }
+    post_cfg = {
+        "task": "pose_estimation",
+        "nl": 3,
+        "reg_max": 16,
+        "nc": 1,
+        "n_extra": 51,
+        "conf_thres": 0.25,
+        "iou_thres": 0.7,
+    }
+    postprocessor = cast(YOLOAnchorlessPosePost, build_postprocess(pre_cfg, post_cfg))
+    anchor_count = postprocessor.anchors_as_tensor().shape[-1]
+    raw = torch.randn((2, 116, anchor_count), dtype=torch.float32)
+    raw[:, 64, :] = 10.0
+
+    batched = postprocessor.decode_batch(raw)
+    per_image = torch.stack([postprocessor.process_box_cls(image) for image in raw])
+
+    torch.testing.assert_close(batched, per_image)
 
 
 def test_scale_coords_matches_ultralytics_rounding() -> None:


### PR DESCRIPTION
## Summary

- preserve raw-MXQ versus converted-output layout provenance through anchorless postprocessing
- normalize every decoded tensor to `(candidates, channels)` before NMS
- use channel-first-first dimension inference only when provenance is unavailable
- enable Ultralytics-compatible multi-label candidates for COCO validation while preserving best-class prediction behavior
- use fractional-coordinate semantics for CPU mask cropping
- add regression coverage for raw, converted, ambiguous square, detection, segmentation, and pose layouts

## Root cause

Raw decoded MXQ output is `(channels, candidates)`, while converted output is `(candidates, channels)`. The previous dimension-only dispatch checked `shape[1]` first. Square tensors such as YOLO11s-seg `(116, 116)` therefore entered the converted row-major path even though they originated from raw MXQ decode. Box coordinates were then interpreted as class scores, producing high-confidence false positives.

## Accuracy impact

Full COCO validation used batch size 8, `multi` core mode, multi-label validation, confidence threshold 0.001, and IoU threshold 0.7.

| Model | Metric | Previous | Corrected | Affected square outputs |
|---|---:|---:|---:|---:|
| YOLO11s | bbox AP | 0.33162 | 0.46184 | 13 / 5,000 |
| YOLO11s-seg | bbox AP | 0.33012 | 0.45769 | 14 / 5,000 |
| YOLO11s-seg | mask AP | 0.26496 | 0.37520 | 14 / 5,000 |
| YOLO11s-pose | keypoint AP | 0.50082 | 0.56286 | 20 / 2,346 |

All 14 ambiguous segmentation images produced materially different COCO records. The previous dispatch hit the 300-detection cap for each image; corrected outputs contained 27–102 predictions.

## Validation

- `pytest -q tests/vision/test_wrapper_download.py` — 68 passed
- `ruff check` on affected files
- `ruff format --check` on affected files
- `pre-commit run --files ...` — Ruff and Ruff format passed
- `git diff --check`
- full cached-MXQ COCO validation for YOLO11s detect, segment, and pose with batch size 8 / `multi` mode