### PR TITLE
feat(benchmark): unify --include-private flag across HF benchmarks

### DIFF
--- a/benchmark/transformers/README.md
+++ b/benchmark/transformers/README.md
@@ -426,6 +426,9 @@ python benchmark/transformers/benchmark_text_generation_models.py measure \
 `mobilint/Llama-3.2-1B-Instruct`). It benchmarks only that model when provided; when omitted, all
 listed text-generation models are benchmarked.
 
+Pass `--include-private` to add private `mobilint/*` text-generation releases to the default target
+list. Requires an authenticated Hugging Face session (`hf auth login`).
+
 Default output directory: `benchmark/transformers/results/text_generation/`.
 
 - `{model}[-{revision}]-{core_mode}.json`: Per-model detailed sweep payload.
@@ -559,6 +562,9 @@ python benchmark/transformers/benchmark_image_text_to_text_models.py sweep \
   --skip-existing
 ```
 
+Pass `--include-private` to add private `mobilint/*` image-text-to-text releases to the default
+target list. Requires an authenticated Hugging Face session (`hf auth login`).
+
 Default output directory: `benchmark/transformers/results/image_text_to_text/`.
 
 - `{model}[-{revision}]-{core_mode}.json`: Per-model full sweep payload.
@@ -672,8 +678,10 @@ python benchmark/transformers/search_npu_prefill_chunk_size.py \
 ```
 
 If `--mxq-dir` is omitted, the script searches public `mobilint/` text-generation models for `W4V8`
-and `W8` revisions. Default output directory: `benchmark/transformers/results/prefill_chunk_search/`.
-Use `--model` to limit the search to one or more model ids:
+and `W8` revisions. Pass `--include-private` to add private `mobilint/*` text-generation releases to
+the default target list. Requires an authenticated Hugging Face session (`hf auth login`). Default
+output directory: `benchmark/transformers/results/prefill_chunk_search/`. Use `--model` to limit the
+search to one or more model ids:
 
 ```bash
 python benchmark/transformers/search_npu_prefill_chunk_size.py \

--- a/benchmark/transformers/README.md
+++ b/benchmark/transformers/README.md
@@ -278,6 +278,8 @@ consumed before measurement. In other words, the loader fetches enough candidate
 - Original/native Qwen3-ASR runs selected via `--original-models` do not use Mobilint
   `--core-mode`. If you pass `--core-mode` explicitly in that mode, the script prints a notice and
   ignores the value.
+- Pass `--include-private` to add private `mobilint/*` ASR releases to the default target list.
+  Requires an authenticated Hugging Face session (`hf auth login`).
 - Per-target JSON files are written as `<target>_beams<beam>.json`, for example
   `openai__whisper-small_beamsdefault.json` or `openai__whisper-small_beams5.json`.
 - The same `--output-dir` can store multiple beam-search runs side by side.

--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -72,7 +72,9 @@ from benchmark.transformers.asr_qwen_utils import (  # noqa: F401
 from benchmark.transformers.asr_qwen_utils import is_qwen3_asr_model as _is_qwen3_asr_model
 from benchmark.transformers.asr_qwen_utils import move_native_qwen3_asr_to_device as _move_native_qwen3_asr_to_device
 from benchmark.transformers.asr_qwen_utils import quiet_apscheduler_info_logs as _quiet_apscheduler_info_logs
-from benchmark.transformers.asr_qwen_utils import resolve_native_qwen3_asr_language as _resolve_native_qwen3_asr_language
+from benchmark.transformers.asr_qwen_utils import (
+    resolve_native_qwen3_asr_language as _resolve_native_qwen3_asr_language,
+)
 from benchmark.transformers.asr_qwen_utils import (  # noqa: F401
     resolve_native_qwen3_asr_pad_token_id as _resolve_native_qwen3_asr_pad_token_id,
 )
@@ -86,6 +88,7 @@ from benchmark.transformers.benchmark_target_utils import (
 from benchmark.transformers.benchmark_target_utils import (
     iter_targets_from_mxq_dir as _iter_targets_from_mxq_dir_shared,
 )
+from benchmark.transformers.benchmark_target_utils import list_default_model_ids
 from benchmark.transformers.benchmark_target_utils import (
     resolve_model_id_from_mxq_name as _resolve_model_id_from_mxq_name_shared,
 )
@@ -94,10 +97,6 @@ from benchmark.transformers.benchmark_target_utils import (
 )
 from benchmark.transformers.benchmark_target_utils import revision_exists as _revision_exists_shared
 from benchmark.transformers.benchmark_target_utils import select_revision as _select_revision_shared
-from mblt_model_zoo.hf_transformers.utils import list_models
-from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
-    add_trace_energy_to_device_metric as _add_trace_energy_to_device_metric_common,
-)
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     CORE_MODE_CHOICES as _CORE_MODE_CHOICES_COMMON,
 )
@@ -106,6 +105,9 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     add_pipeline_device_args as _add_pipeline_device_args,
+)
+from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
+    add_trace_energy_to_device_metric as _add_trace_energy_to_device_metric_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     append_core_mode_suffix as _append_core_mode_suffix_common,
@@ -211,15 +213,11 @@ def _list_default_asr_models(*, include_private: bool = False) -> list[str]:
     Returns:
         A list of ASR model ids with pipeline-incompatible whisper.cpp entries filtered out.
     """
-    available = list_models(
-        tasks="automatic-speech-recognition",
+    available = list_default_model_ids(
+        "automatic-speech-recognition",
         include_private=include_private,
     )
-    return [
-        str(model_id)
-        for model_id in available.get("automatic-speech-recognition", [])
-        if not _is_excluded_asr_model_id(str(model_id))
-    ]
+    return [str(model_id) for model_id in available if not _is_excluded_asr_model_id(str(model_id))]
 
 
 def _is_excluded_asr_model_id(model_id: str) -> bool:
@@ -499,9 +497,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             f"--{prefix}-core-mode",
             choices=list(_CORE_MODE_CHOICES_COMMON),
             default=None,
-            help=(
-                f"encoder-decoder ASR only: {prefix} NPU core mode override (falls back to --core-mode)"
-            ),
+            help=(f"encoder-decoder ASR only: {prefix} NPU core mode override (falls back to --core-mode)"),
         )
     _add_device_tracking_args(parser)
     args = parser.parse_args(argv)
@@ -1017,10 +1013,7 @@ def _build_run_targets(args: argparse.Namespace) -> list[tuple[ASRBenchmarkTarge
         if not mxq_dir.is_dir():
             raise SystemExit(f"--mxq-dir is not a directory: {mxq_dir}")
         if args.models or args.original_models or args.all or args.revision or args.mxq_path:
-            print(
-                "Note: --mxq-dir is set, so --model/--original-models/"
-                "--all/--revision/--mxq-path are ignored."
-            )
+            print("Note: --mxq-dir is set, so --model/--original-models/--all/--revision/--mxq-path are ignored.")
         targets = _iter_asr_targets_from_mxq_dir(mxq_dir, available_model_ids)
         if not targets:
             raise SystemExit("No valid mxq targets found. Expected files named <model_id>-<W8|W4V8>.mxq in --mxq-dir.")

--- a/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
+++ b/benchmark/transformers/benchmark_automatic_speech_recognition_models.py
@@ -201,8 +201,20 @@ def _select_revision(model_id: str, candidates: list[str | None]) -> str | None:
     return _select_revision_shared(model_id, candidates)
 
 
-def _list_default_asr_models() -> list[str]:
-    available = list_models(tasks="automatic-speech-recognition")
+def _list_default_asr_models(*, include_private: bool = False) -> list[str]:
+    """Return the default ASR benchmark target ids, optionally including private mobilint releases.
+
+    Args:
+        include_private: When True, include private mobilint/* models. Requires an authenticated
+            Hugging Face session (`hf auth login`).
+
+    Returns:
+        A list of ASR model ids with pipeline-incompatible whisper.cpp entries filtered out.
+    """
+    available = list_models(
+        tasks="automatic-speech-recognition",
+        include_private=include_private,
+    )
     return [
         str(model_id)
         for model_id in available.get("automatic-speech-recognition", [])
@@ -380,6 +392,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     _add_pipeline_device_args(parser, device_default=None, trust_remote_code_default=True)
     parser.add_argument("--model", dest="models", nargs="+", default=None, help="model id list to benchmark")
+    parser.add_argument(
+        "--include-private",
+        action="store_true",
+        help=(
+            "Include private mobilint/* models in the default target list. "
+            "Requires an authenticated Hugging Face session (hf auth login)."
+        ),
+    )
     parser.add_argument("--revision", default=None, help="model revision (e.g. W8)")
     parser.add_argument("--all", action="store_true", help="benchmark W8 and W4V8 revisions only")
     parser.add_argument("--mxq-dir", default=None, help="directory containing local mxq files")
@@ -990,8 +1010,9 @@ def _resolve_output_dir(args: argparse.Namespace) -> Path:
 
 def _build_run_targets(args: argparse.Namespace) -> list[tuple[ASRBenchmarkTarget, str | None, str, str]]:
     targets: list[ASRBenchmarkTarget]
+    include_private = bool(getattr(args, "include_private", False))
     if args.mxq_dir:
-        available_model_ids = _list_default_asr_models()
+        available_model_ids = _list_default_asr_models(include_private=include_private)
         mxq_dir = Path(args.mxq_dir).expanduser().resolve()
         if not mxq_dir.is_dir():
             raise SystemExit(f"--mxq-dir is not a directory: {mxq_dir}")
@@ -1004,7 +1025,11 @@ def _build_run_targets(args: argparse.Namespace) -> list[tuple[ASRBenchmarkTarge
         if not targets:
             raise SystemExit("No valid mxq targets found. Expected files named <model_id>-<W8|W4V8>.mxq in --mxq-dir.")
     else:
-        model_ids = [str(item) for item in args.models] if args.models else _list_default_asr_models()
+        model_ids = (
+            [str(item) for item in args.models]
+            if args.models
+            else _list_default_asr_models(include_private=include_private)
+        )
         if args.original_models:
             original_count = len(model_ids)
             model_ids = _resolve_original_model_ids(model_ids)

--- a/benchmark/transformers/benchmark_image_text_to_text_models.py
+++ b/benchmark/transformers/benchmark_image_text_to_text_models.py
@@ -45,11 +45,11 @@ from benchmark.transformers.benchmark_target_utils import (
     args_for_target_device_backend as _args_for_target_device_backend_shared,
 )
 from benchmark.transformers.benchmark_target_utils import iter_revision_targets as _iter_revision_targets_shared
+from benchmark.transformers.benchmark_target_utils import list_default_model_ids
 from benchmark.transformers.benchmark_target_utils import (
     resolve_original_model_ids as _resolve_original_model_ids_shared,
 )
 from benchmark.transformers.benchmark_target_utils import revision_exists as _revision_exists_shared
-from mblt_model_zoo.hf_transformers.utils import list_models
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     CORE_MODE_CHOICES as _CORE_MODE_CHOICES_COMMON,
 )
@@ -61,9 +61,6 @@ from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     append_core_mode_suffix as _append_core_mode_suffix_common,
-)
-from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
-    apply_core_mode_model_kwargs as _apply_core_mode_model_kwargs_common,
 )
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     apply_subconfig_core_mode_model_kwargs as _apply_subconfig_core_mode_model_kwargs_common,
@@ -202,7 +199,6 @@ def _vlm_llm_run_payload(run: Any) -> dict[str, Any]:
     payload["llm_prefill_energy_j"] = getattr(run, "llm_prefill_energy_j", getattr(run, "prefill_energy_j", None))
     payload["llm_decode_energy_j"] = getattr(run, "llm_decode_energy_j", getattr(run, "decode_energy_j", None))
     return payload
-
 
 
 def _percentile(values: list[float], q: float) -> float:
@@ -826,9 +822,7 @@ def _run_model(
                         _safe_div(decode_energy, float(decode_tokens)) if decode_tokens > 0 else None
                     )
                     run.total_tps_per_w = _safe_div(float(total_tokens), total_energy)
-                    run.total_j_per_token = (
-                        _safe_div(total_energy, float(total_tokens)) if total_tokens > 0 else None
-                    )
+                    run.total_j_per_token = _safe_div(total_energy, float(total_tokens)) if total_tokens > 0 else None
             llm_runs.append(run)
     finally:
         stop_qbruntime_trace(trace_handle)
@@ -1411,6 +1405,14 @@ def _add_common_benchmark_args(parser: argparse.ArgumentParser) -> None:
         help="resolve each Mobilint model to parent/base model id from HF Hub",
     )
     parser.add_argument(
+        "--include-private",
+        action="store_true",
+        help=(
+            "Include private mobilint/* models in the default target list. "
+            "Requires an authenticated Hugging Face session (hf auth login)."
+        ),
+    )
+    parser.add_argument(
         "--cuda-precheck",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -1581,11 +1583,11 @@ def _run_sweep(args: argparse.Namespace) -> int:
     os.environ.setdefault("MPLBACKEND", "Agg")
     disable_npu_specific_args = bool(args.original_models and not args.mxq_dir)
     if disable_npu_specific_args:
-        print("Note: --original-models is enabled; skipping NPU-specific parameters (core_mode/npu_prefill_chunk_size).")
+        print(
+            "Note: --original-models is enabled; skipping NPU-specific parameters (core_mode/npu_prefill_chunk_size)."
+        )
     script_dir = Path(__file__).resolve().parent
-    output_dir = (
-        Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "image_text_to_text"
-    )
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "image_text_to_text"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.rebuild_charts:
@@ -1594,7 +1596,10 @@ def _run_sweep(args: argparse.Namespace) -> int:
 
     _collect_host_pc_info(output_dir)
 
-    available_model_ids = list_models(tasks="image-text-to-text").get("image-text-to-text", [])
+    available_model_ids = list_default_model_ids(
+        "image-text-to-text",
+        include_private=bool(getattr(args, "include_private", False)),
+    )
     if not available_model_ids:
         print("No image-text-to-text models found.")
         return 0
@@ -1762,13 +1767,14 @@ def _collect_vlm_run_targets(
 ) -> tuple[Path, bool, list[tuple[str, str | None, str, str, str | None, str | None, int, str]]]:
     """Resolve image-text-to-text benchmark targets and core-mode expansion."""
     script_dir = Path(__file__).resolve().parent
-    output_dir = (
-        Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "image_text_to_text"
-    )
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "image_text_to_text"
     output_dir.mkdir(parents=True, exist_ok=True)
     available_model_ids: list[str] | None = None
     if args.mxq_dir or not args.models:
-        available_model_ids = list_models(tasks="image-text-to-text").get("image-text-to-text", [])
+        available_model_ids = list_default_model_ids(
+            "image-text-to-text",
+            include_private=bool(getattr(args, "include_private", False)),
+        )
         if not available_model_ids:
             print("No image-text-to-text models found.")
             return output_dir, False, []
@@ -2053,9 +2059,7 @@ def _rebuild_measure_outputs(output_dir: Path) -> None:
 def _resolve_vlm_output_dir(args: argparse.Namespace) -> Path:
     """Resolve and create the image-text-to-text benchmark output directory."""
     script_dir = Path(__file__).resolve().parent
-    output_dir = (
-        Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "image_text_to_text"
-    )
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "image_text_to_text"
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 

--- a/benchmark/transformers/benchmark_target_utils.py
+++ b/benchmark/transformers/benchmark_target_utils.py
@@ -21,6 +21,25 @@ from huggingface_hub.errors import (
 )
 
 
+def list_default_model_ids(task: str, *, include_private: bool = False) -> list[str]:
+    """Return default Mobilint HF model ids for a benchmark task.
+
+    Wraps :func:`mblt_model_zoo.hf_transformers.utils.list_models` so every
+    benchmark script forwards a consistent ``include_private`` flag.
+
+    Args:
+        task: Hugging Face pipeline task tag (for example ``"text-generation"``).
+        include_private: When True, include private ``mobilint/*`` releases. Requires an
+            authenticated Hugging Face session (``hf auth login``).
+
+    Returns:
+        A list of Mobilint HF model ids for the task, empty when none are available.
+    """
+    from mblt_model_zoo.hf_transformers.utils import list_models
+
+    return list_models(tasks=task, include_private=include_private).get(task, [])
+
+
 def normalize_repo_id(value: str) -> str:
     """Normalize a Hugging Face repository identifier or URL.
 
@@ -280,8 +299,7 @@ def iter_targets_from_mxq_dir(
         resolved_model_id = resolve_model_id_from_mxq_name(model_part, available_model_ids)
         if not resolved_model_id:
             print(
-                f"Skipping mxq (cannot resolve model_id from filename): {path.name} "
-                "(expected <model_id>-<W8|W4V8>.mxq)"
+                f"Skipping mxq (cannot resolve model_id from filename): {path.name} (expected <model_id>-<W8|W4V8>.mxq)"
             )
             continue
         label = f"{resolved_model_id}-{revision}"

--- a/benchmark/transformers/benchmark_text_generation_models.py
+++ b/benchmark/transformers/benchmark_text_generation_models.py
@@ -43,6 +43,7 @@ from benchmark.transformers.benchmark_target_utils import iter_revision_targets 
 from benchmark.transformers.benchmark_target_utils import (
     iter_targets_from_mxq_dir as _iter_targets_from_mxq_dir_shared,
 )
+from benchmark.transformers.benchmark_target_utils import list_default_model_ids
 from benchmark.transformers.benchmark_target_utils import (
     resolve_model_id_from_mxq_name as _resolve_model_id_from_mxq_name_shared,
 )
@@ -51,7 +52,6 @@ from benchmark.transformers.benchmark_target_utils import (
 )
 from benchmark.transformers.benchmark_target_utils import revision_exists as _revision_exists_shared
 from benchmark.transformers.benchmark_target_utils import select_revision as _select_revision_shared
-from mblt_model_zoo.hf_transformers.utils import list_models
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     CORE_MODE_CHOICES as _CORE_MODE_CHOICES_COMMON,
 )
@@ -968,6 +968,14 @@ def _add_common_benchmark_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="resolve each Mobilint model to its parent/base model from HF Hub and benchmark unique parent ids",
     )
+    parser.add_argument(
+        "--include-private",
+        action="store_true",
+        help=(
+            "Include private mobilint/* models in the default target list. "
+            "Requires an authenticated Hugging Face session (hf auth login)."
+        ),
+    )
     _add_device_tracking_args(parser)
     parser.add_argument(
         "--cuda-precheck",
@@ -1197,12 +1205,16 @@ def _run_sweep(args: argparse.Namespace) -> int:
 
     disable_npu_specific_args = bool(args.original_models and not args.mxq_dir)
     if disable_npu_specific_args:
-        print("Note: --original-models is enabled; skipping NPU-specific parameters (core_mode/npu_prefill_chunk_size).")
+        print(
+            "Note: --original-models is enabled; skipping NPU-specific parameters (core_mode/npu_prefill_chunk_size)."
+        )
 
     available_model_ids: list[str] | None = None
     if args.mxq_dir or not args.models:
-        available = list_models(tasks="text-generation")
-        available_model_ids = available.get("text-generation", [])
+        available_model_ids = list_default_model_ids(
+            "text-generation",
+            include_private=bool(getattr(args, "include_private", False)),
+        )
         if not available_model_ids:
             print("No text-generation models found.")
             return 0
@@ -1826,8 +1838,10 @@ def _collect_text_run_targets(
     args: argparse.Namespace,
 ) -> tuple[str, bool, list[tuple[str, list[str | None], str, str, str | None, str | None, int, str]]]:
     """Resolve text-generation benchmark targets and core-mode expansion."""
-    available = list_models(tasks="text-generation")
-    available_model_ids = available.get("text-generation", [])
+    available_model_ids = list_default_model_ids(
+        "text-generation",
+        include_private=bool(getattr(args, "include_private", False)),
+    )
     if not available_model_ids:
         print("No text-generation models found.")
         return "", False, []
@@ -1889,7 +1903,9 @@ def _run_measure(args: argparse.Namespace) -> int:
     if not run_targets:
         return 0
     if disable_npu_specific_args:
-        print("Note: --original-models is enabled; skipping NPU-specific parameters (core_mode/npu_prefill_chunk_size).")
+        print(
+            "Note: --original-models is enabled; skipping NPU-specific parameters (core_mode/npu_prefill_chunk_size)."
+        )
     _collect_host_pc_info(output_dir)
     for model_id, revision_candidates, label, base, mxq_path, core_mode, batch_size, batch_mode in tqdm(
         run_targets, desc="Measuring models", total=len(run_targets), unit="model-mode"

--- a/benchmark/transformers/search_npu_prefill_chunk_size.py
+++ b/benchmark/transformers/search_npu_prefill_chunk_size.py
@@ -32,7 +32,7 @@ from benchmark.common.io_utils import write_json as _write_json
 from benchmark.common.runtime_utils import clear_cuda_memory as _clear_cuda_memory
 from benchmark.common.runtime_utils import is_cuda_device as _is_cuda_device
 from benchmark.common.runtime_utils import release_pipeline as _release_pipeline
-from mblt_model_zoo.hf_transformers.utils import list_models
+from benchmark.transformers.benchmark_target_utils import list_default_model_ids
 from mblt_model_zoo.hf_transformers.utils.benchmark_cli_common import (
     CORE_MODE_SWEEP_VALUES as _CORE_MODE_SWEEP_VALUES_COMMON,
 )
@@ -725,6 +725,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="output directory (default: benchmark/transformers/results/prefill_chunk_search)",
     )
+    parser.add_argument(
+        "--include-private",
+        action="store_true",
+        help=(
+            "Include private mobilint/* models in the default target list. "
+            "Requires an authenticated Hugging Face session (hf auth login)."
+        ),
+    )
     return parser
 
 
@@ -736,9 +744,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     script_dir = Path(__file__).resolve().parent
-    output_dir = (
-        Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "prefill_chunk_search"
-    )
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else script_dir / "results" / "prefill_chunk_search"
     records_dir = output_dir / "records"
     records_dir.mkdir(parents=True, exist_ok=True)
 
@@ -760,7 +766,10 @@ def main(argv: list[str] | None = None) -> int:
     else:
         mxq_dir = None
 
-    available = list_models(tasks="text-generation").get("text-generation", [])
+    available = list_default_model_ids(
+        "text-generation",
+        include_private=bool(getattr(args, "include_private", False)),
+    )
     if not available:
         print("No text-generation models found.")
         return 0
@@ -770,10 +779,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.models:
         unknown_model_ids = sorted(set(selected_model_ids).difference(available_model_ids))
         if unknown_model_ids:
-            print(
-                "[warn] --model target(s) not found in text-generation model list: "
-                + ", ".join(unknown_model_ids)
-            )
+            print("[warn] --model target(s) not found in text-generation model list: " + ", ".join(unknown_model_ids))
 
     skipped_mxq_files: list[dict[str, str]] = []
     skipped_model_revisions: list[dict[str, Any]] = []
@@ -963,4 +969,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
+++ b/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
@@ -448,7 +448,7 @@ def test_default_asr_model_filter_excludes_whisper_cpp(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         asr_bench,
         "list_models",
-        lambda tasks=None: {
+        lambda tasks=None, include_private=False: {
             "automatic-speech-recognition": [
                 "mobilint/whisper-small",
                 "mobilint/whisper.cpp",
@@ -461,6 +461,30 @@ def test_default_asr_model_filter_excludes_whisper_cpp(monkeypatch: pytest.Monke
         "mobilint/whisper-small",
         "mobilint/Qwen3-ASR-1.7B",
     ]
+
+
+def test_include_private_flag_defaults_false_and_forwards_to_list_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify --include-private threads through to list_models; default remains public-only."""
+
+    observed: list[bool] = []
+
+    def fake_list_models(tasks=None, include_private=False):  # type: ignore[no-untyped-def]
+        observed.append(bool(include_private))
+        return {"automatic-speech-recognition": ["mobilint/whisper-small"]}
+
+    monkeypatch.setattr(asr_bench, "list_models", fake_list_models)
+
+    default_args = asr_bench._parse_args([])
+    assert default_args.include_private is False
+    asr_bench._build_run_targets(default_args)
+
+    private_args = asr_bench._parse_args(["--include-private"])
+    assert private_args.include_private is True
+    asr_bench._build_run_targets(private_args)
+
+    assert observed == [False, True]
 
 
 def test_qwen3_asr_uses_encoder_decoder_core_mode_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2306,7 +2330,11 @@ def test_build_run_targets_warns_when_core_mode_is_explicit_for_original_models(
 ) -> None:
     """Verify native original-model runs explicitly warn that core mode is ignored."""
 
-    monkeypatch.setattr(asr_bench, "_list_default_asr_models", lambda: ["Qwen/Qwen3-ASR-1.7B"])
+    monkeypatch.setattr(
+        asr_bench,
+        "_list_default_asr_models",
+        lambda include_private=False: ["Qwen/Qwen3-ASR-1.7B"],
+    )
     args = asr_bench._parse_args(["--original-models", "--core-mode", "all"])
     args._core_mode_explicit = True
 

--- a/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
+++ b/tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py
@@ -447,14 +447,12 @@ def test_default_asr_model_filter_excludes_whisper_cpp(monkeypatch: pytest.Monke
 
     monkeypatch.setattr(
         asr_bench,
-        "list_models",
-        lambda tasks=None, include_private=False: {
-            "automatic-speech-recognition": [
-                "mobilint/whisper-small",
-                "mobilint/whisper.cpp",
-                "mobilint/Qwen3-ASR-1.7B",
-            ]
-        },
+        "list_default_model_ids",
+        lambda task, *, include_private=False: [
+            "mobilint/whisper-small",
+            "mobilint/whisper.cpp",
+            "mobilint/Qwen3-ASR-1.7B",
+        ],
     )
 
     assert asr_bench._list_default_asr_models() == [
@@ -470,11 +468,11 @@ def test_include_private_flag_defaults_false_and_forwards_to_list_models(
 
     observed: list[bool] = []
 
-    def fake_list_models(tasks=None, include_private=False):  # type: ignore[no-untyped-def]
+    def fake_list_default_model_ids(task, *, include_private=False):  # type: ignore[no-untyped-def]
         observed.append(bool(include_private))
-        return {"automatic-speech-recognition": ["mobilint/whisper-small"]}
+        return ["mobilint/whisper-small"]
 
-    monkeypatch.setattr(asr_bench, "list_models", fake_list_models)
+    monkeypatch.setattr(asr_bench, "list_default_model_ids", fake_list_default_model_ids)
 
     default_args = asr_bench._parse_args([])
     assert default_args.include_private is False

--- a/tests/transformers/test_benchmark_transformers_cli.py
+++ b/tests/transformers/test_benchmark_transformers_cli.py
@@ -342,7 +342,11 @@ def test_vlm_target_filtering_uses_image_text_task(monkeypatch, tmp_path) -> Non
         ]
     )
 
-    monkeypatch.setattr(vlm_bench, "list_models", lambda tasks: {"image-text-to-text": ["mobilint/vlm-a"]})
+    monkeypatch.setattr(
+        vlm_bench,
+        "list_default_model_ids",
+        lambda task, *, include_private=False: ["mobilint/vlm-a"],
+    )
 
     def _fake_filter(raw_targets, *, batch_mode: str, task: str):
         assert batch_mode == "batch"
@@ -673,9 +677,7 @@ def test_vlm_benchmark_sweep_populates_llm_tps_per_w(monkeypatch) -> None:
     assert [row["prefill_tps_per_w"] for row in llm_rows] == [pytest.approx(llm_run["prefill_tps_per_w"])] * len(
         llm_rows
     )
-    assert [row["decode_tps_per_w"] for row in llm_rows] == [pytest.approx(llm_run["decode_tps_per_w"])] * len(
-        llm_rows
-    )
+    assert [row["decode_tps_per_w"] for row in llm_rows] == [pytest.approx(llm_run["decode_tps_per_w"])] * len(llm_rows)
 
 
 def test_tps_cli_vlm_sweep_writes_phase_tps_per_w(monkeypatch, tmp_path) -> None:
@@ -1094,3 +1096,50 @@ def test_vlm_aggregate_llm_runs_tolerates_missing_latency_arrays() -> None:
     assert result.decode_sweep.tps_values == [30.0]
     assert result.prefill_sweep.avg_total_token_latency_values == [None]
     assert len(rows) == 2
+
+
+def test_text_benchmark_include_private_flag_defaults_false_and_forwards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify --include-private threads through text-generation default target resolution."""
+    observed: list[bool] = []
+
+    def fake_list_default_model_ids(task, *, include_private=False):  # type: ignore[no-untyped-def]
+        observed.append(bool(include_private))
+        return ["mobilint/text-a"]
+
+    monkeypatch.setattr(text_bench, "list_default_model_ids", fake_list_default_model_ids)
+
+    default_args = text_bench._build_arg_parser().parse_args(["measure"])
+    assert default_args.include_private is False
+    text_bench._collect_text_run_targets(default_args)
+
+    private_args = text_bench._build_arg_parser().parse_args(["measure", "--include-private"])
+    assert private_args.include_private is True
+    text_bench._collect_text_run_targets(private_args)
+
+    assert observed == [False, True]
+
+
+def test_vlm_benchmark_include_private_flag_defaults_false_and_forwards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify --include-private threads through image-text-to-text default target resolution."""
+    observed: list[bool] = []
+
+    def fake_list_default_model_ids(task, *, include_private=False):  # type: ignore[no-untyped-def]
+        observed.append(bool(include_private))
+        return ["mobilint/vlm-a"]
+
+    monkeypatch.setattr(vlm_bench, "list_default_model_ids", fake_list_default_model_ids)
+    monkeypatch.setattr(vlm_bench, "_filter_text_targets_by_batch_mode", lambda targets, **_: [])
+
+    default_args = vlm_bench._build_arg_parser().parse_args(["measure"])
+    assert default_args.include_private is False
+    vlm_bench._collect_vlm_run_targets(default_args)
+
+    private_args = vlm_bench._build_arg_parser().parse_args(["measure", "--include-private"])
+    assert private_args.include_private is True
+    vlm_bench._collect_vlm_run_targets(private_args)
+
+    assert observed == [False, True]

--- a/tests/transformers/test_search_npu_prefill_chunk_size_cli.py
+++ b/tests/transformers/test_search_npu_prefill_chunk_size_cli.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+_TRANSFORMERS_BENCHMARK_DIR = Path(__file__).resolve().parents[2] / "benchmark" / "transformers"
+if str(_TRANSFORMERS_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_TRANSFORMERS_BENCHMARK_DIR))
+
+from benchmark.transformers import search_npu_prefill_chunk_size as chunk_search  # noqa: E402
+
+
+def test_include_private_flag_defaults_false_and_forwards_to_list_default_model_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify --include-private threads through the shared default model listing helper."""
+    observed: list[bool] = []
+
+    class _StopAfterListing(SystemExit):
+        pass
+
+    def fake_list_default_model_ids(task, *, include_private=False):  # type: ignore[no-untyped-def]
+        observed.append(bool(include_private))
+        raise _StopAfterListing("stop after include_private forwarding")
+
+    monkeypatch.setattr(chunk_search, "list_default_model_ids", fake_list_default_model_ids)
+
+    default_args = chunk_search.build_arg_parser().parse_args(["--output-dir", str(tmp_path)])
+    assert default_args.include_private is False
+    private_args = chunk_search.build_arg_parser().parse_args(["--include-private", "--output-dir", str(tmp_path)])
+    assert private_args.include_private is True
+
+    for cli_args in (
+        ["--output-dir", str(tmp_path)],
+        ["--include-private", "--output-dir", str(tmp_path)],
+    ):
+        with pytest.raises(_StopAfterListing):
+            chunk_search.main(cli_args)
+
+    assert observed == [False, True]


### PR DESCRIPTION
## 요약
- HF Hub를 조회하는 네 개의 Transformers 벤치마크 진입점(`benchmark_automatic_speech_recognition_models.py`, `benchmark_text_generation_models.py`, `benchmark_image_text_to_text_models.py`, `search_npu_prefill_chunk_size.py`)에 `--include-private` CLI 플래그를 추가해, `hf auth login`으로 인증된 세션에서 비공개 `mobilint/*` 릴리즈까지 기본 타깃 목록에 포함할 수 있게 했습니다. 기본 동작(공개 릴리즈만)은 그대로입니다.
- `benchmark/transformers/benchmark_target_utils.py`에 공용 헬퍼 `list_default_model_ids(task, *, include_private=False)`를 추가하고, 네 스크립트가 모두 이 헬퍼를 타도록 마이그레이션했습니다. 인라인 `list_models(...)` 호출로 갈라져 있던 코드가 사라졌습니다. ASR의 `_list_default_asr_models`는 헬퍼 반환값 뒤에 `whisper.cpp` 제외 로직을 그대로 적용합니다.
- 라이브러리 쪽 `mblt_model_zoo/hf_transformers/utils/api.py::list_models` 시그니처와 기본값은 건드리지 않았습니다. `mblt_model_zoo/vision/_api.py::list_models`(로컬 레지스트리 스캔, 무관 함수)도 그대로입니다.

## 테스트 플랜
- [x] `pytest tests/transformers/automatic_speech_recognition/test_benchmark_asr_cli.py tests/transformers/test_benchmark_transformers_cli.py tests/transformers/test_search_npu_prefill_chunk_size_cli.py -x`
- [x] 네 스크립트의 `-h` 출력에서 `--include-private`이 동일한 help 문구로 나오는지 확인.
- [x] `hf auth login` 상태에서 `--include-private`을 켜면 비공개 mobilint 릴리즈(예: `mobilint/whisper-tiny`, `mobilint/Qwen3-ASR-0.6B`, `mobilint/kanana-nano-2.1b-instruct`)가 기본 ASR / text-generation 타깃 목록에 잡히는지 확인. 플래그 없이 실행하면 그대로 필터링되어야 함.
- [x] `--include-private` 없이 실행했을 때 각 스크립트의 기본 타깃 개수가 `master`와 동일한지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)