### PR TITLE
Fix: initialize empty generation cache

### DIFF
--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -426,7 +426,7 @@ class MobilintGenerationMixin(ABC, GenerationMixin):
     # args contain only model_kwargs in transformers>=4.56.0
     def _get_cache(self, cache_implementation: str, batch_size: int, max_cache_len: int, *args) -> MobilintCache:
         configured_batch_size = max(1, getattr(self.config, "max_batch_size", 1))
-        if not hasattr(self, "_cache"):
+        if not isinstance(getattr(self, "_cache", None), MobilintCache):
             self._cache = MobilintCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
         elif getattr(self._cache, "batch_size", 1) != configured_batch_size:
             self._cache = MobilintCache(self.get_cache_mxq_model(), batch_size=configured_batch_size)
@@ -615,7 +615,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
 
     def _get_cache(self, cache_implementation: str, batch_size: int, max_cache_len: int, *args) -> MobilintEagle3Cache:
         del cache_implementation, batch_size, max_cache_len, args
-        if not hasattr(self, "_cache"):
+        if not isinstance(getattr(self, "_cache", None), MobilintEagle3Cache):
             base_mxq_model, draft_mxq_model = self.get_cache_mxq_models()
             self._cache = MobilintEagle3Cache(base_mxq_model, draft_mxq_model)
         else:

--- a/tests/transformers/test_generation_cache_initialization.py
+++ b/tests/transformers/test_generation_cache_initialization.py
@@ -1,0 +1,56 @@
+"""Regression tests for generation cache initialization."""
+
+from types import SimpleNamespace
+
+from mblt_model_zoo.hf_transformers.utils.cache_utils import MobilintCache, MobilintEagle3Cache
+from mblt_model_zoo.hf_transformers.utils.generation_utils import (
+    MobilintEagle3GenerationMixin,
+    MobilintGenerationMixin,
+)
+
+
+class _DummyGenerationModel(MobilintGenerationMixin):
+    """Minimal generation model with the upstream-style empty cache default."""
+
+    _cache = None
+
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(max_batch_size=1)
+        self.mxq_model = object()
+
+    def get_cache_mxq_model(self) -> object:
+        """Return a cache backend stub."""
+        return self.mxq_model
+
+
+class _DummyEagle3GenerationModel(MobilintEagle3GenerationMixin):
+    """Minimal EAGLE-3 model with the upstream-style empty cache default."""
+
+    _cache = None
+
+    def __init__(self) -> None:
+        self.mxq_models = (object(), object())
+
+    def get_cache_mxq_models(self) -> tuple[object, object]:
+        """Return base and draft cache backend stubs."""
+        return self.mxq_models
+
+
+def test_generation_cache_initializes_when_cache_attribute_is_none() -> None:
+    """Initialize rather than resetting a class-level empty cache."""
+    model = _DummyGenerationModel()
+
+    cache = model._get_cache("mobilint", batch_size=1, max_cache_len=1)
+
+    assert isinstance(cache, MobilintCache)
+    assert cache.mxq_model is model.mxq_model
+
+
+def test_eagle3_generation_cache_initializes_when_cache_attribute_is_none() -> None:
+    """Initialize the EAGLE-3 cache when its inherited default is empty."""
+    model = _DummyEagle3GenerationModel()
+
+    cache = model._get_cache("mobilint-eagle3", batch_size=1, max_cache_len=1)
+
+    assert isinstance(cache, MobilintEagle3Cache)
+    assert (cache.base_mxq_model, cache.draft_mxq_model) == model.mxq_models


### PR DESCRIPTION
### Motivation

- Prevent a regression that called `reset()` on a `None` `_cache` attribute and raised `AttributeError` during generation when a class-level `_cache = None` default existed.
- Restore the prior semantics where absent or incompatible caches are created instead of unconditionally calling `reset()`.

### Description

- Replace `hasattr(self, "_cache")` guards with type-safe checks using `isinstance(getattr(self, "_cache", None), MobilintCache)` in `MobilintGenerationMixin._get_cache` so only a valid `MobilintCache` is reused and otherwise a new cache is created (`mblt_model_zoo/hf_transformers/utils/generation_utils.py`).
- Apply the same defensive initialization to the EAGLE-3 path with `MobilintEagle3Cache` to avoid the same crash vector in `MobilintEagle3GenerationMixin._get_cache`.
- Add regression tests `tests/transformers/test_generation_cache_initialization.py` that simulate upstream-style ` _cache = None` defaults and assert the helper initializes the correct `MobilintCache` or `MobilintEagle3Cache` instances.

### Testing

- Ran `pytest -q tests/transformers/test_generation_cache_initialization.py` and observed `2 passed` for the new targeted tests.
- Ran static and formatting checks with `ruff check` and `ruff format --check` and a bytecode sanity check with `python -m compileall`, all of which passed for the touched files.
- `pre-commit` was not available in the execution environment, so `pre-commit run` was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7576e3994c83248b54602d509ea775)