### PR TITLE
fix(postprocess): align scale_coords pad with scale_boxes/letterbox

### DIFF
--- a/mblt_model_zoo/vision/utils/postprocess/common.py
+++ b/mblt_model_zoo/vision/utils/postprocess/common.py
@@ -660,15 +660,11 @@ def scale_coords(
     Returns:
         np.ndarray | torch.Tensor: The scaled coordinates, in the format of (x, y)
     """
-    if ratio_pad is None:  # calculate from img0_shape
-        gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
-        pad = (
-            (img1_shape[1] - round(img0_shape[1] * gain)) / 2,
-            (img1_shape[0] - round(img0_shape[0] * gain)) / 2,
-        )  # wh padding
-    else:
-        gain = ratio_pad[0][0]
-        pad = ratio_pad[1]
+    # Use the same ratio/pad as scale_boxes/scale_rboxes so keypoints are
+    # un-letterboxed with the exact integer pad copyMakeBorder applied
+    # (compute_ratio_pad == LetterBox pad). The previous inline formula produced
+    # a fractional pad that drifted from the box/letterbox pad by up to ~0.5 px.
+    gain, pad = compute_ratio_pad(img1_shape, img0_shape, ratio_pad)
     if isinstance(coords, np.ndarray):
         if padding:
             coords[..., 0] -= pad[0]  # x padding


### PR DESCRIPTION
# fix(postprocess): align scale_coords pad with scale_boxes/letterbox

## 요약 (Summary)

`scale_coords`가 keypoint를 원본 좌표로 되돌릴 때 사용하는 letterbox padding을,
`scale_boxes` / `scale_rboxes` 및 실제 `LetterBox` 전처리와 **동일한 정수 pad**
(`compute_ratio_pad`)를 쓰도록 통일합니다. 기존에는 `scale_coords`만 자체 **분수(float)
pad 공식**을 써서 박스/letterbox와 최대 **~0.5px 어긋남**이 있었습니다.

## 문제 (Problem)

좌표 역-letterbox 함수들이 pad를 서로 다르게 계산하고 있었습니다.

| 함수 | pad 계산 |
| --- | --- |
| `scale_boxes`, `scale_rboxes` | `compute_ratio_pad` → `round((img1 − round(img0·gain))/2 − 0.1)` **(정수)** |
| `LetterBox` (전처리, 실제 적용) | `int(round(dw − 0.1))` = 위와 동일 **(정수)** |
| **`scale_coords`** | `(img1 − round(img0·gain))/2` **(분수, inline)** ← 불일치 |

`LetterBox`가 실제로 붙이는 여백은 정수 픽셀인데, `scale_coords`는 분수 pad로 빼기 때문에
**keypoint만** 박스/letterbox 기준에서 미세하게 밀립니다. 패딩된 변의 길이가 홀수인
이미지에서 축당 최대 0.5px 오프셋이 발생합니다.

**Before/after pad (input 640×640):**

| 원본 (H×W) | 기존 `scale_coords` | `compute_ratio_pad` (= box/letterbox) | 차이 |
| --- | --- | --- | --- |
| 427×640 | `(0, 106.5)` | `(0, 106)` | 0.5 |
| 581×640 | `(0, 29.5)` | `(0, 29)` | 0.5 |
| 375×500 | `(0, 80.0)` | `(0, 80)` | 0 |

## 수정 (Fix)

`scale_coords`의 inline pad 계산을 제거하고 `scale_boxes` / `scale_rboxes`와 동일하게
`compute_ratio_pad`를 호출하도록 변경했습니다.

```python
# before
gain = min(...)
pad = ((img1[1] - round(img0[1] * gain)) / 2,
       (img1[0] - round(img0[0] * gain)) / 2)

# after
gain, pad = compute_ratio_pad(img1_shape, img0_shape, ratio_pad)
```

이제 box·keypoint가 **동일한 ratio/pad**로 역-letterbox되어, 실제 적용된 letterbox pad와
정확히 일치합니다.

## 영향 / 리스크 (Impact & Risk)

- **정합성 개선(서브픽셀).** keypoint가 박스/letterbox와 완전히 동일 기준으로 정렬됩니다.
- `scale_boxes` / `scale_rboxes` 동작은 불변 (이미 `compute_ratio_pad` 사용).
- 로직 축소(−9 / +5)이며 새 의존성 없음 (`compute_ratio_pad`는 같은 모듈).