### PR TITLE
eagle3: fix qwen2 sub_config drift and num_assistant_tokens kwarg

### DIFF
--- a/.agents/skills/mblt-transformers/SKILL.md
+++ b/.agents/skills/mblt-transformers/SKILL.md
@@ -107,8 +107,9 @@ description: >-
 - Tune the draft-tree budget through `GenerationConfig.num_assistant_tokens` (default `64` in
   `mblt_model_zoo/hf_transformers/utils/generation_utils.py`). Qwen3-4B measures best in the
   `25`–`30` range: the Hugging Face default of `49` costs more iteration latency than its extra
-  acceptance recovers. Override either by editing the shipped `generation_config.json` or by
-  setting `model.generation_config.num_assistant_tokens = ...` before `generate`.
+  acceptance recovers. Override by editing the shipped `generation_config.json`, by setting
+  `model.generation_config.num_assistant_tokens = ...` before `generate`, or by passing
+  `num_assistant_tokens=<value>` directly to `generate(...)` for a per-call override.
 - Mobilint EAGLE-3 releases train base and draft at a matched hidden size by policy; the
   `draft_emb.shape == target_emb.shape` assert in `scripts/build_eagle3_safetensors.py` enforces
   it. The `MobilintEagle3DraftModelMixin` `hidden_states.shape[-1] != inputs_embeds.shape[-1]`

--- a/mblt_model_zoo/hf_transformers/models/qwen2_eagle3/configuration_qwen2_eagle3.py
+++ b/mblt_model_zoo/hf_transformers/models/qwen2_eagle3/configuration_qwen2_eagle3.py
@@ -4,25 +4,32 @@ from __future__ import annotations
 
 from typing import Any
 
-from transformers.models.auto.configuration_auto import AutoConfig
-from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
-
 from transformers.configuration_utils import PretrainedConfig
+from transformers.models.auto.configuration_auto import AutoConfig
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 
 from ...utils.configuration_utils import MobilintEagle3ConfigMixin
 
 
 class MobilintQwen2Eagle3Config(MobilintEagle3ConfigMixin, Qwen2Config):
-    """Top-level config for Mobilint Qwen2 EAGLE-3."""
+    """Top-level config for Mobilint Qwen2 EAGLE-3.
+
+    The base backend follows the Qwen2 architecture. The draft backend is a
+    Llama-family 1-block draft trained separately, so ``draft_config`` is a
+    raw ``LlamaConfig``. NPU backend fields for base/draft/fc live on the
+    top-level config via the shared EAGLE-3 mixin; the draft sub-config only
+    carries architecture-shape metadata.
+    """
 
     model_type = "mobilint-qwen2-eagle3"
-    sub_configs = {"draft_config": Qwen2Config}
+    sub_configs = {"draft_config": LlamaConfig}
 
     @classmethod
     def _get_draft_config_class(cls) -> type[PretrainedConfig]:
-        return Qwen2Config
+        return LlamaConfig
 
-    def __init__(self, draft_config: dict[str, Any] | Qwen2Config | None = None, **kwargs: Any) -> None:
+    def __init__(self, draft_config: dict[str, Any] | LlamaConfig | None = None, **kwargs: Any) -> None:
         if draft_config is not None:
             kwargs["draft_config"] = draft_config
         super().__init__(**kwargs)

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -1021,6 +1021,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
         GenerationMixin.generate,
         "count_npu_time",
         "npu_prefill_chunk_size",
+        "num_assistant_tokens",
     )
     def generate(
         self,

--- a/mblt_model_zoo/hf_transformers/utils/generation_utils.py
+++ b/mblt_model_zoo/hf_transformers/utils/generation_utils.py
@@ -742,6 +742,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
         temperature: Optional[float],
         top_p: Optional[float],
         top_k: Optional[int],
+        num_assistant_tokens: Optional[int] = None,
     ) -> tuple[GenerationConfig, int, Optional[float], Optional[float], int]:
         """Resolve generation config values used by the EAGLE-3 loop."""
         generation_config = self.generation_config if generation_config is None else generation_config
@@ -781,9 +782,14 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
         resolved_top_k = int(raw_top_k) if raw_top_k is not None else 0
         if not resolved_do_sample:
             resolved_temperature = 0.0
-        raw_num_assistant_tokens = getattr(generation_config, "num_assistant_tokens", None)
-        num_assistant_tokens = int(raw_num_assistant_tokens) if raw_num_assistant_tokens is not None else 64
-        self.eagle3_draft_model.max_draft_tokens = max(1, num_assistant_tokens - 1)
+        # Explicit ``num_assistant_tokens`` kwarg to ``generate`` overrides the value on
+        # ``generation_config``; fall back to the config, then to the historical default of 64.
+        if num_assistant_tokens is not None:
+            resolved_num_assistant_tokens = int(num_assistant_tokens)
+        else:
+            raw_num_assistant_tokens = getattr(generation_config, "num_assistant_tokens", None)
+            resolved_num_assistant_tokens = int(raw_num_assistant_tokens) if raw_num_assistant_tokens is not None else 64
+        self.eagle3_draft_model.max_draft_tokens = max(1, resolved_num_assistant_tokens - 1)
         return generation_config, resolved_max_new_tokens, resolved_temperature, resolved_top_p, resolved_top_k
 
     def _prepare_eagle3_cache(self, past_key_values: Optional[MobilintEagle3Cache]) -> MobilintEagle3Cache:
@@ -863,6 +869,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
         past_key_values: Optional[MobilintEagle3Cache],
         stopping_criteria: Optional[StoppingCriteriaList | list[Any]],
         eos_token_id: Optional[int | list[int]],
+        num_assistant_tokens: Optional[int] = None,
     ) -> tuple[GenerationConfig, int, Any, MobilintEagle3Cache, torch.LongTensor, Optional[int | list[int]], StoppingCriteriaList]:
         """Prepare shared state used by the EAGLE-3 decoding loop."""
         from ..utils.eagle3.decoding import prepare_logits_processor
@@ -877,6 +884,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
                 temperature=temperature,
                 top_p=top_p,
                 top_k=top_k,
+                num_assistant_tokens=num_assistant_tokens,
             )
         )
         cache = self._prepare_eagle3_cache(past_key_values)
@@ -1042,6 +1050,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
         eos_token_id: Optional[int | list[int]] = None,
         count_npu_time: bool = False,
         npu_prefill_chunk_size: Optional[int] = None,
+        num_assistant_tokens: Optional[int] = None,
         **kwargs: Any,
     ) -> torch.Tensor | GenerateDecoderOnlyOutput:
         """Generate tokens with the Mobilint EAGLE-3 decoding loop.
@@ -1052,6 +1061,9 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
           unknown kwargs.
         - Hard error: beam search, ``assistant_model``, ``use_cache=False``,
           custom ``logits_processor``, negative prompts.
+        - ``num_assistant_tokens`` overrides ``generation_config.num_assistant_tokens``
+          for this call; it drives the draft's per-step ``max_draft_tokens``
+          (``= num_assistant_tokens - 1``).
         """
         if attention_mask is not None:
             logger.warning(_EAGLE3_GENERATE_IGNORED_ARGS_MSG["attention_mask"])
@@ -1101,6 +1113,7 @@ class MobilintEagle3GenerationMixin(ABC, GenerationMixin):
                 past_key_values=past_key_values,
                 stopping_criteria=stopping_criteria,
                 eos_token_id=eos_token_id,
+                num_assistant_tokens=num_assistant_tokens,
             )
         )
         if streamer is not None:

--- a/scripts/build_eagle3_safetensors.py
+++ b/scripts/build_eagle3_safetensors.py
@@ -17,7 +17,9 @@ must not appear in the release safetensors.
 
 Inputs (per release folder):
     - ``target_emb.pth``    : target-model input embedding, F32 ``(V, H)`` (fixed filename).
-    - ``<prefix>_emb.pth``  : draft-model input embedding, F32 ``(V, H)`` (auto-detected).
+    - ``<prefix>_emb.pth``  : draft-model input embedding, F32/F16/BF16 ``(V, H)`` (auto-detected).
+      Different training pipelines ship different source dtypes; all three are accepted and
+      cast to F16 before writing.
     - ``<draft-subdir>/model.safetensors`` : draft checkpoint holding ``d2t`` and ``t2d``.
 """
 

--- a/scripts/build_eagle3_safetensors.py
+++ b/scripts/build_eagle3_safetensors.py
@@ -185,7 +185,13 @@ def main() -> int:
     draft_emb = torch.load(draft_emb_path, map_location="cpu", weights_only=True)
     assert isinstance(draft_emb, torch.Tensor), f"{draft_emb_path.name} is not a tensor (got {type(draft_emb)!r})"
     assert draft_emb.dim() == 2, f"draft embed must be rank-2 (V, H); got shape {tuple(draft_emb.shape)}"
-    assert draft_emb.dtype == torch.float32, f"draft embed expected float32, got {draft_emb.dtype}"
+    # The tensor is cast to float16 before writing, so any dtype whose fp16 cast is lossless-enough
+    # for embeddings is acceptable. Different trainers ship different source dtypes (fp32 historically,
+    # fp16 for the JPharmatron-7B release), so accept the common floating point widths and let the
+    # downstream cast normalize.
+    assert draft_emb.dtype in (torch.float32, torch.float16, torch.bfloat16), (
+        f"draft embed expected float32/float16/bfloat16, got {draft_emb.dtype}"
+    )
     # Contract: Mobilint EAGLE-3 releases train base and draft at a matched hidden size,
     # so packaged embeddings must be shape-identical. The runtime FCProjector branch in
     # MobilintEagle3DraftModelMixin is legacy/future scaffolding and is NOT grounds to relax
@@ -232,7 +238,7 @@ def main() -> int:
             f"regenerate or replace the draft artifact."
         )
 
-    print("[cast] draft embed float32 -> float16")
+    print(f"[cast] draft embed {draft_emb.dtype} -> float16")
     draft_emb_f16 = draft_emb.to(torch.float16).contiguous()
     target_emb_f32 = target_emb.contiguous()
 

--- a/tests/transformers/text_generation/eagle3/test_qwen2_eagle3_config.py
+++ b/tests/transformers/text_generation/eagle3/test_qwen2_eagle3_config.py
@@ -47,7 +47,14 @@ def test_qwen2_eagle3_config_roundtrip_preserves_nested_draft_and_backend_fields
 
 
 def test_qwen2_eagle3_config_exposes_prefixed_backend_properties() -> None:
-    """EAGLE-3 config should expose base/draft/fc backend properties consistently."""
+    """EAGLE-3 config should expose base/draft/fc backend properties consistently.
+
+    NPUTargetSpec normalization unifies grain to the field appropriate for each
+    core_mode: single-mode backends surface per-core targets and empty their
+    cluster list, while global4/global8-mode backends surface cluster targets
+    and empty their per-core list. Feeding both grains here verifies the
+    normalizer picks the right one per prefix.
+    """
     config = MobilintQwen2Eagle3Config(
         vocab_size=10,
         hidden_size=8,
@@ -77,17 +84,20 @@ def test_qwen2_eagle3_config_exposes_prefixed_backend_properties() -> None:
     assert config.base_core_mode == "single"
     assert config.draft_core_mode == "global4"
     assert config.fc_core_mode == "global8"
+
+    # single-mode: per-core grain wins, cluster list is emptied
     assert len(config.base_target_cores) == 1
-    assert len(config.draft_target_cores) == 1
-    assert len(config.fc_target_cores) == 1
     assert str(config.base_target_cores[0])
-    assert str(config.draft_target_cores[0])
-    assert str(config.fc_target_cores[0])
-    assert len(config.base_target_clusters) == 1
+    assert config.base_target_clusters == []
+
+    # global4-mode: cluster grain wins, per-core list is emptied
+    assert config.draft_target_cores == []
     assert len(config.draft_target_clusters) == 1
-    assert len(config.fc_target_clusters) == 2
-    assert str(config.base_target_clusters[0])
     assert str(config.draft_target_clusters[0])
+
+    # global8-mode: cluster grain wins with two-cluster coverage
+    assert config.fc_target_cores == []
+    assert len(config.fc_target_clusters) == 2
     assert all(str(cluster) for cluster in config.fc_target_clusters)
 
 

--- a/tests/transformers/text_generation/eagle3/test_qwen2_eagle3_config.py
+++ b/tests/transformers/text_generation/eagle3/test_qwen2_eagle3_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.models.llama.configuration_llama import LlamaConfig
 
 from mblt_model_zoo.hf_transformers.models.qwen2_eagle3.configuration_qwen2_eagle3 import (
     MobilintQwen2Eagle3Config,
@@ -137,7 +137,7 @@ def test_qwen2_eagle3_config_name_or_path_propagates_to_draft_config() -> None:
 
 def test_qwen2_eagle3_config_roundtrip_accepts_draft_config_object() -> None:
     """Round-trip should preserve draft_config when passed as a config object."""
-    draft = Qwen2Config(
+    draft = LlamaConfig(
         vocab_size=10,
         hidden_size=8,
         intermediate_size=16,
@@ -157,5 +157,5 @@ def test_qwen2_eagle3_config_roundtrip_accepts_draft_config_object() -> None:
 
     restored = MobilintQwen2Eagle3Config(**config.to_dict())
 
-    assert isinstance(restored.draft_config, Qwen2Config)
+    assert isinstance(restored.draft_config, LlamaConfig)
     assert restored.draft_config.vocab_size == 10


### PR DESCRIPTION
## 배경

JPharmatron-7B EAGLE-3 산출물을 mobilint HF 포맷으로 패키징하는 과정에서 발견된 네 가지 이슈를 함께 정리했습니다. 개별로도 유효한 수정들이라 한 브랜치에 묶었습니다.

## 변경 사항

### 1. `fix(qwen2-eagle3)`: draft sub_config를 LlamaConfig로 정렬
`MobilintQwen2Eagle3Config`만 `sub_configs`에 `Qwen2Config`를 쓰고 있었는데, `MobilintQwen3Eagle3Config` / `MobilintLlamaEagle3Config` 는 모두 `LlamaConfig`. Mobilint EAGLE-3 draft head는 언제나 Llama-family 1-block으로 학습된다는 규약을 따라 qwen2도 정렬했습니다. 기존 Qwen2 릴리즈들(리포에 mobilint/EAGLE3-Qwen3-4B 확인) 은 이미 `draft.model_type=llama` 로 배포돼 있어 실측 호환 문제 없음. 관련 테스트도 `LlamaConfig` 사용으로 갱신.

### 2. `chore(scripts)`: `build_eagle3_safetensors.py` draft-emb dtype 완화
JPharmatron 릴리즈의 `<prefix>_emb.pth`가 fp16으로 저장돼 있어 스크립트의 `assert draft_emb.dtype == torch.float32` 에 걸림. 스크립트는 어차피 최종적으로 fp16로 캐스팅하므로 `float32/float16/bfloat16` 셋을 모두 허용. 로그 문자열도 실제 입력 dtype 반영.

### 3. `fix(tests)`: NPU target grain normalization 반영
`test_qwen2_eagle3_config_exposes_prefixed_backend_properties` 가 `target_cores` 와 `target_clusters` 두 리스트가 모두 유지된다고 가정했으나, `NPUTargetSpec.from_kwargs` 는 `core_mode` 에 맞는 grain 한쪽만 남기고 반대편은 비웁니다 (single → cores만, global4/global8 → clusters만). 실제 정규화 동작에 맞도록 어설션 수정 + docstring 문서화.

### 4. `fix(eagle3-generate)`: `num_assistant_tokens` kwarg 반영
`MobilintEagle3GenerationMixin.generate` 가 `num_assistant_tokens` 를 `**kwargs` 로 받은 뒤 unknown-kwarg warning 후 폐기하고 있었음. 결과적으로 `generation_config.num_assistant_tokens` 만 유효, per-call override 불가. Draft의 `max_draft_tokens` 튜닝을 위해 명시 파라미터로 승격하고 `_prepare_eagle3_generate_context` → `_resolve_eagle3_generation_config` 로 전파. 미지정 시 기존 fallback(그리고 최종 default 64) 유지, 백워드 호환.

## 검증

- `pytest tests/transformers/text_generation/eagle3/test_qwen2_eagle3_config.py` 5/5 통과.
- `scripts/build_eagle3_safetensors.py` JPharmatron 릴리즈 소스에서 로컬 재실행, 4-key safetensors(target/draft embed + d2t/t2d) 정상 생성.
- 세 개 EAGLE-3 릴리즈(`mobilint/EAGLE3-Llama-3.1-8B-Instruct`, `mobilint/EAGLE3-Qwen3-4B`, `mobilint/EAGLE3-JPharmatron-7B`) config 로드 + to_dict 라운드트립 모두 통과.
- `num_assistant_tokens` 프로브: `nat ∈ {25, 57, 89}` 명시 지정 시 `draft.max_draft_tokens` 가 각각 24 / 56 / 88 로 정상 반영 (fix 전에는 셋 다 25). 미지정 시 `generation_config.num_assistant_tokens` 로 fallback 동작 유지.

## Test plan

- [x] 하드웨어 회귀 확인 필요 시 `mblt-model-zoo tps measure` 로 세 개 EAGLE-3 릴리즈 스모크 (mxq 다운로드 필요, 로컬 검증에선 skip).
- [x] JPharmatron-7B 패키지 산출물은 별도 리포지토리 업로드 워크플로에서 처리.

## 남는 후속 (별도 이슈)

- `eagle3_tree_depth` / `eagle3_tree_top_k` 는 아키텍처 속성이 아닌 런타임 튜너블 → 의미상 `generation_config.json` 으로 이동해야 함. 이번 커밋에서는 손대지 않음.
- `test_qwen2_eagle3_config_exposes_prefixed_backend_properties` 원래 실패는 이번 branch의 sub_config 변경과 무관한 사전 존재 버그였음 (같은 겸사 수정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)