### PR TITLE
test: document cache isolation for MobilintCache

### DIFF
--- a/mblt_model_zoo/hf_transformers/utils/cache_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/cache_utils.py
@@ -123,6 +123,14 @@ class MobilintLayer(CacheLayerMixin):
 
 class MobilintCache(Cache):
     def __init__(self, mxq_model: qbruntime.Model, batch_size: int = 1):
+        """Create a cache with fresh logical cursors for the shared runtime model.
+
+        qbruntime selects the readable KV prefix from the ``cache_size`` passed
+        to inference; it does not expose the old ``reset_cache_memory`` API.
+        Fresh layers therefore start at sequence length zero, causing the next
+        inference to overwrite cache entries from the beginning rather than
+        making a previous request's KV prefix addressable.
+        """
         self.mxq_model = mxq_model
         self.batch_size = max(1, batch_size)
 

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -76,6 +76,17 @@ def test_dump_cache_memory_roundtrip_restores_seq_length() -> None:
     assert mxq_model.loaded == [(0, [b"cache-0"])]
 
 
+def test_new_cache_for_reused_model_starts_with_fresh_logical_cursors() -> None:
+    """A new request must not inherit the prior request's addressable KV prefix."""
+    mxq_model = _FakeMxqModel()
+    previous_request = MobilintCache(mxq_model, batch_size=2)
+    previous_request.set_seq_length({0: 7, 1: 11})
+
+    next_request = MobilintCache(mxq_model, batch_size=2)
+
+    assert [next_request.get_seq_length(index=i) for i in range(2)] == [0, 0]
+
+
 def test_fake_prefill_sets_seq_length_without_cache_buffer() -> None:
     """Fake prefill should only expose sequence length and clear cache payloads."""
     mxq_model = _FakeMxqModel()


### PR DESCRIPTION
### Motivation
- Clarify and document the intended cache-isolation behavior for `MobilintCache` when reusing a shared runtime model so reviewers understand why `reset_cache_memory()` is not required or available with `qbruntime`.
- Add a regression test to prevent accidental reintroduction of cross-request logical-cursor leakage for shared `mxq_model` instances.

### Description
- Add a docstring to `MobilintCache.__init__` in `mblt_model_zoo/hf_transformers/utils/cache_utils.py` explaining that `qbruntime` enforces isolation via the logical `cache_size` (sequence length) and that there is no `reset_cache_memory` API to call.
- Add a unit test `test_new_cache_for_reused_model_starts_with_fresh_logical_cursors()` to `tests/transformers/test_cache_utils.py` that verifies a newly-constructed `MobilintCache` for a reused `mxq_model` starts with sequence lengths `[0, 0, ...]` for each cache id.
- No runtime behavior was changed; the change is documentation plus a test to guard against regressions.

### Testing
- `python -m py_compile mblt_model_zoo/hf_transformers/utils/cache_utils.py tests/transformers/test_cache_utils.py` succeeded and verified syntax.
- `pytest -q tests/transformers/test_cache_utils.py` could not be completed due to an environment-level `ImportError: libGL.so.1` from the installed `cv2` dependency, so the full unit run did not finish in this environment.
- `pre-commit` hooks were not executed because `pre-commit` is not available in the runtime used for validation.
- `git diff --check` reported no whitespace/format issues for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7577034158832497c67a05a94684f3)