### PR TITLE
feat(hf-transformers): forward regulus-rb-usb target device end-to-end

### DIFF
--- a/.agents/skills/mblt-model-zoo/SKILL.md
+++ b/.agents/skills/mblt-model-zoo/SKILL.md
@@ -19,7 +19,12 @@ description: >-
    `compile` handlers must delegate to `mblt_vision.cli`.
 4. Preserve Model Zoo CLI help and README examples when its CLI integration changes. Pass
    board-specific `target_device` through to the standalone packages; do not reintroduce legacy
-   product/artifact selection in Model Zoo.
+   product/artifact selection in Model Zoo. Supported boards are `aries-rb`, `regulus-ra`,
+   `regulus-rb`, `regulus-ra-usb`, and `regulus-rb-usb`; the shared runtime floor is
+   `mblt-npu-python>=0.1.0` / `mobilint-qb-runtime>=1.4.0`. Route every `*target_device` setter
+   (top-level, `encoder_`, `decoder_`, `base_`, `draft_`, `fc_`, and the Qwen3-ASR facade)
+   through `_rebuild_backend_for_target_device` so cross-board overrides switch the destination
+   backend class atomically.
 5. Keep TPS output driven by `mblt_model_zoo/cli/tps_table.py`. Preserve local conventions in
    `hf_transformers` and `MeloTTS`.
 6. Start with focused tests. Report unavailable hardware, downloads, and optional extras instead of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ Before editing, run `git status --short` and preserve unrelated work.
 - Pass board selection through to the standalone Vision/NPU packages with normalized
   `target_device` values. Do not restore legacy Vision artifact lookup or product-specific backend
   code in Model Zoo.
+- Supported target-device identifiers are `aries-rb`, `regulus-ra`, `regulus-rb`,
+  `regulus-ra-usb`, and `regulus-rb-usb`; require `mblt-npu-python>=0.1.0` (which pulls
+  `mobilint-qb-runtime>=1.4.0`). Every board setter — the top-level `target_device` on
+  `MobilintConfigMixin` and its prefixed variants (`encoder_`, `decoder_`, `base_`, `draft_`,
+  `fc_` on the multi-backend mixins, plus the Qwen3-ASR facade) — must route through
+  `_rebuild_backend_for_target_device` so a cross-board `from_pretrained` kwarg actually
+  switches the destination class rather than leaving a stale board with an updated string.
 - Keep the Vision facade a thin, documented compatibility layer. Add no new Vision models,
   processing, datasets, evaluation, benchmarks, or compilation here. The only Vision tests kept
   here are generic, opt-in facade smoke tests under `tests/vision`; implementation-specific tests

--- a/mblt_model_zoo/hf_transformers/README.md
+++ b/mblt_model_zoo/hf_transformers/README.md
@@ -1,8 +1,7 @@
 # Pretrained Models with HuggingFace's Transformers
 
 **mblt-model-zoo** also provides generative AI models from HuggingFace's [Transformers](https://github.com/huggingface/transformers).
-Currently, these models are only available on Mobilint's [ARIES](https://www.mobilint.com/aries).
-Support for [REGULUS](https://www.mobilint.com/regulus) is planned and currently under development
+These models run on Mobilint's [ARIES](https://www.mobilint.com/aries) and [REGULUS](https://www.mobilint.com/regulus) NPU boards. Supported target-device identifiers are `aries-rb`, `regulus-ra`, `regulus-rb`, `regulus-ra-usb`, and `regulus-rb-usb`; a board is selected by the `target_device` value in the shipped `config.json` (see the [NPU settings](#npu-settings) section), and defaults to `aries-rb` when the config omits it. Each Mobilint model release on the Hub is compiled for a specific board — pick the repository whose name ends in the target-device suffix (for example `mobilint/Llama-3.2-1B-Instruct-regulus-rb-usb`) rather than overriding `target_device` on a repository compiled for a different board.
 
 Mobilint's Model Zoo provides a seamless experience for using `transformers` models with the same class/function interfaces. All of the auto classes in `transformers` can import our pre-quantized models (e.g., `mobilint/Llama-3.2-3B-Instruct`) and download the required files from HuggingFace hub. It also supports a locally downloaded model directory, just like the original `transformers`.
 
@@ -263,6 +262,12 @@ For `pipeline(...)`, pass them via `model_kwargs={...}`.
 
 These are custom keyword parameters for Mobilint NPU execution (the compiled model is stored in an `*.mxq` file).
 
+- `target_device` (`str`)
+
+  Selects the Mobilint NPU board that the runtime opens. Supported values are `aries-rb`, `regulus-ra`, `regulus-rb`, `regulus-ra-usb`, and `regulus-rb-usb`; the legacy identifiers `aries` and `regulus` remain accepted and are normalized to `aries-rb` and `regulus-ra`. When omitted, the value ships with the model's `config.json`; loaders default to `aries-rb` if the config does not declare one. The board choice also constrains `core_mode` / `target_cores` / `target_clusters` (see below): every Regulus variant exposes a single cluster with a single core (`d:0:0`), so only `single` and `auto` core modes are valid and multi-core / cluster options apply to `aries-rb` only.
+
+  Requires `mblt-npu-python>=0.1.0` (which pulls `mobilint-qb-runtime>=1.4.0`) for the USB variants and the board-aware runtime dispatch.
+
 - `mxq_path` (`str`)
 
   Overrides which `*.mxq` file to load.
@@ -285,19 +290,21 @@ These are custom keyword parameters for Mobilint NPU execution (the compiled mod
   - `global8`: global scheduling across all cores (requires all clusters)
 
   Note: the effective/valid core mode depends on how the `*.mxq` was compiled. Some compiled models can reuse the same `*.mxq` file across `single`, `global4`, and `global8`, while others may only support the default stored in the model config.
-  For general inference and benchmarks in this repository, the default runtime mode is `global8` unless you explicitly override it.
+  For general inference and benchmarks in this repository, the default runtime mode is `global8` unless you explicitly override it. Regulus variants (`regulus-ra`, `regulus-rb`, `regulus-ra-usb`, `regulus-rb-usb`) expose only one cluster and one core, so only `single` and `auto` are valid on those boards; `multi`, `global4`, and `global8` apply to `aries-rb` only.
 
 - `target_cores` (`list[str]`)
 
-  Used only when `core_mode="single"`. Each entry must be in the form `"cluster:core"`.
-  - `cluster`: `0` or `1`
-  - `core`: `0`, `1`, `2`, or `3`
+  Used only when `core_mode="single"`. Each entry must be in the form `"cluster:core"` on `aries-rb`, or `"0:0"` on every Regulus variant (single-core topology).
+  - `cluster`: `0` or `1` on `aries-rb`; `0` on Regulus
+  - `core`: `0`, `1`, `2`, or `3` on `aries-rb`; `0` on Regulus
 
-  Example: `target_cores=["0:0", "0:1"]`
+  Example (Aries): `target_cores=["0:0", "0:1"]`
+  Example (Regulus): `target_cores=["0:0"]`
 
 - `target_clusters` (`list[int]`)
 
-  Used when `core_mode` is `multi`, `global4`, or `global8`. Each entry is a cluster index (`0` or `1`).
+  Used when `core_mode` is `multi`, `global4`, or `global8`; therefore Aries-only.
+  Each entry is a cluster index (`0` or `1`).
   - For `global8`, all clusters must be included (e.g. `target_clusters=[0, 1]`).
 
   Example: `target_clusters=[0]`

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
@@ -20,6 +20,19 @@ with guard_qwen_asr_import():
     )
 
 
+# Fields consumed by ``MobilintNPUBackend.from_dict`` that ``MobilintConfigMixin``
+# does not expose as a forwarding property. Routing them through
+# ``setattr(sub_config, k, v)`` would leave them on ``config.__dict__`` and
+# never reach the backend, so both the constructor and ``from_dict`` override
+# have to write them straight onto ``sub_config.npu_backend``. The value maps
+# the caller-facing kwarg name to the backend's storage-name — ``commit_hash``
+# is exposed publicly but stored as ``_commit_hash`` on the backend.
+_QWEN3_ASR_BACKEND_DIRECT_FIELDS: dict[str, str] = {
+    "revision": "revision",
+    "commit_hash": "_commit_hash",
+}
+
+
 class MobilintQwen3ASRAudioEncoderConfig(MobilintConfigMixin, Qwen3ASRAudioEncoderConfig):
     model_type = "mobilint-qwen3_asr_audio_encoder"
 
@@ -126,25 +139,21 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
         # cross-board rebuild via ``_rebuild_backend_for_target_device``
         # (setting the string on the backend directly would leave an
         # Aries instance in place with a Regulus target_device string).
-        # Fields with no forwarding property (``revision``, ``commit_hash``)
-        # cannot round-trip through the config layer — a
-        # ``setattr(audio_config, "revision", ...)`` would land on
-        # ``config.__dict__`` and never reach ``npu_backend.revision``,
-        # so remote MXQ resolution would silently use the shipped
-        # revision. Route these two to the backend directly, mapping
-        # ``commit_hash`` to the backend's internal ``_commit_hash``
+        # Fields with no forwarding property
+        # (:data:`_QWEN3_ASR_BACKEND_DIRECT_FIELDS`) route straight to the
+        # nested backend, mapping ``commit_hash`` to its ``_commit_hash``
         # storage name.
-        _BACKEND_DIRECT_FIELDS: dict[str, str] = {
-            "revision": "revision",
-            "commit_hash": "_commit_hash",
-        }
         for sub_config, prefixed_kwargs in (
             (thinker_config.audio_config, encoder_kwargs),
             (thinker_config.text_config, decoder_kwargs),
         ):
             for k, v in prefixed_kwargs.items():
-                if k in _BACKEND_DIRECT_FIELDS:
-                    setattr(sub_config.npu_backend, _BACKEND_DIRECT_FIELDS[k], v)
+                if k in _QWEN3_ASR_BACKEND_DIRECT_FIELDS:
+                    setattr(
+                        sub_config.npu_backend,
+                        _QWEN3_ASR_BACKEND_DIRECT_FIELDS[k],
+                        v,
+                    )
                 else:
                     setattr(sub_config, k, v)
 
@@ -302,10 +311,30 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
         replay them via ``_apply_npu_backend_kwargs`` in the shared apply
         order — ``target_device`` first — so the whole override set lands
         on the destination board atomically.
+
+        Fields without a top-level forwarding property on this facade
+        (``revision``, ``commit_hash``) cannot ride the shared setattr
+        helper — ``setattr(config, "encoder_revision", v)`` would land on
+        ``config.__dict__`` and leave the nested backend's own
+        ``revision`` / ``_commit_hash`` untouched, so remote MXQ
+        resolution would silently keep the shipped revision. Route those
+        two directly to the nested backend the same way the constructor
+        does (with ``commit_hash`` mapped to the internal
+        ``_commit_hash`` storage name).
         """
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
         encoder_sub = _split_npu_backend_kwargs(kwargs, prefix="encoder_")
         decoder_sub = _split_npu_backend_kwargs(kwargs, prefix="decoder_")
+        encoder_direct = {
+            k: encoder_sub.pop(k)
+            for k in list(encoder_sub)
+            if k in _QWEN3_ASR_BACKEND_DIRECT_FIELDS
+        }
+        decoder_direct = {
+            k: decoder_sub.pop(k)
+            for k in list(decoder_sub)
+            if k in _QWEN3_ASR_BACKEND_DIRECT_FIELDS
+        }
 
         config, unused_kwargs = super().from_dict(
             config_dict, return_unused_kwargs=True, **kwargs
@@ -313,6 +342,18 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
 
         _apply_npu_backend_kwargs(config, encoder_sub, prefix="encoder_")
         _apply_npu_backend_kwargs(config, decoder_sub, prefix="decoder_")
+        for k, v in encoder_direct.items():
+            setattr(
+                config.thinker_config.audio_config.npu_backend,
+                _QWEN3_ASR_BACKEND_DIRECT_FIELDS[k],
+                v,
+            )
+        for k, v in decoder_direct.items():
+            setattr(
+                config.thinker_config.text_config.npu_backend,
+                _QWEN3_ASR_BACKEND_DIRECT_FIELDS[k],
+                v,
+            )
 
         if return_unused_kwargs:
             return config, unused_kwargs

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
@@ -5,6 +5,7 @@ from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
 
 from ...utils.configuration_utils import (
+    _NPU_BACKEND_DIRECT_FIELDS,
     MobilintConfigMixin,
     _apply_npu_backend_kwargs,
     _split_npu_backend_kwargs,
@@ -20,17 +21,6 @@ with guard_qwen_asr_import():
     )
 
 
-# Fields consumed by ``MobilintNPUBackend.from_dict`` that ``MobilintConfigMixin``
-# does not expose as a forwarding property. Routing them through
-# ``setattr(sub_config, k, v)`` would leave them on ``config.__dict__`` and
-# never reach the backend, so both the constructor and ``from_dict`` override
-# have to write them straight onto ``sub_config.npu_backend``. The value maps
-# the caller-facing kwarg name to the backend's storage-name — ``commit_hash``
-# is exposed publicly but stored as ``_commit_hash`` on the backend.
-_QWEN3_ASR_BACKEND_DIRECT_FIELDS: dict[str, str] = {
-    "revision": "revision",
-    "commit_hash": "_commit_hash",
-}
 
 
 class MobilintQwen3ASRAudioEncoderConfig(MobilintConfigMixin, Qwen3ASRAudioEncoderConfig):
@@ -140,7 +130,7 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
         # (setting the string on the backend directly would leave an
         # Aries instance in place with a Regulus target_device string).
         # Fields with no forwarding property
-        # (:data:`_QWEN3_ASR_BACKEND_DIRECT_FIELDS`) route straight to the
+        # (:data:`_NPU_BACKEND_DIRECT_FIELDS`) route straight to the
         # nested backend, mapping ``commit_hash`` to its ``_commit_hash``
         # storage name.
         for sub_config, prefixed_kwargs in (
@@ -148,10 +138,10 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
             (thinker_config.text_config, decoder_kwargs),
         ):
             for k, v in prefixed_kwargs.items():
-                if k in _QWEN3_ASR_BACKEND_DIRECT_FIELDS:
+                if k in _NPU_BACKEND_DIRECT_FIELDS:
                     setattr(
                         sub_config.npu_backend,
-                        _QWEN3_ASR_BACKEND_DIRECT_FIELDS[k],
+                        _NPU_BACKEND_DIRECT_FIELDS[k],
                         v,
                     )
                 else:
@@ -325,35 +315,23 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
         encoder_sub = _split_npu_backend_kwargs(kwargs, prefix="encoder_")
         decoder_sub = _split_npu_backend_kwargs(kwargs, prefix="decoder_")
-        encoder_direct = {
-            k: encoder_sub.pop(k)
-            for k in list(encoder_sub)
-            if k in _QWEN3_ASR_BACKEND_DIRECT_FIELDS
-        }
-        decoder_direct = {
-            k: decoder_sub.pop(k)
-            for k in list(decoder_sub)
-            if k in _QWEN3_ASR_BACKEND_DIRECT_FIELDS
-        }
 
         config, unused_kwargs = super().from_dict(
             config_dict, return_unused_kwargs=True, **kwargs
         )  # type: ignore[misc]
 
-        _apply_npu_backend_kwargs(config, encoder_sub, prefix="encoder_")
-        _apply_npu_backend_kwargs(config, decoder_sub, prefix="decoder_")
-        for k, v in encoder_direct.items():
-            setattr(
-                config.thinker_config.audio_config.npu_backend,
-                _QWEN3_ASR_BACKEND_DIRECT_FIELDS[k],
-                v,
-            )
-        for k, v in decoder_direct.items():
-            setattr(
-                config.thinker_config.text_config.npu_backend,
-                _QWEN3_ASR_BACKEND_DIRECT_FIELDS[k],
-                v,
-            )
+        _apply_npu_backend_kwargs(
+            config,
+            encoder_sub,
+            prefix="encoder_",
+            backend=config.thinker_config.audio_config.npu_backend,
+        )
+        _apply_npu_backend_kwargs(
+            config,
+            decoder_sub,
+            prefix="decoder_",
+            backend=config.thinker_config.text_config.npu_backend,
+        )
 
         if return_unused_kwargs:
             return config, unused_kwargs

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
@@ -1,9 +1,14 @@
 from functools import wraps
+from typing import Any
 
 from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
 
-from ...utils.configuration_utils import MobilintConfigMixin
+from ...utils.configuration_utils import (
+    MobilintConfigMixin,
+    _apply_npu_backend_kwargs,
+    _split_npu_backend_kwargs,
+)
 from ._errors import guard_qwen_asr_import
 
 with guard_qwen_asr_import():
@@ -264,6 +269,39 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
     @decoder_target_clusters.setter
     def decoder_target_clusters(self, values: list) -> None:
         self.thinker_config.text_config.npu_backend.target_clusters = values
+
+    @classmethod
+    def from_dict(cls, config_dict: dict, **kwargs: Any):
+        """Buffer ``encoder_*`` / ``decoder_*`` NPU kwargs across HF's ``from_dict``.
+
+        This facade does not inherit ``MobilintEncoderDecoderConfigMixin``, so
+        the shared buffered ``from_dict`` there does not apply here. Without
+        buffering, HF's upstream ``PretrainedConfig.from_dict`` probes every
+        override with ``hasattr`` before ``setattr``; the encoder / decoder
+        topology getters exposed on this facade route through the nested
+        ``npu_backend._spec`` finalize, so a caller override that combines
+        ``encoder_target_device`` with a board-specific mode
+        (e.g. ``encoder_core_mode="global8"`` on a Regulus baseline) raises
+        during the probe before the target-device rebuild has a chance to
+        run. Extract the NPU fields ahead of ``super().from_dict`` and
+        replay them via ``_apply_npu_backend_kwargs`` in the shared apply
+        order — ``target_device`` first — so the whole override set lands
+        on the destination board atomically.
+        """
+        return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+        encoder_sub = _split_npu_backend_kwargs(kwargs, prefix="encoder_")
+        decoder_sub = _split_npu_backend_kwargs(kwargs, prefix="decoder_")
+
+        config, unused_kwargs = super().from_dict(
+            config_dict, return_unused_kwargs=True, **kwargs
+        )  # type: ignore[misc]
+
+        _apply_npu_backend_kwargs(config, encoder_sub, prefix="encoder_")
+        _apply_npu_backend_kwargs(config, decoder_sub, prefix="decoder_")
+
+        if return_unused_kwargs:
+            return config, unused_kwargs
+        return config
 
 
 AutoConfig.register("mobilint-qwen3_asr", MobilintQwen3ASRConfig)

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
@@ -121,17 +121,32 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
         elif thinker_config is None:
             thinker_config = MobilintQwen3ASRThinkerConfig()
 
-        # Route through the sub-config's property setters (which delegate
-        # to the underlying npu_backend and, for ``target_device``, run
-        # the cross-board rebuild helper) rather than mutating the
-        # backend attribute directly, so a constructor-time
-        # ``encoder_target_device`` / ``decoder_target_device`` override
-        # actually switches the destination backend class instead of
-        # leaving an Aries instance with a Regulus string.
-        for k, v in encoder_kwargs.items():
-            setattr(thinker_config.audio_config, k, v)
-        for k, v in decoder_kwargs.items():
-            setattr(thinker_config.text_config, k, v)
+        # Fields with a config-level property setter on ``MobilintConfigMixin``
+        # go through the sub-config so ``target_device`` triggers the
+        # cross-board rebuild via ``_rebuild_backend_for_target_device``
+        # (setting the string on the backend directly would leave an
+        # Aries instance in place with a Regulus target_device string).
+        # Fields with no forwarding property (``revision``, ``commit_hash``)
+        # cannot round-trip through the config layer — a
+        # ``setattr(audio_config, "revision", ...)`` would land on
+        # ``config.__dict__`` and never reach ``npu_backend.revision``,
+        # so remote MXQ resolution would silently use the shipped
+        # revision. Route these two to the backend directly, mapping
+        # ``commit_hash`` to the backend's internal ``_commit_hash``
+        # storage name.
+        _BACKEND_DIRECT_FIELDS: dict[str, str] = {
+            "revision": "revision",
+            "commit_hash": "_commit_hash",
+        }
+        for sub_config, prefixed_kwargs in (
+            (thinker_config.audio_config, encoder_kwargs),
+            (thinker_config.text_config, decoder_kwargs),
+        ):
+            for k, v in prefixed_kwargs.items():
+                if k in _BACKEND_DIRECT_FIELDS:
+                    setattr(sub_config.npu_backend, _BACKEND_DIRECT_FIELDS[k], v)
+                else:
+                    setattr(sub_config, k, v)
 
         self.thinker_config = thinker_config
         self.support_languages = support_languages

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
@@ -116,10 +116,17 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
         elif thinker_config is None:
             thinker_config = MobilintQwen3ASRThinkerConfig()
 
+        # Route through the sub-config's property setters (which delegate
+        # to the underlying npu_backend and, for ``target_device``, run
+        # the cross-board rebuild helper) rather than mutating the
+        # backend attribute directly, so a constructor-time
+        # ``encoder_target_device`` / ``decoder_target_device`` override
+        # actually switches the destination backend class instead of
+        # leaving an Aries instance with a Regulus string.
         for k, v in encoder_kwargs.items():
-            setattr(thinker_config.audio_config.npu_backend, k, v)
+            setattr(thinker_config.audio_config, k, v)
         for k, v in decoder_kwargs.items():
-            setattr(thinker_config.text_config.npu_backend, k, v)
+            setattr(thinker_config.text_config, k, v)
 
         self.thinker_config = thinker_config
         self.support_languages = support_languages
@@ -145,6 +152,19 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
     @encoder_mxq_path.setter
     def encoder_mxq_path(self, value: str) -> None:
         self.thinker_config.audio_config.npu_backend.mxq_path = value
+
+    @property
+    def encoder_target_device(self) -> str:
+        """Board identifier used by the audio encoder NPU backend."""
+        return self.thinker_config.audio_config.npu_backend.target_device
+
+    @encoder_target_device.setter
+    def encoder_target_device(self, value: str) -> None:
+        # Route through the sub-config property setter so cross-board
+        # switches rebuild the backend via
+        # ``_rebuild_backend_for_target_device`` instead of leaving an
+        # Aries instance with a Regulus string.
+        self.thinker_config.audio_config.target_device = value
 
     @property
     def encoder_dev_no(self) -> int:
@@ -193,6 +213,17 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
     @decoder_mxq_path.setter
     def decoder_mxq_path(self, value: str) -> None:
         self.thinker_config.text_config.npu_backend.mxq_path = value
+
+    @property
+    def decoder_target_device(self) -> str:
+        """Board identifier used by the text decoder NPU backend."""
+        return self.thinker_config.text_config.npu_backend.target_device
+
+    @decoder_target_device.setter
+    def decoder_target_device(self, value: str) -> None:
+        # Route through the sub-config property setter (see the
+        # ``encoder_target_device`` counterpart).
+        self.thinker_config.text_config.target_device = value
 
     @property
     def decoder_dev_no(self) -> int:

--- a/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen3_asr/configuration_qwen3_asr.py
@@ -324,13 +324,13 @@ class MobilintQwen3ASRConfig(Qwen3ASRConfig):
             config,
             encoder_sub,
             prefix="encoder_",
-            backend=config.thinker_config.audio_config.npu_backend,
+            resolve_backend=lambda c: c.thinker_config.audio_config.npu_backend,
         )
         _apply_npu_backend_kwargs(
             config,
             decoder_sub,
             prefix="decoder_",
-            backend=config.thinker_config.text_config.npu_backend,
+            resolve_backend=lambda c: c.thinker_config.text_config.npu_backend,
         )
 
         if return_unused_kwargs:

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -68,6 +68,19 @@ def _normalize_npu_target_kwargs(kwargs: dict[str, Any], prefix: str = "") -> No
     NPUTargetSpec.from_kwargs(kwargs, prefix=prefix)
 
 
+# NPU fields that ``MobilintNPUBackend.from_dict`` consumes. Buffering them
+# through :func:`_pop_consumed_backend_kwargs` / :func:`_split_npu_backend_kwargs`
+# keeps HF's downstream setattr loop from re-firing every property setter
+# (which would pollute :class:`NPUTargetSpecPending` with baseline echoes)
+# and from probing topology getters against a stale pending (which would
+# finalize the source spec against overrides intended for a different
+# board — the hasattr hazard called out for
+# :class:`MobilintVisionTextConfigMixin`).
+#
+# ``npu_prefill_chunk_size`` is deliberately excluded: it is a config-only
+# attribute stored directly on ``self.__dict__`` and is not consumed by the
+# shared backend, so leaving HF to apply it via the normal setattr loop
+# preserves the caller's configured value.
 _NPU_BACKEND_KWARG_FIELDS: tuple[str, ...] = (
     "mxq_path",
     "target_device",
@@ -78,7 +91,26 @@ _NPU_BACKEND_KWARG_FIELDS: tuple[str, ...] = (
     "max_batch_size",
     "revision",
     "commit_hash",
-    "npu_prefill_chunk_size",
+)
+
+
+# Order in which :func:`_apply_npu_backend_kwargs` replays the buffered
+# NPU kwargs onto the config after :meth:`super().from_dict` returns.
+# ``target_device`` runs first so a cross-board override rebuilds the
+# backend before the topology / mode fields land on the (now-fresh)
+# destination. The remaining order is arbitrary — each subsequent
+# ``setattr`` accumulates on the fresh :class:`NPUTargetSpecPending` and
+# the canonical spec finalizes only on the next getter read.
+_NPU_APPLY_ORDER: tuple[str, ...] = (
+    "target_device",
+    "mxq_path",
+    "revision",
+    "commit_hash",
+    "max_batch_size",
+    "dev_no",
+    "core_mode",
+    "target_cores",
+    "target_clusters",
 )
 
 
@@ -102,6 +134,52 @@ def _pop_consumed_backend_kwargs(kwargs: dict[str, Any], prefix: str = "") -> No
     """
     for field in _NPU_BACKEND_KWARG_FIELDS:
         kwargs.pop(f"{prefix}{field}", None)
+
+
+def _split_npu_backend_kwargs(
+    kwargs: dict[str, Any], prefix: str = ""
+) -> dict[str, Any]:
+    """Pop the NPU-backend fields for ``prefix`` off ``kwargs``.
+
+    Callers use the returned unprefixed dict with
+    :func:`_apply_npu_backend_kwargs` after :meth:`super().from_dict` has
+    processed the remaining kwargs, so the buffered fields are never
+    exposed to HF's ``PretrainedConfig.from_dict`` kwargs loop. That loop
+    otherwise probes every override with ``hasattr`` before ``setattr``,
+    and the topology getters (``target_cores``, ``target_clusters``,
+    ``core_mode``, ``dev_no``) all trigger a spec finalize on the current
+    pending state. When a caller overrides ``target_device`` alongside
+    a topology field, the finalize fires against the source board's
+    topology before the target-device rebuild has a chance to run —
+    e.g. ``core_mode="global8"`` on a Regulus config raises during the
+    probe. Buffering routes the whole override set through
+    :meth:`_apply_npu_backend_kwargs` in a controlled order instead.
+    """
+    sub: dict[str, Any] = {}
+    for field in _NPU_BACKEND_KWARG_FIELDS:
+        key = f"{prefix}{field}"
+        if key in kwargs:
+            sub[field] = kwargs.pop(key)
+    return sub
+
+
+def _apply_npu_backend_kwargs(
+    config: PretrainedConfig, sub_kwargs: dict[str, Any], prefix: str = ""
+) -> None:
+    """Apply buffered NPU-backend fields to ``config`` in :data:`_NPU_APPLY_ORDER`.
+
+    Companion to :func:`_split_npu_backend_kwargs`. ``target_device`` is
+    applied first so a cross-board override rebuilds the backend before
+    subsequent topology / mode assignments land — the destination
+    board's fresh pending then absorbs the remaining fields without a
+    partial-state finalize against the source topology.
+    """
+    remaining = dict(sub_kwargs)
+    for field in _NPU_APPLY_ORDER:
+        if field in remaining:
+            setattr(config, f"{prefix}{field}", remaining.pop(field))
+    for field, value in remaining.items():
+        setattr(config, f"{prefix}{field}", value)
 
 
 def _serialized_target_cores(backend: MobilintNPUBackend) -> list[str]:
@@ -332,6 +410,38 @@ class MobilintConfigMixin(PretrainedConfig):
     def npu_prefill_chunk_size(self, value: Any) -> None:
         self.__dict__["npu_prefill_chunk_size"] = value
 
+    @classmethod
+    def from_dict(
+        cls: type[SpecificPretrainedConfigType], config_dict: dict[str, Any], **kwargs
+    ) -> Union["MobilintConfigMixin", tuple["MobilintConfigMixin", dict[str, Any]]]:
+        """Buffer NPU-backend kwargs across HF's ``from_dict`` kwargs loop.
+
+        HF ``PretrainedConfig.from_dict`` probes every override with
+        ``hasattr`` before ``setattr``. The topology getters
+        (``target_cores`` / ``target_clusters`` / ``core_mode`` /
+        ``dev_no``) all trigger a spec finalize on the current pending
+        state, so a caller override set that combines ``target_device``
+        with a board-specific mode (e.g. ``core_mode="global8"``) raises
+        during the probe against the source board's topology before the
+        target-device rebuild has a chance to run. Extract the NPU
+        fields ahead of time and apply them once ``super().from_dict``
+        has finished with the remaining kwargs; the shared apply order
+        (see :data:`_NPU_APPLY_ORDER`) runs ``target_device`` first, so
+        cross-board rebuilds land before topology / mode overrides.
+        """
+        return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+        npu_sub_kwargs = _split_npu_backend_kwargs(kwargs)
+
+        config, unused_kwargs = super().from_dict(
+            config_dict, return_unused_kwargs=True, **kwargs
+        )  # type: ignore[misc]
+
+        _apply_npu_backend_kwargs(config, npu_sub_kwargs)
+
+        if return_unused_kwargs:
+            return config, unused_kwargs
+        return config
+
     def _remove_keys_not_serialized(self, d: dict[str, Any]) -> None:
         if hasattr(self, "npu_backend"):
             _ = d.pop("npu_backend", None)
@@ -501,6 +611,34 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
     @decoder_target_clusters.setter
     def decoder_target_clusters(self, values: list) -> None:
         self.decoder_npu_backend.target_clusters = values
+
+    @classmethod
+    def from_dict(
+        cls: type[SpecificPretrainedConfigType], config_dict: dict[str, Any], **kwargs
+    ) -> Union[
+        "MobilintEncoderDecoderConfigMixin",
+        tuple["MobilintEncoderDecoderConfigMixin", dict[str, Any]],
+    ]:
+        """Buffer ``encoder_*`` / ``decoder_*`` NPU kwargs across HF's ``from_dict``.
+
+        Mirrors :meth:`MobilintConfigMixin.from_dict` for the two prefixed
+        sub-backends. See that override's docstring for the hasattr-probe
+        rationale.
+        """
+        return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+        encoder_sub = _split_npu_backend_kwargs(kwargs, prefix="encoder_")
+        decoder_sub = _split_npu_backend_kwargs(kwargs, prefix="decoder_")
+
+        config, unused_kwargs = super().from_dict(
+            config_dict, return_unused_kwargs=True, **kwargs
+        )  # type: ignore[misc]
+
+        _apply_npu_backend_kwargs(config, encoder_sub, prefix="encoder_")
+        _apply_npu_backend_kwargs(config, decoder_sub, prefix="decoder_")
+
+        if return_unused_kwargs:
+            return config, unused_kwargs
+        return config
 
     def _remove_keys_not_serialized(self, d: dict[str, Any]) -> None:
         if hasattr(self, "encoder_npu_backend"):
@@ -1043,6 +1181,36 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
     @fc_mxq_path.setter
     def fc_mxq_path(self, value: str) -> None:
         self.fc_npu_backend.mxq_path = value
+
+    @classmethod
+    def from_dict(
+        cls: type[SpecificPretrainedConfigType], config_dict: dict[str, Any], **kwargs
+    ) -> Union[
+        "MobilintEagle3ConfigMixin",
+        tuple["MobilintEagle3ConfigMixin", dict[str, Any]],
+    ]:
+        """Buffer ``base_*`` / ``draft_*`` / ``fc_*`` NPU kwargs across HF's ``from_dict``.
+
+        Mirrors :meth:`MobilintConfigMixin.from_dict` for Eagle3's three
+        prefixed sub-backends. See that override's docstring for the
+        hasattr-probe rationale.
+        """
+        return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+        base_sub = _split_npu_backend_kwargs(kwargs, prefix="base_")
+        draft_sub = _split_npu_backend_kwargs(kwargs, prefix="draft_")
+        fc_sub = _split_npu_backend_kwargs(kwargs, prefix="fc_")
+
+        config, unused_kwargs = super().from_dict(
+            config_dict, return_unused_kwargs=True, **kwargs
+        )  # type: ignore[misc]
+
+        _apply_npu_backend_kwargs(config, base_sub, prefix="base_")
+        _apply_npu_backend_kwargs(config, draft_sub, prefix="draft_")
+        _apply_npu_backend_kwargs(config, fc_sub, prefix="fc_")
+
+        if return_unused_kwargs:
+            return config, unused_kwargs
+        return config
 
     def _remove_keys_not_serialized(self, d: dict[str, Any]) -> None:
         _ = d.pop("base_npu_backend", None)

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -157,8 +157,8 @@ class MobilintConfigMixin(PretrainedConfig):
         # config-file value, so a plain string mutation here would leave
         # ``self.npu_backend`` on the wrong board's class (e.g. Aries when
         # the caller asked for ``regulus-rb-usb``). Rebuild the backend
-        # from its current serialized state whenever the requested board
-        # maps to a different subclass so the class matches the string.
+        # whenever the requested board maps to a different subclass so the
+        # class matches the string.
         from mblt_npu import MobilintNPUBackend, backend_class_for
 
         try:
@@ -171,7 +171,20 @@ class MobilintConfigMixin(PretrainedConfig):
         if type(self.npu_backend) is desired_cls:
             self.npu_backend.target_device = value
             return
+        # Cross-board rebuild: preserve board-agnostic runtime state
+        # (mxq_path, dev_no, revision, commit_hash, max_batch_size,
+        # name_or_path) but discard topology fields — the source board's
+        # target_cores / target_clusters / core_mode encode its own
+        # topology (e.g. Aries's 8-core grid or a multi-cluster mode)
+        # that the destination board's __init__ would reject. Dropping
+        # them lets the destination class's board-aware default sugar
+        # fill in a valid spec (e.g. Regulus's sole ``d:0:0`` core in
+        # ``single`` mode); subsequent HF kwargs (target_cores=...,
+        # core_mode=...) then override on the fresh backend via the
+        # per-field setters.
         state = self.npu_backend.to_dict()
+        for topology_key in ("target_cores", "target_clusters", "core_mode"):
+            state.pop(topology_key, None)
         state["target_device"] = value
         self.npu_backend = MobilintNPUBackend.from_dict(state)
 

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -68,6 +68,42 @@ def _normalize_npu_target_kwargs(kwargs: dict[str, Any], prefix: str = "") -> No
     NPUTargetSpec.from_kwargs(kwargs, prefix=prefix)
 
 
+_NPU_BACKEND_KWARG_FIELDS: tuple[str, ...] = (
+    "mxq_path",
+    "target_device",
+    "target_cores",
+    "target_clusters",
+    "core_mode",
+    "dev_no",
+    "max_batch_size",
+    "revision",
+    "commit_hash",
+    "npu_prefill_chunk_size",
+)
+
+
+def _pop_consumed_backend_kwargs(kwargs: dict[str, Any], prefix: str = "") -> None:
+    """Remove NPU-backend fields from ``kwargs`` after the backend consumes them.
+
+    ``_ensure_*_npu_backend`` hands ``kwargs`` to
+    :meth:`MobilintNPUBackend.from_dict`, which reads the fields it needs
+    and constructs the backend. The caller-facing ``kwargs`` dict, however,
+    still carries the very same NPU keys — HF's downstream
+    ``PretrainedConfig.__init__(**kwargs)`` iterates every entry and calls
+    ``setattr``, which routes right back through the config's NPU property
+    setters. Each such setter appends a raw override to the backend's
+    :class:`NPUTargetSpecPending` accumulator (``raw_cores`` /
+    ``raw_clusters`` / etc.), so a freshly-loaded config ends up with
+    pending state that echoes the just-baked baseline instead of the
+    caller-neutral :data:`_UNSET`. That echo later corrupts any
+    cross-board rebuild in :func:`_rebuild_backend_for_target_device`,
+    which replays the source pending onto the destination backend on
+    the assumption that non-``_UNSET`` slots represent real user intent.
+    """
+    for field in _NPU_BACKEND_KWARG_FIELDS:
+        kwargs.pop(f"{prefix}{field}", None)
+
+
 def _serialized_target_cores(backend: MobilintNPUBackend) -> list[str]:
     """Return JSON-safe core assignments for a Transformers configuration."""
 
@@ -104,17 +140,21 @@ def _rebuild_backend_for_target_device(
       ``"aries-rb"`` — otherwise ``to_dict`` would emit the alias and
       :class:`qbruntime.Accelerator` would receive an identifier its
       1.4 signature does not accept.
-    * Cross-board: rebuild via :meth:`MobilintNPUBackend.from_dict` while
-      preserving board-agnostic runtime state (mxq_path, dev_no,
-      revision, commit_hash, max_batch_size, name_or_path) and dropping
-      topology fields (``target_cores`` / ``target_clusters`` /
-      ``core_mode``). The source board's topology encodes its own layout
-      (e.g. Aries's 2×4 grid or a multi-cluster mode) that the
-      destination board's ``__init__`` would reject; dropping them lets
-      the destination class's board-aware default sugar fill in a spec
-      its own validator accepts. Subsequent HF kwargs from the same
-      loop (``target_cores=...``, ``core_mode=...``) then override on
-      the fresh backend via the per-field setter chain.
+    * Cross-board: rebuild via :meth:`MobilintNPUBackend.from_dict` from
+      the source backend's board-agnostic raw attributes (mxq_path,
+      dev_no baseline, revision, commit_hash, max_batch_size,
+      name_or_path). :meth:`to_dict` is deliberately avoided because it
+      would finalize the source :class:`NPUTargetSpecPending` — a
+      preceding kwarg like ``core_mode="global8"`` set on a Regulus
+      backend accumulates as a pending override that would raise here
+      against the source topology, making the rebuild order-dependent.
+      After ``from_dict`` seeds a fresh backend with the destination
+      board's default sugar (e.g. Regulus's sole ``d:0:0`` core in
+      ``single`` mode), the caller's raw pending overrides (``dev_no``,
+      ``core_mode``, ``target_cores``, ``target_clusters``) are replayed
+      onto the fresh backend's pending accumulator so the complete
+      override set applies atomically to the destination board
+      regardless of setattr order in the HF kwargs loop.
 
     Args:
         backend: The current NPU backend held by the config.
@@ -148,15 +188,28 @@ def _rebuild_backend_for_target_device(
     if type(backend) is desired_cls:
         backend.target_device = normalize_target_device(value)
         return backend
-    state = backend.to_dict(prefix=prefix)
-    for topology_key in (
-        f"{prefix}target_cores",
-        f"{prefix}target_clusters",
-        f"{prefix}core_mode",
-    ):
-        state.pop(topology_key, None)
-    state[f"{prefix}target_device"] = value
-    return _Backend.from_dict(state, prefix=prefix)
+    source_pending = backend._pending
+    state = {
+        f"{prefix}mxq_path": backend.mxq_path,
+        f"{prefix}max_batch_size": backend.max_batch_size,
+        f"{prefix}revision": backend.revision,
+        f"{prefix}commit_hash": backend._commit_hash,
+        f"{prefix}name_or_path": backend.name_or_path,
+        f"{prefix}target_device": value,
+        # Baseline reads the last-finalized ``dev_no`` without triggering
+        # a pending-state finalize; any caller ``dev_no`` override still
+        # rides on ``source_pending.raw_dev_no`` and is replayed below.
+        f"{prefix}dev_no": source_pending.baseline.dev_no_public(),
+    }
+    fresh = _Backend.from_dict(state, prefix=prefix)
+    fresh._pending = fresh._pending._with(
+        dev_no=source_pending.raw_dev_no,
+        core_mode=source_pending.raw_core_mode,
+        target_cores=source_pending.raw_cores,
+        target_clusters=source_pending.raw_clusters,
+    )
+    fresh._finalized = None
+    return fresh
 
 
 class MobilintConfigMixin(PretrainedConfig):
@@ -204,6 +257,7 @@ class MobilintConfigMixin(PretrainedConfig):
         if not hasattr(self, "npu_backend"):
             _normalize_npu_target_kwargs(kwargs, prefix="")
             self.npu_backend = MobilintNPUBackend.from_dict(kwargs, prefix="")
+            _pop_consumed_backend_kwargs(kwargs, prefix="")
 
     def __init__(self, *args, **kwargs):
         self._ensure_npu_backend(kwargs)
@@ -315,10 +369,12 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
         if not hasattr(self, "encoder_npu_backend"):
             _normalize_npu_target_kwargs(kwargs, prefix="encoder_")
             self.encoder_npu_backend = MobilintNPUBackend.from_dict(kwargs, prefix="encoder_")
+            _pop_consumed_backend_kwargs(kwargs, prefix="encoder_")
 
         if not hasattr(self, "decoder_npu_backend"):
             _normalize_npu_target_kwargs(kwargs, prefix="decoder_")
             self.decoder_npu_backend = MobilintNPUBackend.from_dict(kwargs, prefix="decoder_")
+            _pop_consumed_backend_kwargs(kwargs, prefix="decoder_")
 
     def __init__(self, **kwargs):
         self._ensure_encoder_decoder_npu_backends(kwargs)
@@ -761,6 +817,14 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
             fc_kwargs = _resolve_backend_kwargs("fc_")
             _normalize_npu_target_kwargs(fc_kwargs, prefix="fc_")
             self.fc_npu_backend = MobilintNPUBackend.from_dict(fc_kwargs, prefix="fc_")
+        # Drop the base_/draft_/fc_ NPU keys and their unprefixed fallbacks
+        # from ``kwargs`` so downstream ``PretrainedConfig.__init__`` does
+        # not re-apply them via setattr and pollute the just-baked
+        # ``NPUTargetSpecPending`` state — see the top-level
+        # :func:`_pop_consumed_backend_kwargs` docstring for the underlying
+        # HF init pattern.
+        for prefix in ("base_", "draft_", "fc_", ""):
+            _pop_consumed_backend_kwargs(kwargs, prefix=prefix)
 
     def _ensure_eagle3_runtime_fields(self, kwargs: dict[str, Any]) -> None:
         for field_name, default_value, _annotation in self._EAGLE3_RUNTIME_FIELDS:

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -1,6 +1,6 @@
 import inspect
 from inspect import Parameter, Signature
-from typing import Any, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 
 from transformers.configuration_utils import PretrainedConfig
 
@@ -114,6 +114,21 @@ _NPU_APPLY_ORDER: tuple[str, ...] = (
 )
 
 
+# Kwargs consumed by ``MobilintNPUBackend.from_dict`` that
+# ``MobilintConfigMixin`` does not surface as a forwarding property (either
+# top-level or prefixed on the multi-backend mixins). Routing them through
+# ``setattr(config, f"{prefix}{field}", ...)`` would land on the outer
+# ``config.__dict__`` and never reach the nested backend, so
+# :func:`_apply_npu_backend_kwargs` writes them straight onto the caller-
+# supplied ``backend`` when one is given. The value maps the caller-facing
+# kwarg name to the backend's storage-name — ``commit_hash`` is exposed
+# publicly as a kwarg but stored as ``_commit_hash`` on the backend.
+_NPU_BACKEND_DIRECT_FIELDS: dict[str, str] = {
+    "revision": "revision",
+    "commit_hash": "_commit_hash",
+}
+
+
 def _pop_consumed_backend_kwargs(kwargs: dict[str, Any], prefix: str = "") -> None:
     """Remove NPU-backend fields from ``kwargs`` after the backend consumes them.
 
@@ -164,7 +179,11 @@ def _split_npu_backend_kwargs(
 
 
 def _apply_npu_backend_kwargs(
-    config: PretrainedConfig, sub_kwargs: dict[str, Any], prefix: str = ""
+    config: PretrainedConfig,
+    sub_kwargs: dict[str, Any],
+    prefix: str = "",
+    *,
+    backend: Optional[MobilintNPUBackend] = None,
 ) -> None:
     """Apply buffered NPU-backend fields to ``config`` in :data:`_NPU_APPLY_ORDER`.
 
@@ -173,13 +192,30 @@ def _apply_npu_backend_kwargs(
     subsequent topology / mode assignments land — the destination
     board's fresh pending then absorbs the remaining fields without a
     partial-state finalize against the source topology.
+
+    Fields listed in :data:`_NPU_BACKEND_DIRECT_FIELDS` (``revision`` /
+    ``commit_hash``) have no forwarding property on
+    ``MobilintConfigMixin`` (nor its multi-backend variants), so a plain
+    ``setattr(config, f"{prefix}{field}", ...)`` would land on the outer
+    config's ``__dict__`` and never reach the nested backend — remote MXQ
+    resolution would silently keep the shipped revision. When the caller
+    passes ``backend``, those fields are written straight onto it,
+    mapping the caller-facing kwarg name to the backend's storage-name
+    (``commit_hash`` → ``_commit_hash``).
     """
+
+    def _apply(field: str, value: Any) -> None:
+        if backend is not None and field in _NPU_BACKEND_DIRECT_FIELDS:
+            setattr(backend, _NPU_BACKEND_DIRECT_FIELDS[field], value)
+        else:
+            setattr(config, f"{prefix}{field}", value)
+
     remaining = dict(sub_kwargs)
     for field in _NPU_APPLY_ORDER:
         if field in remaining:
-            setattr(config, f"{prefix}{field}", remaining.pop(field))
+            _apply(field, remaining.pop(field))
     for field, value in remaining.items():
-        setattr(config, f"{prefix}{field}", value)
+        _apply(field, value)
 
 
 def _serialized_target_cores(backend: MobilintNPUBackend) -> list[str]:
@@ -436,7 +472,7 @@ class MobilintConfigMixin(PretrainedConfig):
             config_dict, return_unused_kwargs=True, **kwargs
         )  # type: ignore[misc]
 
-        _apply_npu_backend_kwargs(config, npu_sub_kwargs)
+        _apply_npu_backend_kwargs(config, npu_sub_kwargs, backend=config.npu_backend)
 
         if return_unused_kwargs:
             return config, unused_kwargs
@@ -633,8 +669,12 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
             config_dict, return_unused_kwargs=True, **kwargs
         )  # type: ignore[misc]
 
-        _apply_npu_backend_kwargs(config, encoder_sub, prefix="encoder_")
-        _apply_npu_backend_kwargs(config, decoder_sub, prefix="decoder_")
+        _apply_npu_backend_kwargs(
+            config, encoder_sub, prefix="encoder_", backend=config.encoder_npu_backend
+        )
+        _apply_npu_backend_kwargs(
+            config, decoder_sub, prefix="decoder_", backend=config.decoder_npu_backend
+        )
 
         if return_unused_kwargs:
             return config, unused_kwargs
@@ -1204,9 +1244,15 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
             config_dict, return_unused_kwargs=True, **kwargs
         )  # type: ignore[misc]
 
-        _apply_npu_backend_kwargs(config, base_sub, prefix="base_")
-        _apply_npu_backend_kwargs(config, draft_sub, prefix="draft_")
-        _apply_npu_backend_kwargs(config, fc_sub, prefix="fc_")
+        _apply_npu_backend_kwargs(
+            config, base_sub, prefix="base_", backend=config.base_npu_backend
+        )
+        _apply_npu_backend_kwargs(
+            config, draft_sub, prefix="draft_", backend=config.draft_npu_backend
+        )
+        _apply_npu_backend_kwargs(
+            config, fc_sub, prefix="fc_", backend=config.fc_npu_backend
+        )
 
         if return_unused_kwargs:
             return config, unused_kwargs

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -149,7 +149,31 @@ class MobilintConfigMixin(PretrainedConfig):
 
     @target_device.setter
     def target_device(self, value: str) -> None:
-        self.npu_backend.target_device = value
+        # HF ``PretrainedConfig.from_dict`` instantiates the config with the
+        # values from ``config.json`` first and then applies any user
+        # ``from_pretrained`` kwargs (including ``target_device``) via
+        # ``setattr``. The initial __init__ has already dispatched
+        # ``MobilintNPUBackend.__new__`` to a concrete subclass based on the
+        # config-file value, so a plain string mutation here would leave
+        # ``self.npu_backend`` on the wrong board's class (e.g. Aries when
+        # the caller asked for ``regulus-rb-usb``). Rebuild the backend
+        # from its current serialized state whenever the requested board
+        # maps to a different subclass so the class matches the string.
+        from mblt_npu import MobilintNPUBackend, backend_class_for
+
+        try:
+            desired_cls = backend_class_for(value)
+        except (KeyError, ValueError):
+            # Let the backend layer raise its documented error for unknown
+            # target_device values instead of shadowing it here.
+            self.npu_backend.target_device = value
+            return
+        if type(self.npu_backend) is desired_cls:
+            self.npu_backend.target_device = value
+            return
+        state = self.npu_backend.to_dict()
+        state["target_device"] = value
+        self.npu_backend = MobilintNPUBackend.from_dict(state)
 
     @property
     def dev_no(self) -> int:

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -80,6 +80,85 @@ def _serialized_target_clusters(backend: MobilintNPUBackend) -> list[int]:
     return list(backend._target_clusters_serialized)
 
 
+def _rebuild_backend_for_target_device(
+    backend: MobilintNPUBackend, value: str, prefix: str = ""
+) -> MobilintNPUBackend:
+    """Apply a ``target_device`` reassignment to an existing NPU backend.
+
+    HF :meth:`PretrainedConfig.from_dict` instantiates the config with the
+    ``config.json`` values first and then applies any caller
+    ``from_pretrained`` kwargs (including ``target_device``) via
+    :func:`setattr`. The initial ``__init__`` has already dispatched
+    :meth:`MobilintNPUBackend.__new__` to a concrete subclass based on the
+    config-file board, so a plain string mutation on the existing backend
+    would leave it on the wrong class (e.g. ``MobilintAriesBackend`` when
+    the caller asked for ``regulus-rb-usb``).
+
+    Three paths:
+
+    * Unknown / unresolvable ``value``: mutate the string and let the
+      backend layer raise its documented error on the next validation
+      check rather than shadowing it here.
+    * Same board class: mutate in place, but first normalize the value
+      so a legacy alias like ``"aries"`` becomes the canonical
+      ``"aries-rb"`` — otherwise ``to_dict`` would emit the alias and
+      :class:`qbruntime.Accelerator` would receive an identifier its
+      1.4 signature does not accept.
+    * Cross-board: rebuild via :meth:`MobilintNPUBackend.from_dict` while
+      preserving board-agnostic runtime state (mxq_path, dev_no,
+      revision, commit_hash, max_batch_size, name_or_path) and dropping
+      topology fields (``target_cores`` / ``target_clusters`` /
+      ``core_mode``). The source board's topology encodes its own layout
+      (e.g. Aries's 2×4 grid or a multi-cluster mode) that the
+      destination board's ``__init__`` would reject; dropping them lets
+      the destination class's board-aware default sugar fill in a spec
+      its own validator accepts. Subsequent HF kwargs from the same
+      loop (``target_cores=...``, ``core_mode=...``) then override on
+      the fresh backend via the per-field setter chain.
+
+    Args:
+        backend: The current NPU backend held by the config.
+        value: The requested board identifier (canonical name or legacy
+            alias like ``"aries"`` / ``"regulus"``).
+        prefix: Serialization prefix that scopes the NPU keys on this
+            backend (``""``, ``"encoder_"``, ``"decoder_"``, ``"base_"``,
+            ``"draft_"``, ``"fc_"``). Must match the prefix used by
+            :meth:`MobilintNPUBackend.to_dict` / :meth:`from_dict` for
+            the same backend.
+
+    Returns:
+        The backend to store on the config after the assignment. Either
+        the original ``backend`` (mutated in place for unknown-value or
+        same-class paths) or a freshly rebuilt one for the cross-board
+        path.
+    """
+    from mblt_npu import (
+        MobilintNPUBackend as _Backend,
+    )
+    from mblt_npu import (
+        backend_class_for,
+        normalize_target_device,
+    )
+
+    try:
+        desired_cls = backend_class_for(value)
+    except (KeyError, ValueError):
+        backend.target_device = value
+        return backend
+    if type(backend) is desired_cls:
+        backend.target_device = normalize_target_device(value)
+        return backend
+    state = backend.to_dict(prefix=prefix)
+    for topology_key in (
+        f"{prefix}target_cores",
+        f"{prefix}target_clusters",
+        f"{prefix}core_mode",
+    ):
+        state.pop(topology_key, None)
+    state[f"{prefix}target_device"] = value
+    return _Backend.from_dict(state, prefix=prefix)
+
+
 class MobilintConfigMixin(PretrainedConfig):
     # ``dev_no`` is exposed as syntactic sugar for the device-prefix component
     # of the canonical target strings. It accepts either a single device index
@@ -149,44 +228,7 @@ class MobilintConfigMixin(PretrainedConfig):
 
     @target_device.setter
     def target_device(self, value: str) -> None:
-        # HF ``PretrainedConfig.from_dict`` instantiates the config with the
-        # values from ``config.json`` first and then applies any user
-        # ``from_pretrained`` kwargs (including ``target_device``) via
-        # ``setattr``. The initial __init__ has already dispatched
-        # ``MobilintNPUBackend.__new__`` to a concrete subclass based on the
-        # config-file value, so a plain string mutation here would leave
-        # ``self.npu_backend`` on the wrong board's class (e.g. Aries when
-        # the caller asked for ``regulus-rb-usb``). Rebuild the backend
-        # whenever the requested board maps to a different subclass so the
-        # class matches the string.
-        from mblt_npu import MobilintNPUBackend, backend_class_for
-
-        try:
-            desired_cls = backend_class_for(value)
-        except (KeyError, ValueError):
-            # Let the backend layer raise its documented error for unknown
-            # target_device values instead of shadowing it here.
-            self.npu_backend.target_device = value
-            return
-        if type(self.npu_backend) is desired_cls:
-            self.npu_backend.target_device = value
-            return
-        # Cross-board rebuild: preserve board-agnostic runtime state
-        # (mxq_path, dev_no, revision, commit_hash, max_batch_size,
-        # name_or_path) but discard topology fields — the source board's
-        # target_cores / target_clusters / core_mode encode its own
-        # topology (e.g. Aries's 8-core grid or a multi-cluster mode)
-        # that the destination board's __init__ would reject. Dropping
-        # them lets the destination class's board-aware default sugar
-        # fill in a valid spec (e.g. Regulus's sole ``d:0:0`` core in
-        # ``single`` mode); subsequent HF kwargs (target_cores=...,
-        # core_mode=...) then override on the fresh backend via the
-        # per-field setters.
-        state = self.npu_backend.to_dict()
-        for topology_key in ("target_cores", "target_clusters", "core_mode"):
-            state.pop(topology_key, None)
-        state["target_device"] = value
-        self.npu_backend = MobilintNPUBackend.from_dict(state)
+        self.npu_backend = _rebuild_backend_for_target_device(self.npu_backend, value)
 
     @property
     def dev_no(self) -> int:
@@ -295,6 +337,17 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
         self.encoder_npu_backend.mxq_path = value
 
     @property
+    def encoder_target_device(self) -> str:
+        """Board identifier used by the encoder NPU backend."""
+        return self.encoder_npu_backend.target_device
+
+    @encoder_target_device.setter
+    def encoder_target_device(self, value: str) -> None:
+        self.encoder_npu_backend = _rebuild_backend_for_target_device(
+            self.encoder_npu_backend, value, prefix="encoder_"
+        )
+
+    @property
     def encoder_dev_no(self) -> int:
         return self.encoder_npu_backend.dev_no
 
@@ -341,6 +394,17 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
     @decoder_mxq_path.setter
     def decoder_mxq_path(self, value: str) -> None:
         self.decoder_npu_backend.mxq_path = value
+
+    @property
+    def decoder_target_device(self) -> str:
+        """Board identifier used by the decoder NPU backend."""
+        return self.decoder_npu_backend.target_device
+
+    @decoder_target_device.setter
+    def decoder_target_device(self, value: str) -> None:
+        self.decoder_npu_backend = _rebuild_backend_for_target_device(
+            self.decoder_npu_backend, value, prefix="decoder_"
+        )
 
     @property
     def decoder_dev_no(self) -> int:
@@ -772,7 +836,9 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
 
     @base_target_device.setter
     def base_target_device(self, value: str) -> None:
-        self.base_npu_backend.target_device = value
+        self.base_npu_backend = _rebuild_backend_for_target_device(
+            self.base_npu_backend, value, prefix="base_"
+        )
 
     @property
     def draft_target_device(self) -> str:
@@ -780,7 +846,9 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
 
     @draft_target_device.setter
     def draft_target_device(self, value: str) -> None:
-        self.draft_npu_backend.target_device = value
+        self.draft_npu_backend = _rebuild_backend_for_target_device(
+            self.draft_npu_backend, value, prefix="draft_"
+        )
 
     @property
     def fc_target_device(self) -> str:
@@ -788,7 +856,9 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
 
     @fc_target_device.setter
     def fc_target_device(self, value: str) -> None:
-        self.fc_npu_backend.target_device = value
+        self.fc_npu_backend = _rebuild_backend_for_target_device(
+            self.fc_npu_backend, value, prefix="fc_"
+        )
 
     @property
     def base_max_batch_size(self) -> int:

--- a/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/configuration_utils.py
@@ -1,6 +1,6 @@
 import inspect
 from inspect import Parameter, Signature
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from transformers.configuration_utils import PretrainedConfig
 
@@ -183,7 +183,7 @@ def _apply_npu_backend_kwargs(
     sub_kwargs: dict[str, Any],
     prefix: str = "",
     *,
-    backend: Optional[MobilintNPUBackend] = None,
+    resolve_backend: Optional[Callable[[PretrainedConfig], MobilintNPUBackend]] = None,
 ) -> None:
     """Apply buffered NPU-backend fields to ``config`` in :data:`_NPU_APPLY_ORDER`.
 
@@ -198,15 +198,23 @@ def _apply_npu_backend_kwargs(
     ``MobilintConfigMixin`` (nor its multi-backend variants), so a plain
     ``setattr(config, f"{prefix}{field}", ...)`` would land on the outer
     config's ``__dict__`` and never reach the nested backend — remote MXQ
-    resolution would silently keep the shipped revision. When the caller
-    passes ``backend``, those fields are written straight onto it,
-    mapping the caller-facing kwarg name to the backend's storage-name
-    (``commit_hash`` → ``_commit_hash``).
+    resolution would silently keep the shipped revision.
+
+    When the caller passes ``resolve_backend``, those fields are written
+    straight onto the backend the callable returns, mapping the caller-
+    facing kwarg name to the backend's storage-name (``commit_hash`` →
+    ``_commit_hash``). The callable is invoked **per field**, not once,
+    so a preceding ``target_device`` override that rebuilds the config's
+    backend (:func:`_rebuild_backend_for_target_device` allocates a fresh
+    instance and reassigns ``config.<prefix>npu_backend``) is followed by
+    ``resolve_backend(config)`` returning the newly-installed backend —
+    ``revision`` / ``commit_hash`` therefore always land on the live
+    destination backend, never on the discarded source.
     """
 
     def _apply(field: str, value: Any) -> None:
-        if backend is not None and field in _NPU_BACKEND_DIRECT_FIELDS:
-            setattr(backend, _NPU_BACKEND_DIRECT_FIELDS[field], value)
+        if resolve_backend is not None and field in _NPU_BACKEND_DIRECT_FIELDS:
+            setattr(resolve_backend(config), _NPU_BACKEND_DIRECT_FIELDS[field], value)
         else:
             setattr(config, f"{prefix}{field}", value)
 
@@ -472,7 +480,11 @@ class MobilintConfigMixin(PretrainedConfig):
             config_dict, return_unused_kwargs=True, **kwargs
         )  # type: ignore[misc]
 
-        _apply_npu_backend_kwargs(config, npu_sub_kwargs, backend=config.npu_backend)
+        _apply_npu_backend_kwargs(
+            config,
+            npu_sub_kwargs,
+            resolve_backend=lambda c: c.npu_backend,
+        )
 
         if return_unused_kwargs:
             return config, unused_kwargs
@@ -670,10 +682,16 @@ class MobilintEncoderDecoderConfigMixin(PretrainedConfig):
         )  # type: ignore[misc]
 
         _apply_npu_backend_kwargs(
-            config, encoder_sub, prefix="encoder_", backend=config.encoder_npu_backend
+            config,
+            encoder_sub,
+            prefix="encoder_",
+            resolve_backend=lambda c: c.encoder_npu_backend,
         )
         _apply_npu_backend_kwargs(
-            config, decoder_sub, prefix="decoder_", backend=config.decoder_npu_backend
+            config,
+            decoder_sub,
+            prefix="decoder_",
+            resolve_backend=lambda c: c.decoder_npu_backend,
         )
 
         if return_unused_kwargs:
@@ -1245,13 +1263,22 @@ class MobilintEagle3ConfigMixin(PretrainedConfig):
         )  # type: ignore[misc]
 
         _apply_npu_backend_kwargs(
-            config, base_sub, prefix="base_", backend=config.base_npu_backend
+            config,
+            base_sub,
+            prefix="base_",
+            resolve_backend=lambda c: c.base_npu_backend,
         )
         _apply_npu_backend_kwargs(
-            config, draft_sub, prefix="draft_", backend=config.draft_npu_backend
+            config,
+            draft_sub,
+            prefix="draft_",
+            resolve_backend=lambda c: c.draft_npu_backend,
         )
         _apply_npu_backend_kwargs(
-            config, fc_sub, prefix="fc_", backend=config.fc_npu_backend
+            config,
+            fc_sub,
+            prefix="fc_",
+            resolve_backend=lambda c: c.fc_npu_backend,
         )
 
         if return_unused_kwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "PyYAML",
     "matplotlib",
     "cityscapesScripts",
-    "mblt-npu-python",
+    "mblt-npu-python>=0.1.0",
     "mblt-vision-python>=0.0.2",
 ]
 classifiers = [

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -235,6 +235,55 @@ def test_from_dict_buffers_target_device_across_topology_probe_hazard() -> None:
     assert set(config.to_dict()["target_clusters"]) == {"0:0", "0:1"}
 
 
+@pytest.mark.parametrize("prefix", ["encoder", "decoder"])
+def test_qwen3_asr_from_dict_buffers_prefixed_target_device_atomically(prefix: str) -> None:
+    """Buffer ``encoder_*`` / ``decoder_*`` overrides on the Qwen3-ASR facade.
+
+    ``MobilintQwen3ASRConfig`` does not inherit
+    ``MobilintEncoderDecoderConfigMixin``, so the mixin's buffered
+    ``from_dict`` does not apply. The facade's own ``from_dict`` must
+    mirror the buffering pattern; otherwise HF's ``hasattr`` probe on
+    e.g. ``encoder_target_clusters`` fires against a Regulus baseline
+    that already has ``core_mode="global8"`` pending and raises before
+    the ``encoder_target_device`` setter can rebuild to Aries.
+    """
+
+    pytest.importorskip("qwen_asr")
+    from mblt_model_zoo.hf_transformers.models.qwen3_asr.configuration_qwen3_asr import (
+        MobilintQwen3ASRConfig,
+    )
+
+    prefix_ = f"{prefix}_"
+    inner_config = "audio_config" if prefix == "encoder" else "text_config"
+    inner_model_type = (
+        "mobilint-qwen3_asr_audio_encoder" if prefix == "encoder"
+        else "mobilint-qwen3_asr_text"
+    )
+
+    config = MobilintQwen3ASRConfig.from_dict(
+        {
+            "model_type": MobilintQwen3ASRConfig.model_type,
+            "thinker_config": {
+                inner_config: {
+                    "model_type": inner_model_type,
+                    "target_device": "regulus-rb-usb",
+                }
+            },
+        },
+        **{
+            f"{prefix_}core_mode": "global8",
+            f"{prefix_}target_clusters": [0, 1],
+            f"{prefix_}target_device": "aries-rb",
+        },
+    )
+
+    sub_config = getattr(config.thinker_config, inner_config)
+    sub_backend = sub_config.npu_backend
+    assert type(sub_backend).__name__ == "MobilintAriesBackend"
+    assert getattr(config, f"{prefix_}core_mode") == "global8"
+    assert set(sub_config.to_dict()["target_clusters"]) == {"0:0", "0:1"}
+
+
 @pytest.mark.parametrize(
     "prefix",
     ["encoder", "decoder"],

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -154,6 +154,38 @@ def test_eagle3_prefixed_target_device_setter_rebuilds_backend(prefix: str) -> N
     assert config.to_dict()[f"{prefix}_target_cores"] == ["0:0:0"]
 
 
+def test_target_device_setter_reapplies_pending_topology_atomically() -> None:
+    """Preserve caller topology overrides across a cross-board setter switch.
+
+    HF ``PretrainedConfig.from_dict`` applies caller kwargs via ``setattr``
+    in insertion order, so ``core_mode="global8"`` may land on a Regulus
+    baseline before the accompanying ``target_device="aries-rb"`` kwarg.
+    The Regulus board rejects ``global8``; the previous rebuild
+    serialized the source via ``to_dict`` and thus finalized that
+    pending override against the wrong topology and raised. The atomic
+    rebuild reads only board-agnostic raw attributes from the source
+    backend and replays the caller's pending topology overrides
+    (``dev_no`` / ``core_mode`` / ``target_cores`` / ``target_clusters``)
+    onto the fresh destination pending accumulator, so the same override
+    set behaves the same regardless of setattr order.
+    """
+
+    config = _TargetDeviceConfig(target_device="regulus-rb-usb")
+    # Setter A: pending ``core_mode="global8"`` recorded against Regulus
+    # (not finalized yet — Regulus would reject it if finalize ran).
+    config.core_mode = "global8"
+    # Setter B: cross-board rebuild to Aries. Must not finalize the
+    # source pending; must replay ``core_mode="global8"`` on the fresh
+    # Aries backend so the final state honours the caller's intent.
+    config.target_device = "aries-rb"
+
+    assert type(config.npu_backend).__name__ == "MobilintAriesBackend"
+    assert config.target_device == "aries-rb"
+    assert config.core_mode == "global8"
+    # Aries's ``global8`` sugar covers both clusters.
+    assert set(config.to_dict()["target_clusters"]) == {"0:0", "0:1"}
+
+
 @pytest.mark.parametrize(
     "prefix",
     ["encoder", "decoder"],

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -272,6 +272,43 @@ def test_qwen3_asr_ctor_routes_revision_and_commit_hash_to_backend(prefix: str) 
 
 
 @pytest.mark.parametrize("prefix", ["encoder", "decoder"])
+def test_qwen3_asr_from_dict_routes_revision_and_commit_hash_to_backend(prefix: str) -> None:
+    """Forward buffered ``revision`` / ``commit_hash`` kwargs to the nested backend.
+
+    The Qwen3-ASR ``from_dict`` override buffers every ``encoder_*`` /
+    ``decoder_*`` NPU kwarg to sidestep HF's hasattr-probe hazard and
+    replays them via ``_apply_npu_backend_kwargs``, which drives the
+    top-level config's setattr path. That path only reaches the nested
+    backend for fields with a forwarding property on
+    ``MobilintConfigMixin``. ``revision`` and ``commit_hash`` have no
+    such property, so the same direct-to-backend routing that the
+    constructor uses must apply on the ``from_dict`` path as well —
+    otherwise remote MXQ resolution silently keeps the shipped
+    revision.
+    """
+
+    pytest.importorskip("qwen_asr")
+    from mblt_model_zoo.hf_transformers.models.qwen3_asr.configuration_qwen3_asr import (
+        MobilintQwen3ASRConfig,
+    )
+
+    prefix_ = f"{prefix}_"
+    inner_config = "audio_config" if prefix == "encoder" else "text_config"
+
+    config = MobilintQwen3ASRConfig.from_dict(
+        {"model_type": MobilintQwen3ASRConfig.model_type},
+        **{
+            f"{prefix_}revision": "from-dict-release",
+            f"{prefix_}commit_hash": "fedcba9876543210",
+        },
+    )
+
+    sub_backend = getattr(config.thinker_config, inner_config).npu_backend
+    assert sub_backend.revision == "from-dict-release"
+    assert sub_backend._commit_hash == "fedcba9876543210"
+
+
+@pytest.mark.parametrize("prefix", ["encoder", "decoder"])
 def test_qwen3_asr_from_dict_buffers_prefixed_target_device_atomically(prefix: str) -> None:
     """Buffer ``encoder_*`` / ``decoder_*`` overrides on the Qwen3-ASR facade.
 

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mblt_model_zoo.hf_transformers.utils.configuration_utils import MobilintConfigMixin
 
 
@@ -18,10 +20,27 @@ def test_transformers_config_defaults_to_aries_rb() -> None:
     assert config.to_dict()["target_device"] == "aries-rb"
 
 
-def test_transformers_config_selects_regulus_backend() -> None:
-    """Forward an explicit Regulus board setting without direct class usage."""
+@pytest.mark.parametrize(
+    ("target_device", "backend_class_name"),
+    [
+        ("aries-rb", "MobilintAriesBackend"),
+        ("regulus-ra", "MobilintRegulusBackend"),
+        ("regulus-rb", "MobilintRegulusBackend"),
+        ("regulus-rb-usb", "MobilintRegulusBackend"),
+    ],
+)
+def test_transformers_config_forwards_target_device(
+    target_device: str, backend_class_name: str
+) -> None:
+    """Forward every documented Model Zoo target device without direct class usage.
 
-    config = _TargetDeviceConfig(target_device="regulus-rb")
+    ``regulus-rb-usb`` reaches ``MobilintRegulusBackend`` via mblt-npu-python's
+    dispatch table; it requires the qbruntime 1.4 shared package. The other
+    boards remain covered so a regression at the forwarding layer surfaces on
+    Aries, Regulus PCIe, and Regulus USB alike.
+    """
 
-    assert type(config.npu_backend).__name__ == "MobilintRegulusBackend"
-    assert config.to_dict()["target_device"] == "regulus-rb"
+    config = _TargetDeviceConfig(target_device=target_device)
+
+    assert type(config.npu_backend).__name__ == backend_class_name
+    assert config.to_dict()["target_device"] == target_device

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -186,6 +186,55 @@ def test_target_device_setter_reapplies_pending_topology_atomically() -> None:
     assert set(config.to_dict()["target_clusters"]) == {"0:0", "0:1"}
 
 
+def test_npu_prefill_chunk_size_kwarg_survives_from_dict() -> None:
+    """Keep the caller's ``npu_prefill_chunk_size`` override across ``from_dict``.
+
+    ``MobilintNPUBackend.from_dict`` does not consume
+    ``npu_prefill_chunk_size`` — it is a config-only attribute stored
+    on ``self.__dict__`` and read by
+    ``resolve_npu_prefill_chunk_size`` as a fallback / per-core-mode
+    mapping. Including it in ``_NPU_BACKEND_KWARG_FIELDS`` (an earlier
+    revision did) caused ``_pop_consumed_backend_kwargs`` to delete it
+    before HF's ``PretrainedConfig.__init__`` could route it through
+    the property setter, so the config surfaced ``None`` and the
+    resolver silently fell back to 128.
+    """
+
+    config = _TargetDeviceConfig.from_dict(
+        {"model_type": _TargetDeviceConfig.model_type},
+        npu_prefill_chunk_size={"single": 64, "global4": 96, "global8": 192},
+    )
+    assert config.npu_prefill_chunk_size == {"single": 64, "global4": 96, "global8": 192}
+
+
+def test_from_dict_buffers_target_device_across_topology_probe_hazard() -> None:
+    """Apply cross-board overrides after the ``super().from_dict`` kwargs loop.
+
+    HF ``PretrainedConfig.from_dict`` probes every override with
+    ``hasattr`` before ``setattr``. The topology getters
+    (``target_cores`` / ``target_clusters`` / ``core_mode`` /
+    ``dev_no``) all trigger a spec finalize on the current pending
+    state, so a caller override that combines ``target_device`` with a
+    board-specific mode (e.g. ``core_mode="global8"``) raises during
+    the probe against the source board's topology before the target-
+    device rebuild has a chance to run. Buffering the NPU kwargs and
+    replaying them after ``super().from_dict`` returns lets the
+    complete override set land on the destination board atomically.
+    """
+
+    config = _TargetDeviceConfig.from_dict(
+        {"model_type": _TargetDeviceConfig.model_type, "target_device": "regulus-rb-usb"},
+        core_mode="global8",
+        target_clusters=[0, 1],
+        target_device="aries-rb",
+    )
+
+    assert type(config.npu_backend).__name__ == "MobilintAriesBackend"
+    assert config.target_device == "aries-rb"
+    assert config.core_mode == "global8"
+    assert set(config.to_dict()["target_clusters"]) == {"0:0", "0:1"}
+
+
 @pytest.mark.parametrize(
     "prefix",
     ["encoder", "decoder"],

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -235,6 +235,31 @@ def test_from_dict_buffers_target_device_across_topology_probe_hazard() -> None:
     assert set(config.to_dict()["target_clusters"]) == {"0:0", "0:1"}
 
 
+def test_from_dict_target_device_rebuild_still_receives_revision_and_commit_hash() -> None:
+    """Land ``revision`` / ``commit_hash`` on the rebuilt backend, not the discarded source.
+
+    ``_apply_npu_backend_kwargs`` writes ``target_device`` first, which
+    routes through ``_rebuild_backend_for_target_device`` and reassigns
+    ``config.npu_backend`` to a freshly constructed instance for the new
+    board. If the direct-backend routing captured the source backend at
+    helper entry, ``revision`` / ``commit_hash`` would then land on the
+    detached object and the newly-installed backend would keep its
+    shipped defaults — remote MXQ resolution would fetch the wrong
+    artifact. The helper must resolve the backend per field so the
+    metadata reaches the live destination after the rebuild.
+    """
+
+    config = _TargetDeviceConfig.from_dict(
+        {"model_type": _TargetDeviceConfig.model_type, "target_device": "regulus-rb-usb"},
+        target_device="aries-rb",
+        revision="post-rebuild-release",
+        commit_hash="cafebabe12345678",
+    )
+    assert type(config.npu_backend).__name__ == "MobilintAriesBackend"
+    assert config.npu_backend.revision == "post-rebuild-release"
+    assert config.npu_backend._commit_hash == "cafebabe12345678"
+
+
 @pytest.mark.parametrize("prefix", ["encoder", "decoder"])
 def test_encoder_decoder_from_dict_routes_revision_and_commit_hash_to_backend(
     prefix: str,

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -4,11 +4,23 @@ from __future__ import annotations
 
 import pytest
 
-from mblt_model_zoo.hf_transformers.utils.configuration_utils import MobilintConfigMixin
+from mblt_model_zoo.hf_transformers.utils.configuration_utils import (
+    MobilintConfigMixin,
+    MobilintEagle3ConfigMixin,
+    MobilintEncoderDecoderConfigMixin,
+)
 
 
 class _TargetDeviceConfig(MobilintConfigMixin):
     model_type = "target-device-test"
+
+
+class _EncoderDecoderTargetDeviceConfig(MobilintEncoderDecoderConfigMixin):
+    model_type = "target-device-encdec-test"
+
+
+class _Eagle3TargetDeviceConfig(MobilintEagle3ConfigMixin):
+    model_type = "target-device-eagle3-test"
 
 
 def test_transformers_config_defaults_to_aries_rb() -> None:
@@ -90,3 +102,81 @@ def test_target_device_setter_is_a_noop_when_the_class_does_not_change() -> None
 
     assert config.npu_backend is original_backend
     assert config.to_dict()["target_cores"] == original_cores
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [("aries", "aries-rb"), ("regulus", "regulus-ra")],
+)
+def test_target_device_setter_normalizes_legacy_aliases(alias: str, canonical: str) -> None:
+    """Rewrite legacy family aliases to their canonical board identifier.
+
+    ``qbruntime>=1.4`` expects the canonical board name as the first
+    positional argument to ``Accelerator``; without normalization the
+    same-class fast path would leave the alias in place on the backend and
+    surface at inference time as a runtime error from ``qbruntime`` for an
+    unknown target device.
+    """
+
+    config = _TargetDeviceConfig(target_device=canonical)  # same class as alias
+    config.target_device = alias
+
+    assert config.target_device == canonical
+    assert config.to_dict()["target_device"] == canonical
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["base", "draft", "fc"],
+)
+def test_eagle3_prefixed_target_device_setter_rebuilds_backend(prefix: str) -> None:
+    """Rebuild the prefixed Eagle3 backend when its target_device setter switches boards.
+
+    Every ``MobilintEagle3ConfigMixin`` sub-backend (``base_*``, ``draft_*``,
+    ``fc_*``) exposes its own ``*_target_device`` property that HF's
+    ``from_dict`` kwargs loop applies via ``setattr``. Each setter must run
+    through the same cross-board rebuild logic as the single-backend mixin
+    so a caller override actually reaches the destination board's class.
+    """
+
+    config = _Eagle3TargetDeviceConfig()
+    backend_attr = f"{prefix}_npu_backend"
+    setattr_key = f"{prefix}_target_device"
+    original_backend = getattr(config, backend_attr)
+    assert type(original_backend).__name__ == "MobilintAriesBackend"
+
+    setattr(config, setattr_key, "regulus-rb-usb")
+
+    rebuilt = getattr(config, backend_attr)
+    assert type(rebuilt).__name__ == "MobilintRegulusBackend"
+    assert rebuilt.target_device == "regulus-rb-usb"
+    # Topology reset: the destination class fills its single-core default.
+    assert config.to_dict()[f"{prefix}_target_cores"] == ["0:0:0"]
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["encoder", "decoder"],
+)
+def test_encoder_decoder_target_device_property_rebuilds_backend(prefix: str) -> None:
+    """Expose ``encoder_target_device`` / ``decoder_target_device`` and rebuild across boards.
+
+    ``MobilintEncoderDecoderConfigMixin`` previously offered no
+    ``encoder_target_device`` / ``decoder_target_device`` property, so HF's
+    ``from_dict`` kwargs loop silently dropped those keys via its
+    ``hasattr`` gate. Advertising the setters — and routing them through
+    the shared rebuild helper — makes prefixed board overrides work
+    end-to-end for encoder-decoder models.
+    """
+
+    config = _EncoderDecoderTargetDeviceConfig()
+    backend_attr = f"{prefix}_npu_backend"
+    setattr_key = f"{prefix}_target_device"
+    assert type(getattr(config, backend_attr)).__name__ == "MobilintAriesBackend"
+
+    setattr(config, setattr_key, "regulus-rb-usb")
+
+    rebuilt = getattr(config, backend_attr)
+    assert type(rebuilt).__name__ == "MobilintRegulusBackend"
+    assert getattr(config, setattr_key) == "regulus-rb-usb"
+    assert config.to_dict()[f"{prefix}_target_cores"] == ["0:0:0"]

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -44,3 +44,49 @@ def test_transformers_config_forwards_target_device(
 
     assert type(config.npu_backend).__name__ == backend_class_name
     assert config.to_dict()["target_device"] == target_device
+
+
+@pytest.mark.parametrize(
+    "target_device",
+    ["regulus-ra", "regulus-rb", "regulus-ra-usb", "regulus-rb-usb"],
+)
+def test_target_device_setter_reassigns_backend_class_across_boards(
+    target_device: str,
+) -> None:
+    """Rebuild the backend to the destination class when the setter switches boards.
+
+    Reproduces the HF ``PretrainedConfig.from_dict`` flow: an Aries-shaped
+    config (target_cores expanded to the 2×4 grid on ``__init__``) then
+    receives a ``target_device`` override from a user ``from_pretrained``
+    kwarg via ``setattr``. The setter must rebuild the backend on the
+    destination class *and* reset the source board's topology fields,
+    otherwise the Aries-shaped ``target_cores`` propagates into
+    ``MobilintRegulusBackend`` and its single-core validator rejects the
+    spec.
+    """
+
+    config = _TargetDeviceConfig()  # defaults to Aries, expands 8-core grid
+    assert type(config.npu_backend).__name__ == "MobilintAriesBackend"
+    assert len(config.to_dict()["target_cores"]) == 8
+
+    config.target_device = target_device
+
+    assert type(config.npu_backend).__name__ == "MobilintRegulusBackend"
+    assert config.target_device == target_device
+    assert config.to_dict()["target_cores"] == ["0:0:0"]
+
+
+def test_target_device_setter_is_a_noop_when_the_class_does_not_change() -> None:
+    """Preserve the topology fields when the caller reassigns to the same board class."""
+
+    config = _TargetDeviceConfig()
+    original_backend = config.npu_backend
+    original_cores = list(config.to_dict()["target_cores"])
+
+    # ``aries`` normalizes to ``aries-rb`` — same class as the default, so
+    # the setter must not rebuild the backend and must preserve the
+    # already-expanded topology.
+    config.target_device = "aries"
+
+    assert config.npu_backend is original_backend
+    assert config.to_dict()["target_cores"] == original_cores

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -236,6 +236,42 @@ def test_from_dict_buffers_target_device_across_topology_probe_hazard() -> None:
 
 
 @pytest.mark.parametrize("prefix", ["encoder", "decoder"])
+def test_qwen3_asr_ctor_routes_revision_and_commit_hash_to_backend(prefix: str) -> None:
+    """Forward ``revision`` / ``commit_hash`` kwargs to the nested NPU backend.
+
+    ``MobilintConfigMixin`` exposes no forwarding property for
+    ``revision`` or ``commit_hash``, so routing every prefixed kwarg
+    through the sub-config setter would land those two on
+    ``config.__dict__`` while leaving ``npu_backend.revision`` and
+    ``npu_backend._commit_hash`` at their init-time defaults. Remote
+    MXQ resolution then falls back to the shipped revision and can
+    load the wrong artifact. Route ``revision`` and ``commit_hash``
+    directly to the backend (mapping ``commit_hash`` to the internal
+    ``_commit_hash`` attribute) while keeping the target-device rebuild
+    routing intact for the fields that do have a config property.
+    """
+
+    pytest.importorskip("qwen_asr")
+    from mblt_model_zoo.hf_transformers.models.qwen3_asr.configuration_qwen3_asr import (
+        MobilintQwen3ASRConfig,
+    )
+
+    prefix_ = f"{prefix}_"
+    inner_config = "audio_config" if prefix == "encoder" else "text_config"
+
+    config = MobilintQwen3ASRConfig(
+        **{
+            f"{prefix_}revision": "test-release-1",
+            f"{prefix_}commit_hash": "0123456789abcdef",
+        }
+    )
+
+    sub_backend = getattr(config.thinker_config, inner_config).npu_backend
+    assert sub_backend.revision == "test-release-1"
+    assert sub_backend._commit_hash == "0123456789abcdef"
+
+
+@pytest.mark.parametrize("prefix", ["encoder", "decoder"])
 def test_qwen3_asr_from_dict_buffers_prefixed_target_device_atomically(prefix: str) -> None:
     """Buffer ``encoder_*`` / ``decoder_*`` overrides on the Qwen3-ASR facade.
 

--- a/tests/transformers/test_target_device_backend.py
+++ b/tests/transformers/test_target_device_backend.py
@@ -236,6 +236,62 @@ def test_from_dict_buffers_target_device_across_topology_probe_hazard() -> None:
 
 
 @pytest.mark.parametrize("prefix", ["encoder", "decoder"])
+def test_encoder_decoder_from_dict_routes_revision_and_commit_hash_to_backend(
+    prefix: str,
+) -> None:
+    """Route ``encoder_/decoder_revision`` and ``commit_hash`` to the prefixed backend.
+
+    ``MobilintEncoderDecoderConfigMixin`` exposes no forwarding property
+    for ``encoder_revision`` / ``decoder_revision`` (nor their
+    ``commit_hash`` counterparts), so the shared
+    ``_apply_npu_backend_kwargs`` helper must write those fields straight
+    onto the prefixed backend when the caller passes ``backend=...``.
+    Without that path the setattr replay would land the values on
+    ``config.__dict__`` and leave ``encoder_npu_backend.revision`` /
+    ``._commit_hash`` at the shipped defaults, so remote MXQ resolution
+    would silently pick the wrong artifact.
+    """
+
+    prefix_ = f"{prefix}_"
+    config = _EncoderDecoderTargetDeviceConfig.from_dict(
+        {"model_type": _EncoderDecoderTargetDeviceConfig.model_type},
+        **{
+            f"{prefix_}revision": "encdec-release",
+            f"{prefix_}commit_hash": "0011223344556677",
+        },
+    )
+    backend = getattr(config, f"{prefix}_npu_backend")
+    assert backend.revision == "encdec-release"
+    assert backend._commit_hash == "0011223344556677"
+
+
+@pytest.mark.parametrize("prefix", ["base", "draft", "fc"])
+def test_eagle3_from_dict_routes_revision_and_commit_hash_to_backend(
+    prefix: str,
+) -> None:
+    """Route ``base_/draft_/fc_revision`` and ``commit_hash`` to the prefixed backend.
+
+    ``MobilintEagle3ConfigMixin`` also has no forwarding property for
+    ``{base,draft,fc}_revision`` / ``_commit_hash``, so the same
+    backend-direct routing must land those fields on
+    ``{base,draft,fc}_npu_backend`` — otherwise the Eagle3 draft
+    resolver silently keeps the shipped revision.
+    """
+
+    prefix_ = f"{prefix}_"
+    config = _Eagle3TargetDeviceConfig.from_dict(
+        {"model_type": _Eagle3TargetDeviceConfig.model_type},
+        **{
+            f"{prefix_}revision": f"{prefix}-release",
+            f"{prefix_}commit_hash": f"deadbeef{prefix.ljust(8, 'x')}",
+        },
+    )
+    backend = getattr(config, f"{prefix}_npu_backend")
+    assert backend.revision == f"{prefix}-release"
+    assert backend._commit_hash == f"deadbeef{prefix.ljust(8, 'x')}"
+
+
+@pytest.mark.parametrize("prefix", ["encoder", "decoder"])
 def test_qwen3_asr_ctor_routes_revision_and_commit_hash_to_backend(prefix: str) -> None:
     """Forward ``revision`` / ``commit_hash`` kwargs to the nested NPU backend.
 


### PR DESCRIPTION
## Summary

- Bump `mblt-npu-python>=0.1.0` so Model Zoo picks up the shared runtime that (a) registers `regulus-ra-usb` / `regulus-rb-usb` in the board dispatch table, (b) forwards `target_device` to `qbruntime.Accelerator` as its first positional argument (requires `mobilint-qb-runtime>=1.4.0`), and (c) threads `target_device` through `NPUTargetSpec.from_kwargs` / `NPUTargetSpecPending.finalize` so `dev_no` sugar expands to the board-appropriate topology instead of Aries's 2×4 grid.
- Extend `tests/transformers/test_target_device_backend.py` to parametrize the forwarding case over aries-rb, regulus-ra, regulus-rb, and regulus-rb-usb, replacing the single-case regulus-rb assertion so a regression at the Model Zoo config layer surfaces on every documented board.

No production code change in Model Zoo. `MobilintConfigMixin` already respects `target_device` (default `aries-rb`) and delegates dispatch to `mblt_npu.MobilintNPUBackend.from_dict`, which now forwards the resolved board name straight through to the concrete backend.

Depends on mobilint/mblt-npu-python#6 (merged as v0.1.0).

## Test plan

- [x] `python -m pytest tests/transformers/test_target_device_backend.py -v` — 5 passed (default aries-rb + parametrized 4 boards).
- [x] `python -m ruff check pyproject.toml tests/transformers/test_target_device_backend.py`
- [x] Verified end-to-end with `mblt_npu==0.1.0`: `_TargetDeviceConfig(target_device="regulus-rb-usb")` returns `MobilintRegulusBackend` with `target_cores=["0:0:0"]`; omitting `target_device` still resolves to `MobilintAriesBackend`.
- ⚠️ Pre-existing failures in `tests/transformers/test_npu_config_normalization.py::test_migrate_target_cores_rejects_out_of_range_core_canonical` and `..._legacy_two_part` reproduce on master; unrelated to this change.